### PR TITLE
Add static release packaging targets

### DIFF
--- a/.github/workflows/package-static.yml
+++ b/.github/workflows/package-static.yml
@@ -1,4 +1,4 @@
-name: Package Static Binary
+name: Package Static Builds
 
 on:
   push:
@@ -11,11 +11,21 @@ on:
       - master
   workflow_dispatch:
 
+concurrency:
+  group: package-static-${{ github.ref }}
+  cancel-in-progress: true
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: ${{ github.repository }}-static
+
 jobs:
-  package:
+  linux:
+    name: Linux static binary and distroless image
     runs-on: ubuntu-latest
     permissions:
       contents: read
+      packages: write
 
     steps:
       - name: Checkout repository
@@ -24,19 +34,139 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 
-      - name: Build package artifacts
+      - name: Log in to Container Registry
+        if: github.event_name != 'pull_request'
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract distroless image metadata
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          tags: |
+            type=raw,value=nightly,enable={{is_default_branch}}
+            type=sha,prefix=nightly-,enable={{is_default_branch}}
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
+            type=semver,pattern={{major}}
+
+      - name: Build Linux artifacts
         uses: docker/build-push-action@v6
         with:
           context: .
           file: ./docker/Dockerfile
-          target: package-artifacts
-          outputs: type=local,dest=dist
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
+          target: package-linux-artifacts
+          outputs: type=local,dest=dist/linux-amd64
+          cache-from: type=gha,scope=package-linux-amd64
+          cache-to: type=gha,scope=package-linux-amd64,mode=max
           platforms: linux/amd64
 
-      - name: Upload package artifacts
+      - name: Smoke test Linux binary
+        run: ./dist/linux-amd64/yiipress --help
+
+      - name: Upload Linux artifacts
         uses: actions/upload-artifact@v4
         with:
           name: yiipress-linux-amd64
-          path: dist/
+          path: dist/linux-amd64/
+          if-no-files-found: error
+
+      - name: Build and push distroless image
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: ./docker/Dockerfile
+          target: distroless
+          push: ${{ github.event_name != 'pull_request' }}
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha,scope=package-linux-amd64
+          cache-to: type=gha,scope=package-linux-amd64,mode=max
+          platforms: linux/amd64
+
+  windows:
+    name: Windows static binary
+    if: github.event_name != 'pull_request'
+    runs-on: windows-latest
+    permissions:
+      contents: read
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: '8.5'
+          coverage: none
+
+      - name: Set up Rust
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: x86_64-pc-windows-msvc
+
+      - name: Set up MSVC
+        uses: ilammy/msvc-dev-cmd@v1
+
+      - name: Cache Windows package dependencies
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~\AppData\Local\Composer\files
+            ~\.cargo\git
+            ~\.cargo\registry
+            runtime\package-windows\app\vendor
+            runtime\package-windows\static-php-cli
+            runtime\package-windows\md4c-extension
+            runtime\package-windows\yiipress-highlighter
+          key: windows-package-${{ runner.os }}-${{ hashFiles('composer.lock', 'build/package-windows.ps1') }}
+          restore-keys: |
+            windows-package-${{ runner.os }}-
+
+      - name: Build Windows artifacts
+        shell: pwsh
+        run: build/package-windows.ps1 -DistDir dist/windows-amd64
+
+      - name: Smoke test Windows binary
+        shell: pwsh
+        run: ./dist/windows-amd64/yiipress.exe --help
+
+      - name: Upload Windows artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: yiipress-windows-amd64
+          path: dist/windows-amd64/
+          if-no-files-found: error
+
+  release:
+    name: Publish release artifacts
+    if: startsWith(github.ref, 'refs/tags/')
+    needs:
+      - linux
+      - windows
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+
+    steps:
+      - name: Download artifacts
+        uses: actions/download-artifact@v4
+        with:
+          path: release
+
+      - name: Pack release archives
+        run: |
+          tar -C release/yiipress-linux-amd64 -czf yiipress-linux-amd64.tar.gz .
+          zip -j yiipress-windows-amd64.zip release/yiipress-windows-amd64/*
+
+      - name: Publish GitHub release
+        uses: softprops/action-gh-release@v2
+        with:
+          files: |
+            yiipress-linux-amd64.tar.gz
+            yiipress-windows-amd64.zip

--- a/.github/workflows/package-static.yml
+++ b/.github/workflows/package-static.yml
@@ -28,13 +28,13 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f
 
       - name: Build PHAR artifact
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8
         with:
           context: .
           file: ./docker/Dockerfile
@@ -45,7 +45,7 @@ jobs:
           platforms: linux/amd64
 
       - name: Upload PHAR artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02
         with:
           name: yiipress-phar
           path: dist/phar/yiipress.phar
@@ -60,14 +60,14 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f
 
       - name: Log in to Container Registry
         if: github.event_name != 'pull_request' && (github.ref == 'refs/heads/master' || startsWith(github.ref, 'refs/tags/'))
-        uses: docker/login-action@v3
+        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
@@ -75,7 +75,7 @@ jobs:
 
       - name: Extract distroless image metadata
         id: meta
-        uses: docker/metadata-action@v5
+        uses: docker/metadata-action@c299e40c65443455700f0fdfc63efafe5b349051
         with:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
           tags: |
@@ -86,7 +86,7 @@ jobs:
             type=semver,pattern={{major}}
 
       - name: Build Linux artifacts
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8
         with:
           context: .
           file: ./docker/Dockerfile
@@ -100,14 +100,14 @@ jobs:
         run: ./dist/linux-amd64/yiipress --help
 
       - name: Upload Linux artifacts
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02
         with:
           name: yiipress-linux-amd64
           path: dist/linux-amd64/yiipress
           if-no-files-found: error
 
       - name: Build and push distroless image
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8
         with:
           context: .
           file: ./docker/Dockerfile
@@ -128,24 +128,24 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
 
       - name: Set up PHP
-        uses: shivammathur/setup-php@v2
+        uses: shivammathur/setup-php@7c071dfe9dc99bdf297fa79cb49ea005b9fcadbc
         with:
           php-version: '8.5'
           coverage: none
 
       - name: Set up Rust
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8
         with:
           targets: x86_64-pc-windows-msvc
 
       - name: Set up MSVC
-        uses: ilammy/msvc-dev-cmd@v1
+        uses: ilammy/msvc-dev-cmd@0b201ec74fa43914dc39ae48a89fd1d8cb592756
 
       - name: Cache Windows package dependencies
-        uses: actions/cache@v4
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830
         with:
           path: |
             ~\AppData\Local\Composer\files
@@ -168,7 +168,7 @@ jobs:
         run: ./dist/windows-amd64/yiipress.exe --help
 
       - name: Upload Windows artifacts
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02
         with:
           name: yiipress-windows-amd64
           path: dist/windows-amd64/yiipress.exe
@@ -187,7 +187,7 @@ jobs:
 
     steps:
       - name: Download artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093
         with:
           path: release
 
@@ -198,7 +198,7 @@ jobs:
           cp release/yiipress-phar/yiipress.phar yiipress.phar
 
       - name: Publish GitHub release
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@3bb12739c298aeb8a4eeaf626c5b8d85266b0e65
         with:
           files: |
             yiipress.phar

--- a/.github/workflows/package-static.yml
+++ b/.github/workflows/package-static.yml
@@ -35,7 +35,7 @@ jobs:
         uses: docker/setup-buildx-action@v3
 
       - name: Log in to Container Registry
-        if: github.event_name != 'pull_request'
+        if: github.event_name != 'pull_request' && (github.ref == 'refs/heads/master' || startsWith(github.ref, 'refs/tags/'))
         uses: docker/login-action@v3
         with:
           registry: ${{ env.REGISTRY }}
@@ -81,7 +81,7 @@ jobs:
           context: .
           file: ./docker/Dockerfile
           target: distroless
-          push: ${{ github.event_name != 'pull_request' }}
+          push: ${{ github.event_name != 'pull_request' && (github.ref == 'refs/heads/master' || startsWith(github.ref, 'refs/tags/')) }}
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
           cache-from: type=gha,scope=package-linux-amd64

--- a/.github/workflows/package-static.yml
+++ b/.github/workflows/package-static.yml
@@ -121,7 +121,7 @@ jobs:
 
   windows:
     name: Windows static binary
-    if: github.event_name != 'pull_request'
+    if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
     runs-on: windows-latest
     permissions:
       contents: read

--- a/.github/workflows/package-static.yml
+++ b/.github/workflows/package-static.yml
@@ -29,6 +29,8 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
+        with:
+          persist-credentials: false
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f
@@ -61,6 +63,8 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
+        with:
+          persist-credentials: false
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f
@@ -129,6 +133,8 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
+        with:
+          persist-credentials: false
 
       - name: Set up PHP
         uses: shivammathur/setup-php@7c071dfe9dc99bdf297fa79cb49ea005b9fcadbc

--- a/.github/workflows/package-static.yml
+++ b/.github/workflows/package-static.yml
@@ -20,6 +20,37 @@ env:
   IMAGE_NAME: ${{ github.repository }}-static
 
 jobs:
+  phar:
+    name: YiiPress PHAR
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Build PHAR artifact
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: ./docker/Dockerfile
+          target: package-phar-artifacts
+          outputs: type=local,dest=dist/phar
+          cache-from: type=gha,scope=package-phar
+          cache-to: type=gha,scope=package-phar,mode=max
+          platforms: linux/amd64
+
+      - name: Upload PHAR artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: yiipress-phar
+          path: dist/phar/yiipress.phar
+          if-no-files-found: error
+
   linux:
     name: Linux static binary and distroless image
     runs-on: ubuntu-latest
@@ -72,7 +103,7 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: yiipress-linux-amd64
-          path: dist/linux-amd64/
+          path: dist/linux-amd64/yiipress
           if-no-files-found: error
 
       - name: Build and push distroless image
@@ -140,13 +171,14 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: yiipress-windows-amd64
-          path: dist/windows-amd64/
+          path: dist/windows-amd64/yiipress.exe
           if-no-files-found: error
 
   release:
     name: Publish release artifacts
     if: startsWith(github.ref, 'refs/tags/')
     needs:
+      - phar
       - linux
       - windows
     runs-on: ubuntu-latest
@@ -163,10 +195,12 @@ jobs:
         run: |
           tar -C release/yiipress-linux-amd64 -czf yiipress-linux-amd64.tar.gz .
           zip -j yiipress-windows-amd64.zip release/yiipress-windows-amd64/*
+          cp release/yiipress-phar/yiipress.phar yiipress.phar
 
       - name: Publish GitHub release
         uses: softprops/action-gh-release@v2
         with:
           files: |
+            yiipress.phar
             yiipress-linux-amd64.tar.gz
             yiipress-windows-amd64.zip

--- a/Makefile
+++ b/Makefile
@@ -21,8 +21,13 @@ endif
 export COMPOSE_PROJECT_NAME=${STACK_NAME}
 DOCKER_COMPOSE_DEV := docker compose -f docker/compose.yml -f docker/dev/compose.yml
 DOCKER_COMPOSE_TEST := docker compose -f docker/compose.yml -f docker/test/compose.yml
+PACKAGE_PLATFORM ?= linux/amd64
+PACKAGE_LINUX_DIST ?= dist/linux-amd64
+PACKAGE_WINDOWS_DIST ?= dist/windows-amd64
+PACKAGE_IMAGE ?= ${IMAGE}-static
+WINDOWS_PACKAGE_ARGS ?=
 
-.PHONY: build up open down stop clear shell yii composer rector cs-fix test test-coverage psalm composer-dependency-analyser bench-generate bench-generate-realistic bench bench-baseline bench-compare bench-profile profile-build php build-docs package prod-build prod-push prod-deploy help
+.PHONY: build up open down stop clear shell yii composer rector cs-fix test test-coverage psalm composer-dependency-analyser bench-generate bench-generate-realistic bench bench-baseline bench-compare bench-profile profile-build php build-docs package package-linux package-windows package-distroless package-distroless-push prod-build prod-push prod-deploy help
 
 #
 # Development
@@ -190,8 +195,29 @@ build-docs: ## Build documentation site from docs/ directory
 endif
 
 ifeq ($(PRIMARY_GOAL),package)
-package: ## Build PHAR and static PHP artifacts into dist/
-	docker build --file docker/Dockerfile --target package-artifacts --output type=local,dest=dist .
+package: ## Build Linux PHAR and static PHP artifacts into dist/linux-amd64/
+	docker buildx build --file docker/Dockerfile --target package-linux-artifacts --platform $(PACKAGE_PLATFORM) --output type=local,dest=$(PACKAGE_LINUX_DIST) .
+endif
+
+ifeq ($(PRIMARY_GOAL),package-linux)
+package-linux: ## Build Linux PHAR and static PHP artifacts into dist/linux-amd64/
+	docker buildx build --file docker/Dockerfile --target package-linux-artifacts --platform $(PACKAGE_PLATFORM) --output type=local,dest=$(PACKAGE_LINUX_DIST) .
+endif
+
+ifeq ($(PRIMARY_GOAL),package-windows)
+package-windows: ## Build Windows PHAR and static PHP executable into dist/windows-amd64/
+	@command -v pwsh >/dev/null 2>&1 || { echo 'PowerShell 7 (pwsh) is required for package-windows.' >&2; exit 127; }
+	pwsh -NoLogo -NoProfile -ExecutionPolicy Bypass -File build/package-windows.ps1 -DistDir $(PACKAGE_WINDOWS_DIST) $(WINDOWS_PACKAGE_ARGS)
+endif
+
+ifeq ($(PRIMARY_GOAL),package-distroless)
+package-distroless: ## Build local distroless image containing only the static Linux binary
+	docker buildx build --file docker/Dockerfile --target distroless --platform $(PACKAGE_PLATFORM) --load -t $(PACKAGE_IMAGE):$(IMAGE_TAG) .
+endif
+
+ifeq ($(PRIMARY_GOAL),package-distroless-push)
+package-distroless-push: ## Build and push distroless image containing only the static Linux binary
+	docker buildx build --file docker/Dockerfile --target distroless --platform $(PACKAGE_PLATFORM) --push -t $(PACKAGE_IMAGE):$(IMAGE_TAG) .
 endif
 
 #

--- a/Makefile
+++ b/Makefile
@@ -24,10 +24,11 @@ DOCKER_COMPOSE_TEST := docker compose -f docker/compose.yml -f docker/test/compo
 PACKAGE_PLATFORM ?= linux/amd64
 PACKAGE_LINUX_DIST ?= dist/linux-amd64
 PACKAGE_WINDOWS_DIST ?= dist/windows-amd64
+PACKAGE_PHAR_DIST ?= dist/phar
 PACKAGE_IMAGE ?= ${IMAGE}-static
 WINDOWS_PACKAGE_ARGS ?=
 
-.PHONY: build up open down stop clear shell yii composer rector cs-fix test test-coverage psalm composer-dependency-analyser bench-generate bench-generate-realistic bench bench-baseline bench-compare bench-profile profile-build php build-docs package package-linux package-windows package-distroless package-distroless-push prod-build prod-push prod-deploy help
+.PHONY: build up open down stop clear shell yii composer rector cs-fix test test-coverage psalm composer-dependency-analyser bench-generate bench-generate-realistic bench bench-baseline bench-compare bench-profile profile-build php build-docs package package-phar package-linux package-windows package-distroless package-distroless-push prod-build prod-push prod-deploy help
 
 #
 # Development
@@ -195,17 +196,26 @@ build-docs: ## Build documentation site from docs/ directory
 endif
 
 ifeq ($(PRIMARY_GOAL),package)
-package: ## Build Linux PHAR and static PHP artifacts into dist/linux-amd64/
+package: ## Build Linux static binary into dist/linux-amd64/
+	@mkdir -p $(PACKAGE_LINUX_DIST)
+	@rm -f $(PACKAGE_LINUX_DIST)/yiipress.phar
 	docker buildx build --file docker/Dockerfile --target package-linux-artifacts --platform $(PACKAGE_PLATFORM) --output type=local,dest=$(PACKAGE_LINUX_DIST) .
 endif
 
+ifeq ($(PRIMARY_GOAL),package-phar)
+package-phar: ## Build YiiPress PHAR into dist/phar/
+	docker buildx build --file docker/Dockerfile --target package-phar-artifacts --platform $(PACKAGE_PLATFORM) --output type=local,dest=$(PACKAGE_PHAR_DIST) .
+endif
+
 ifeq ($(PRIMARY_GOAL),package-linux)
-package-linux: ## Build Linux PHAR and static PHP artifacts into dist/linux-amd64/
+package-linux: ## Build Linux static binary into dist/linux-amd64/
+	@mkdir -p $(PACKAGE_LINUX_DIST)
+	@rm -f $(PACKAGE_LINUX_DIST)/yiipress.phar
 	docker buildx build --file docker/Dockerfile --target package-linux-artifacts --platform $(PACKAGE_PLATFORM) --output type=local,dest=$(PACKAGE_LINUX_DIST) .
 endif
 
 ifeq ($(PRIMARY_GOAL),package-windows)
-package-windows: ## Build Windows PHAR and static PHP executable into dist/windows-amd64/
+package-windows: ## Build Windows static executable into dist/windows-amd64/
 	@command -v pwsh >/dev/null 2>&1 || { echo 'PowerShell 7 (pwsh) is required for package-windows.' >&2; exit 127; }
 	pwsh -NoLogo -NoProfile -ExecutionPolicy Bypass -File build/package-windows.ps1 -DistDir $(PACKAGE_WINDOWS_DIST) $(WINDOWS_PACKAGE_ARGS)
 endif

--- a/README.md
+++ b/README.md
@@ -99,6 +99,7 @@ make yii new "My First Post"
 make yii build -- --workers=4
 make yii build -- --drafts --future
 make yii clean
+make package-phar
 make package
 make package-distroless
 ```

--- a/README.md
+++ b/README.md
@@ -100,6 +100,7 @@ make yii build -- --workers=4
 make yii build -- --drafts --future
 make yii clean
 make package
+make package-distroless
 ```
 
 When using `serve`, HTML pages include live reload and a small edit button that opens the current Markdown source file in the

--- a/build/package-windows.ps1
+++ b/build/package-windows.ps1
@@ -42,6 +42,17 @@ function Test-NativeCommand {
     }
 }
 
+function Write-LogTail {
+    param(
+        [string] $Path
+    )
+
+    if (Test-Path $Path) {
+        Write-Output "===== $Path ====="
+        Get-Content $Path -Tail 200
+    }
+}
+
 function Expand-TarGzArchive {
     param(
         [string] $Url,
@@ -170,15 +181,21 @@ try {
         "--without-suggestions"
     )
     Invoke-NativeCommand "php" @("bin/spc", "doctor", "--auto-fix")
-    Invoke-NativeCommand "php" @(
-        "bin/spc",
-        "build",
-        $StaticPhpExtensions,
-        "--build-micro",
-        "--with-micro-fake-cli",
-        "-P",
-        (Join-Path $root "build/static-php/register-yiipress-highlighter.php")
-    )
+    try {
+        Invoke-NativeCommand "php" @(
+            "bin/spc",
+            "build",
+            $StaticPhpExtensions,
+            "--build-micro",
+            "--with-micro-fake-cli",
+            "-P",
+            (Join-Path $root "build/static-php/register-yiipress-highlighter.php")
+        )
+    } catch {
+        Write-LogTail (Join-Path $staticPhpPath "log/spc.output.log")
+        Write-LogTail (Join-Path $staticPhpPath "log/spc.shell.log")
+        throw
+    }
     Invoke-NativeCommand "php" @("bin/spc", "micro:combine", $pharPath, "-O", $exePath)
 } finally {
     Pop-Location

--- a/build/package-windows.ps1
+++ b/build/package-windows.ps1
@@ -181,6 +181,12 @@ try {
         "--without-suggestions"
     )
     Invoke-NativeCommand "php" @("bin/spc", "doctor", "--auto-fix")
+    $buildrootLibraryPath = Join-Path $staticPhpPath "buildroot/lib"
+    New-Item -ItemType Directory -Force -Path $buildrootLibraryPath | Out-Null
+    Copy-Item `
+        (Join-Path $highlighterPath "target/$($env:CARGO_BUILD_TARGET)/release/highlighter.lib") `
+        (Join-Path $buildrootLibraryPath "highlighter.lib") `
+        -Force
     try {
         Invoke-NativeCommand "php" @(
             "bin/spc",

--- a/build/package-windows.ps1
+++ b/build/package-windows.ps1
@@ -2,6 +2,7 @@ param(
     [string] $DistDir = "dist/windows-amd64",
     [string] $PhpVersion = "8.5",
     [string] $Md4cVersion = "1.1",
+    [string] $HighlighterVersion = "1.0.1",
     [string] $StaticPhpCliRef = "5b5861c366a0d94bc84002db7b3f46144b388fbb",
     [string] $StaticPhpExtensions = "ctype,dom,filter,highlighter,mbstring,md4c,opcache,phar,xml,xmlwriter,yaml"
 )
@@ -147,7 +148,7 @@ if (!(Test-Path $highlighterPath)) {
         "--no-interaction",
         "yiipress/highlighter",
         $highlighterPath,
-        "dev-master"
+        $HighlighterVersion
     )
 }
 

--- a/build/package-windows.ps1
+++ b/build/package-windows.ps1
@@ -158,6 +158,7 @@ try {
     $env:HIGHLIGHTER_SOURCE = $highlighterPath
     $env:YIIPRESS_MD4C_SOURCE = $md4cPath
     $env:YIIPRESS_STATIC_INCLUDE_PROCESS_EXTENSIONS = "0"
+    $env:RUSTFLAGS = "-C target-feature=+crt-static"
 
     Push-Location $highlighterPath
     try {

--- a/build/package-windows.ps1
+++ b/build/package-windows.ps1
@@ -60,10 +60,15 @@ function Expand-TarGzArchive {
     )
 
     $archive = Join-Path $workPath ([IO.Path]::GetRandomFileName() + ".tar.gz")
-    Invoke-WebRequest -Uri $Url -OutFile $archive
-    New-Item -ItemType Directory -Force -Path $Destination | Out-Null
-    Invoke-NativeCommand "tar" @("-xzf", $archive, "--strip-components=1", "-C", $Destination)
-    Remove-Item $archive -Force
+    try {
+        Invoke-WebRequest -Uri $Url -OutFile $archive -TimeoutSec 300
+        New-Item -ItemType Directory -Force -Path $Destination | Out-Null
+        Invoke-NativeCommand "tar" @("-xzf", $archive, "--strip-components=1", "-C", $Destination)
+    } finally {
+        if (Test-Path $archive) {
+            Remove-Item $archive -Force
+        }
+    }
 }
 
 function Copy-CleanPath {
@@ -83,10 +88,8 @@ foreach ($command in @("php", "composer", "tar", "rustup", "cargo")) {
     Test-NativeCommand $command
 }
 
-if ($IsWindows) {
-    foreach ($command in @("cl", "nmake")) {
-        Test-NativeCommand $command
-    }
+foreach ($command in @("cl", "nmake")) {
+    Test-NativeCommand $command
 }
 
 New-Item -ItemType Directory -Force -Path $distPath, $workPath | Out-Null

--- a/build/package-windows.ps1
+++ b/build/package-windows.ps1
@@ -16,7 +16,7 @@ $appPath = Join-Path $workPath "app"
 $staticPhpPath = Join-Path $workPath "static-php-cli"
 $md4cPath = Join-Path $workPath "md4c-extension"
 $highlighterPath = Join-Path $workPath "yiipress-highlighter"
-$pharPath = Join-Path $distPath "yiipress.phar"
+$pharPath = Join-Path $workPath "yiipress.phar"
 $exePath = Join-Path $distPath "yiipress.exe"
 
 function Invoke-NativeCommand {
@@ -90,6 +90,10 @@ if ($IsWindows) {
 }
 
 New-Item -ItemType Directory -Force -Path $distPath, $workPath | Out-Null
+$legacyDistPharPath = Join-Path $distPath "yiipress.phar"
+if (Test-Path $legacyDistPharPath) {
+    Remove-Item $legacyDistPharPath -Force
+}
 
 New-Item -ItemType Directory -Force -Path $appPath | Out-Null
 foreach ($directory in @("config", "public", "src", "themes")) {

--- a/build/package-windows.ps1
+++ b/build/package-windows.ps1
@@ -187,7 +187,6 @@ try {
             "build",
             $StaticPhpExtensions,
             "--build-micro",
-            "--with-micro-fake-cli",
             "-P",
             (Join-Path $root "build/static-php/register-yiipress-highlighter.php")
         )

--- a/build/package-windows.ps1
+++ b/build/package-windows.ps1
@@ -1,0 +1,187 @@
+param(
+    [string] $DistDir = "dist/windows-amd64",
+    [string] $PhpVersion = "8.5",
+    [string] $Md4cVersion = "1.1",
+    [string] $StaticPhpCliRef = "5b5861c366a0d94bc84002db7b3f46144b388fbb",
+    [string] $StaticPhpExtensions = "ctype,dom,filter,highlighter,mbstring,md4c,opcache,phar,xml,xmlwriter,yaml"
+)
+
+$ErrorActionPreference = "Stop"
+Set-StrictMode -Version Latest
+
+$root = (Resolve-Path (Join-Path $PSScriptRoot "..")).Path
+$distPath = Join-Path $root $DistDir
+$workPath = Join-Path $root "runtime/package-windows"
+$appPath = Join-Path $workPath "app"
+$staticPhpPath = Join-Path $workPath "static-php-cli"
+$md4cPath = Join-Path $workPath "md4c-extension"
+$highlighterPath = Join-Path $workPath "yiipress-highlighter"
+$pharPath = Join-Path $distPath "yiipress.phar"
+$exePath = Join-Path $distPath "yiipress.exe"
+
+function Invoke-NativeCommand {
+    param(
+        [string] $FilePath,
+        [Parameter(ValueFromRemainingArguments = $true)]
+        [string[]] $Arguments
+    )
+
+    & $FilePath @Arguments
+    if ($LASTEXITCODE -ne 0) {
+        throw "Command failed with exit code ${LASTEXITCODE}: $FilePath $($Arguments -join ' ')"
+    }
+}
+
+function Test-NativeCommand {
+    param(
+        [string] $Command
+    )
+
+    if ($null -eq (Get-Command $Command -ErrorAction SilentlyContinue)) {
+        throw "Required command was not found in PATH: $Command"
+    }
+}
+
+function Expand-TarGzArchive {
+    param(
+        [string] $Url,
+        [string] $Destination
+    )
+
+    $archive = Join-Path $workPath ([IO.Path]::GetRandomFileName() + ".tar.gz")
+    Invoke-WebRequest -Uri $Url -OutFile $archive
+    New-Item -ItemType Directory -Force -Path $Destination | Out-Null
+    Invoke-NativeCommand "tar" @("-xzf", $archive, "--strip-components=1", "-C", $Destination)
+    Remove-Item $archive -Force
+}
+
+function Copy-CleanPath {
+    param(
+        [string] $Source,
+        [string] $Destination
+    )
+
+    if (Test-Path $Destination) {
+        Remove-Item $Destination -Recurse -Force
+    }
+
+    Copy-Item $Source $Destination -Recurse -Force
+}
+
+foreach ($command in @("php", "composer", "tar", "rustup", "cargo")) {
+    Test-NativeCommand $command
+}
+
+if ($IsWindows) {
+    foreach ($command in @("cl", "nmake")) {
+        Test-NativeCommand $command
+    }
+}
+
+New-Item -ItemType Directory -Force -Path $distPath, $workPath | Out-Null
+
+New-Item -ItemType Directory -Force -Path $appPath | Out-Null
+foreach ($directory in @("config", "public", "src", "themes")) {
+    Copy-CleanPath (Join-Path $root $directory) (Join-Path $appPath $directory)
+}
+New-Item -ItemType Directory -Force -Path (Join-Path $appPath "build") | Out-Null
+Copy-Item (Join-Path $root "build/package-phar.php") (Join-Path $appPath "build/package-phar.php") -Force
+Copy-Item (Join-Path $root "build/PharArchiveFilter.php") (Join-Path $appPath "build/PharArchiveFilter.php") -Force
+Copy-Item (Join-Path $root "yii") (Join-Path $appPath "yii") -Force
+Copy-Item (Join-Path $root "composer.json") (Join-Path $appPath "composer.json") -Force
+Copy-Item (Join-Path $root "composer.lock") (Join-Path $appPath "composer.lock") -Force
+
+Push-Location $appPath
+try {
+    Invoke-NativeCommand "composer" @(
+        "install",
+        "--no-dev",
+        "--no-progress",
+        "--no-interaction",
+        "--classmap-authoritative",
+        "--ignore-platform-req=ext-inotify",
+        "--ignore-platform-req=ext-pcntl",
+        "--ignore-platform-req=ext-posix",
+        "--ignore-platform-req=ext-md4c",
+        "--ignore-platform-req=ext-yaml",
+        "--ignore-platform-req=ext-highlighter"
+    )
+    Invoke-NativeCommand "php" @("-d", "phar.readonly=0", "build/package-phar.php", $pharPath)
+} finally {
+    Pop-Location
+}
+
+if (!(Test-Path $staticPhpPath)) {
+    Expand-TarGzArchive `
+        "https://github.com/crazywhalecc/static-php-cli/archive/${StaticPhpCliRef}.tar.gz" `
+        $staticPhpPath
+}
+
+if (!(Test-Path $md4cPath)) {
+    Expand-TarGzArchive "https://pecl.php.net/get/md4c-${Md4cVersion}.tgz" $md4cPath
+}
+
+if (!(Test-Path $highlighterPath)) {
+    Invoke-NativeCommand "composer" @(
+        "create-project",
+        "--no-dev",
+        "--no-progress",
+        "--no-interaction",
+        "yiipress/highlighter",
+        $highlighterPath,
+        "dev-master"
+    )
+}
+
+Push-Location $staticPhpPath
+try {
+    Invoke-NativeCommand "composer" @(
+        "install",
+        "--no-dev",
+        "--no-progress",
+        "--no-interaction",
+        "--classmap-authoritative"
+    )
+
+    $env:CARGO_BUILD_TARGET = "x86_64-pc-windows-msvc"
+    $env:HIGHLIGHTER_SOURCE = $highlighterPath
+    $env:YIIPRESS_MD4C_SOURCE = $md4cPath
+    $env:YIIPRESS_STATIC_INCLUDE_PROCESS_EXTENSIONS = "0"
+
+    Push-Location $highlighterPath
+    try {
+        Invoke-NativeCommand "rustup" @("target", "add", $env:CARGO_BUILD_TARGET)
+        Invoke-NativeCommand "cargo" @("build", "--release", "--target", $env:CARGO_BUILD_TARGET)
+    } finally {
+        Pop-Location
+    }
+
+    Invoke-NativeCommand "php" @((Join-Path $root "build/static-php/patch-extension-config.php"), "config/ext.json")
+    Invoke-NativeCommand "php" @(
+        (Join-Path $root "build/static-php/patch-source-config.php"),
+        "config/source.json",
+        "config/lib.json"
+    )
+    Invoke-NativeCommand "php" @(
+        "bin/spc",
+        "download",
+        "--for-extensions=${StaticPhpExtensions}",
+        "--with-php=${PhpVersion}",
+        "--without-suggestions"
+    )
+    Invoke-NativeCommand "php" @("bin/spc", "doctor", "--auto-fix")
+    Invoke-NativeCommand "php" @(
+        "bin/spc",
+        "build",
+        $StaticPhpExtensions,
+        "--build-micro",
+        "--with-micro-fake-cli",
+        "-P",
+        (Join-Path $root "build/static-php/register-yiipress-highlighter.php")
+    )
+    Invoke-NativeCommand "php" @("bin/spc", "micro:combine", $pharPath, "-O", $exePath)
+} finally {
+    Pop-Location
+}
+
+Write-Output "Built $exePath"

--- a/build/static-php/patch-extension-config.php
+++ b/build/static-php/patch-extension-config.php
@@ -18,7 +18,6 @@ foreach ($externalExtensions as $extension) {
     $json[$extension] = [
         'type' => 'builtin',
         'arg-type' => 'enable',
-        'unix-only' => true,
     ];
 }
 ksort($json);

--- a/build/static-php/register-yiipress-highlighter.php
+++ b/build/static-php/register-yiipress-highlighter.php
@@ -128,7 +128,12 @@ $highlighterWindowsConfigContents = str_replace(
     'EXTENSION("highlighter", "highlighter.c", true);',
     'EXTENSION("highlighter", "highlighter.c", false);',
     $highlighterWindowsConfigContents,
+    $highlighterWindowsConfigReplacementCount,
 );
+
+if ($highlighterWindowsConfigReplacementCount !== 1) {
+    throw new RuntimeException('Unable to patch highlighter config.w32 extension mode.');
+}
 
 file_put_contents($highlighterWindowsConfig, $highlighterWindowsConfigContents);
 
@@ -160,9 +165,8 @@ if ($md4cSource === false || $md4cSource === '') {
 FileSystem::copyDir($md4cSource, SOURCE_PATH . '/php-src/ext/md4c');
 
 $md4cWindowsConfig = SOURCE_PATH . '/php-src/ext/md4c/config.w32';
-$md4cWindowsConfigContents = file_get_contents($md4cWindowsConfig);
-if ($md4cWindowsConfigContents === false) {
-    throw new RuntimeException('Unable to read md4c config.w32.');
+if (!is_file($md4cWindowsConfig)) {
+    throw new RuntimeException('md4c config.w32 was not found.');
 }
 
 $md4cWindowsConfigContents = <<<'JS'

--- a/build/static-php/register-yiipress-highlighter.php
+++ b/build/static-php/register-yiipress-highlighter.php
@@ -97,7 +97,7 @@ C;
     return;
 }
 
-if (patch_point() !== 'before-php-buildconf') {
+if (patch_point() !== 'after-exts-extract') {
     return;
 }
 
@@ -107,6 +107,30 @@ if ($source === false || $source === '') {
 }
 
 FileSystem::copyDir($source, SOURCE_PATH . '/php-src/ext/highlighter');
+
+$highlighterWindowsConfig = SOURCE_PATH . '/php-src/ext/highlighter/config.w32';
+$highlighterWindowsConfigContents = file_get_contents($highlighterWindowsConfig);
+if ($highlighterWindowsConfigContents === false) {
+    throw new RuntimeException('Unable to read highlighter config.w32.');
+}
+
+if (!str_contains($highlighterWindowsConfigContents, 'ARG_ENABLE("highlighter"')) {
+    $highlighterWindowsConfigContents = <<<JS
+ARG_ENABLE("highlighter", "highlighter", "no");
+
+if (PHP_HIGHLIGHTER == "yes") {
+{$highlighterWindowsConfigContents}
+}
+JS;
+}
+
+$highlighterWindowsConfigContents = str_replace(
+    'EXTENSION("highlighter", "highlighter.c", true);',
+    'EXTENSION("highlighter", "highlighter.c", false);',
+    $highlighterWindowsConfigContents,
+);
+
+file_put_contents($highlighterWindowsConfig, $highlighterWindowsConfigContents);
 
 $highlighterConfig = SOURCE_PATH . '/php-src/ext/highlighter/config.m4';
 $highlighterConfigContents = file_get_contents($highlighterConfig);
@@ -134,3 +158,27 @@ if ($md4cSource === false || $md4cSource === '') {
 }
 
 FileSystem::copyDir($md4cSource, SOURCE_PATH . '/php-src/ext/md4c');
+
+$md4cWindowsConfig = SOURCE_PATH . '/php-src/ext/md4c/config.w32';
+$md4cWindowsConfigContents = file_get_contents($md4cWindowsConfig);
+if ($md4cWindowsConfigContents === false) {
+    throw new RuntimeException('Unable to read md4c config.w32.');
+}
+
+if (!str_contains($md4cWindowsConfigContents, 'ARG_ENABLE("md4c"')) {
+    $md4cWindowsConfigContents = <<<JS
+ARG_ENABLE("md4c", "md4c", "no");
+
+if (PHP_MD4C == "yes") {
+{$md4cWindowsConfigContents}
+}
+JS;
+}
+
+$md4cWindowsConfigContents = str_replace(
+    'EXTENSION("md4c", "md4c.c", true);',
+    'EXTENSION("md4c", "md4c.c", false);',
+    $md4cWindowsConfigContents,
+);
+
+file_put_contents($md4cWindowsConfig, $md4cWindowsConfigContents);

--- a/build/static-php/register-yiipress-highlighter.php
+++ b/build/static-php/register-yiipress-highlighter.php
@@ -15,12 +15,19 @@ if (patch_point() === 'before-php-make') {
         throw new RuntimeException('Unable to read generated internal_functions_cli.c.');
     }
 
+    $includeProcessExtensions = getenv('YIIPRESS_STATIC_INCLUDE_PROCESS_EXTENSIONS') !== '0';
     if (!str_contains($contents, 'YIIPRESS_STATIC_PATCHED_INTERNAL_FUNCTIONS')) {
-        $includes = <<<'C'
-/* YIIPRESS_STATIC_PATCHED_INTERNAL_FUNCTIONS */
-#include "ext/opcache/zend_accelerator_module.h"
+        $processExtensionIncludes = '';
+        if ($includeProcessExtensions) {
+            $processExtensionIncludes = <<<'C'
 #include "ext/pcntl/php_pcntl.h"
 #include "ext/posix/php_posix.h"
+C;
+        }
+
+        $includes = <<<C
+/* YIIPRESS_STATIC_PATCHED_INTERNAL_FUNCTIONS */
+#include "ext/opcache/zend_accelerator_module.h"
 #include "ext/standard/php_standard.h"
 #include "ext/spl/php_spl.h"
 #include "ext/phar/php_phar.h"
@@ -29,6 +36,7 @@ if (patch_point() === 'before-php-make') {
 #include "ext/uri/php_uri.h"
 #include "ext/xml/php_xml.h"
 #include "ext/xmlwriter/php_xmlwriter.h"
+{$processExtensionIncludes}
 
 extern zend_module_entry md4c_module_entry;
 #ifndef phpext_md4c_ptr
@@ -52,6 +60,10 @@ C;
         }
 
         file_put_contents($internalFunctionsFile, $contents);
+    }
+
+    if (DIRECTORY_SEPARATOR === '\\') {
+        return;
     }
 
     $target = getenv('CARGO_BUILD_TARGET') ?: 'x86_64-unknown-linux-musl';

--- a/build/static-php/register-yiipress-highlighter.php
+++ b/build/static-php/register-yiipress-highlighter.php
@@ -165,20 +165,24 @@ if ($md4cWindowsConfigContents === false) {
     throw new RuntimeException('Unable to read md4c config.w32.');
 }
 
-if (!str_contains($md4cWindowsConfigContents, 'ARG_ENABLE("md4c"')) {
-    $md4cWindowsConfigContents = <<<JS
-ARG_ENABLE("md4c", "md4c", "no");
+$md4cWindowsConfigContents = <<<'JS'
+ARG_ENABLE("md4c", "Enable the md4c extension", "no");
 
-if (PHP_MD4C == "yes") {
-{$md4cWindowsConfigContents}
+if (PHP_MD4C != "no") {
+    EXTENSION("md4c", "md4c.c", false);
 }
 JS;
-}
-
-$md4cWindowsConfigContents = str_replace(
-    'EXTENSION("md4c", "md4c.c", true);',
-    'EXTENSION("md4c", "md4c.c", false);',
-    $md4cWindowsConfigContents,
-);
 
 file_put_contents($md4cWindowsConfig, $md4cWindowsConfigContents);
+
+$md4cHeader = <<<'C'
+#ifndef PHP_MD4C_H
+#define PHP_MD4C_H
+
+extern zend_module_entry md4c_module_entry;
+#define phpext_md4c_ptr &md4c_module_entry
+
+#endif
+C;
+
+file_put_contents(SOURCE_PATH . '/php-src/ext/md4c/php_md4c.h', $md4cHeader);

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -201,7 +201,7 @@ COPY --from=static-package /artifacts/yiipress /yiipress
 
 FROM package-linux-artifacts AS package-artifacts
 
-FROM gcr.io/distroless/static-debian12:nonroot AS distroless
+FROM gcr.io/distroless/static-debian12:nonroot@sha256:d093aa3e30dbadd3efe1310db061a14da60299baff8450a17fe0ccc514a16639 AS distroless
 LABEL org.opencontainers.image.licenses="BSD-3-Clause" \
     org.opencontainers.image.title="YiiPress" \
     org.opencontainers.image.description="YiiPress static website builder" \

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -181,10 +181,11 @@ RUN --mount=type=cache,target=/root/.cargo/git \
     php /opt/patch-extension-config.php /static-php/config/ext.json \
     && php /opt/patch-source-config.php /static-php/config/source.json /static-php/config/lib.json \
     && bin/spc download --for-extensions="${STATIC_PHP_EXTENSIONS}" --with-php="${PHP_VERSION}" --without-suggestions \
+    && bin/spc install-pkg upx \
     && mkdir -p buildroot/bin \
     && ln -sf /usr/bin/pkg-config buildroot/bin/pkg-config \
     && SPC_TOOLCHAIN='SPC\toolchain\MuslToolchain' SPC_TARGET=x86_64-linux-musl bin/spc doctor --auto-fix \
-    && (bin/spc build "${STATIC_PHP_EXTENSIONS}" --build-micro --with-micro-fake-cli -P /opt/register-yiipress-highlighter.php \
+    && (bin/spc build "${STATIC_PHP_EXTENSIONS}" --build-micro --with-micro-fake-cli --with-upx-pack -P /opt/register-yiipress-highlighter.php \
         || (tail -n 200 /static-php/log/spc.shell.log && false))
 COPY --from=phar-builder /app/dist/yiipress.phar /artifacts/yiipress.phar
 RUN bin/spc micro:combine /artifacts/yiipress.phar -O /artifacts/yiipress \

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -171,7 +171,6 @@ RUN mkdir -p /opt/md4c-extension \
     | tar -xz --strip-components=1 -C /opt/md4c-extension
 RUN --mount=type=cache,target=/tmp/composer-cache \
     COMPOSER_CACHE_DIR=/tmp/composer-cache composer create-project --no-dev --no-progress --no-interaction yiipress/highlighter /opt/yiipress-highlighter dev-master
-RUN cd /opt/yiipress-highlighter && rustup target add x86_64-unknown-linux-musl
 COPY build/static-php/patch-extension-config.php /opt/patch-extension-config.php
 COPY build/static-php/patch-source-config.php /opt/patch-source-config.php
 COPY build/static-php/register-yiipress-highlighter.php /opt/register-yiipress-highlighter.php
@@ -201,8 +200,8 @@ FROM package-linux-artifacts AS package-artifacts
 
 FROM gcr.io/distroless/static-debian12:nonroot AS distroless
 LABEL org.opencontainers.image.licenses="BSD-3-Clause" \
-    org.opencontainers.image.title="YiiPress static binary" \
-    org.opencontainers.image.description="YiiPress static website builder packaged as a distroless image with only the static binary copied in" \
+    org.opencontainers.image.title="YiiPress" \
+    org.opencontainers.image.description="YiiPress static website builder" \
     org.opencontainers.image.source="https://github.com/yiipress/engine" \
     org.opencontainers.image.url="https://github.com/yiipress/engine" \
     org.opencontainers.image.vendor="Alexander Makarov" \

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -27,6 +27,7 @@ RUN install-php-extensions \
     posix
 
 FROM base AS highlighter-extension-builder
+ARG HIGHLIGHTER_VERSION=1.0.1
 ENV CARGO_HOME=/root/.cargo \
     RUSTUP_HOME=/usr/local/rustup \
     PATH="/root/.cargo/bin:${PATH}"
@@ -34,7 +35,7 @@ COPY --from=composer /composer /usr/bin/composer
 COPY --from=rust:bookworm /usr/local/cargo /root/.cargo
 COPY --from=rust:bookworm /usr/local/rustup /usr/local/rustup
 RUN --mount=type=cache,target=/tmp/composer-cache \
-    COMPOSER_CACHE_DIR=/tmp/composer-cache composer create-project --no-dev --no-progress --no-interaction yiipress/highlighter /build/highlighter-extension dev-master
+    COMPOSER_CACHE_DIR=/tmp/composer-cache composer create-project --no-dev --no-progress --no-interaction yiipress/highlighter /build/highlighter-extension "${HIGHLIGHTER_VERSION}"
 RUN --mount=type=cache,target=/root/.cargo/git \
     --mount=type=cache,target=/root/.cargo/registry \
     cd /build/highlighter-extension \
@@ -124,6 +125,7 @@ RUN --mount=type=cache,target=/tmp/composer-cache \
 FROM app-base AS static-package
 ARG PHP_VERSION=8.5
 ARG MD4C_VERSION=1.1
+ARG HIGHLIGHTER_VERSION=1.0.1
 ARG STATIC_PHP_CLI_REF=5b5861c366a0d94bc84002db7b3f46144b388fbb
 ARG STATIC_PHP_EXTENSIONS=ctype,dom,filter,highlighter,inotify,mbstring,md4c,opcache,pcntl,phar,posix,xml,xmlwriter,yaml
 ARG TARGETARCH
@@ -170,7 +172,7 @@ RUN mkdir -p /opt/md4c-extension \
     && curl -fsSL "https://pecl.php.net/get/md4c-${MD4C_VERSION}.tgz" \
     | tar -xz --strip-components=1 -C /opt/md4c-extension
 RUN --mount=type=cache,target=/tmp/composer-cache \
-    COMPOSER_CACHE_DIR=/tmp/composer-cache composer create-project --no-dev --no-progress --no-interaction yiipress/highlighter /opt/yiipress-highlighter dev-master
+    COMPOSER_CACHE_DIR=/tmp/composer-cache composer create-project --no-dev --no-progress --no-interaction yiipress/highlighter /opt/yiipress-highlighter "${HIGHLIGHTER_VERSION}"
 COPY build/static-php/patch-extension-config.php /opt/patch-extension-config.php
 COPY build/static-php/patch-source-config.php /opt/patch-source-config.php
 COPY build/static-php/register-yiipress-highlighter.php /opt/register-yiipress-highlighter.php

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -185,15 +185,16 @@ RUN --mount=type=cache,target=/root/.cargo/git \
     && ln -sf /usr/bin/pkg-config buildroot/bin/pkg-config \
     && SPC_TOOLCHAIN='SPC\toolchain\MuslToolchain' SPC_TARGET=x86_64-linux-musl bin/spc doctor --auto-fix \
     && (bin/spc build "${STATIC_PHP_EXTENSIONS}" --build-micro --with-micro-fake-cli -P /opt/register-yiipress-highlighter.php \
-        || (tail -n 200 /static-php/log/spc.shell.log && false)) \
-    && cp buildroot/bin/micro.sfx /artifacts/micro.sfx
+        || (tail -n 200 /static-php/log/spc.shell.log && false))
 COPY --from=phar-builder /app/dist/yiipress.phar /artifacts/yiipress.phar
 RUN bin/spc micro:combine /artifacts/yiipress.phar -O /artifacts/yiipress \
     && chmod +x /artifacts/yiipress
 
+FROM scratch AS package-phar-artifacts
+COPY --from=phar-builder /app/dist/yiipress.phar /yiipress.phar
+
 FROM scratch AS package-linux-artifacts
 COPY --from=static-package /artifacts/yiipress /yiipress
-COPY --from=static-package /artifacts/yiipress.phar /yiipress.phar
 
 FROM package-linux-artifacts AS package-artifacts
 

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -173,6 +173,7 @@ RUN mkdir -p /opt/md4c-extension \
     | tar -xz --strip-components=1 -C /opt/md4c-extension
 RUN --mount=type=cache,target=/tmp/composer-cache \
     COMPOSER_CACHE_DIR=/tmp/composer-cache composer create-project --no-dev --no-progress --no-interaction yiipress/highlighter /opt/yiipress-highlighter "${HIGHLIGHTER_VERSION}"
+RUN cd /opt/yiipress-highlighter && rustup target add x86_64-unknown-linux-musl
 COPY build/static-php/patch-extension-config.php /opt/patch-extension-config.php
 COPY build/static-php/patch-source-config.php /opt/patch-source-config.php
 COPY build/static-php/register-yiipress-highlighter.php /opt/register-yiipress-highlighter.php

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -33,8 +33,11 @@ ENV CARGO_HOME=/root/.cargo \
 COPY --from=composer /composer /usr/bin/composer
 COPY --from=rust:bookworm /usr/local/cargo /root/.cargo
 COPY --from=rust:bookworm /usr/local/rustup /usr/local/rustup
-RUN composer create-project --no-dev --no-progress --no-interaction yiipress/highlighter /build/highlighter-extension dev-master
-RUN cd /build/highlighter-extension \
+RUN --mount=type=cache,target=/tmp/composer-cache \
+    COMPOSER_CACHE_DIR=/tmp/composer-cache composer create-project --no-dev --no-progress --no-interaction yiipress/highlighter /build/highlighter-extension dev-master
+RUN --mount=type=cache,target=/root/.cargo/git \
+    --mount=type=cache,target=/root/.cargo/registry \
+    cd /build/highlighter-extension \
     && phpize \
     && ./configure \
     && make -j"$(nproc)" \
@@ -88,8 +91,8 @@ COPY public /app/public
 COPY src /app/src
 COPY themes /app/themes
 COPY yii composer.json composer.lock /app/
-RUN --mount=type=cache,target=/tmp/cache \
-    composer install --no-dev --no-progress --no-interaction --classmap-authoritative && \
+RUN --mount=type=cache,target=/tmp/composer-cache \
+    COMPOSER_CACHE_DIR=/tmp/composer-cache composer install --no-dev --no-progress --no-interaction --classmap-authoritative && \
     rm composer.lock composer.json
 
 FROM app-base AS prod
@@ -114,8 +117,8 @@ COPY src /app/src
 COPY themes /app/themes
 COPY build/package-phar.php build/PharArchiveFilter.php /app/build/
 COPY yii composer.json composer.lock /app/
-RUN --mount=type=cache,target=/tmp/cache \
-    composer install --no-dev --no-progress --no-interaction --classmap-authoritative && \
+RUN --mount=type=cache,target=/tmp/composer-cache \
+    COMPOSER_CACHE_DIR=/tmp/composer-cache composer install --no-dev --no-progress --no-interaction --classmap-authoritative && \
     php -d phar.readonly=0 build/package-phar.php dist/yiipress.phar
 
 FROM app-base AS static-package
@@ -159,18 +162,23 @@ COPY --from=rust:bookworm /usr/local/cargo /root/.cargo
 COPY --from=rust:bookworm /usr/local/rustup /usr/local/rustup
 RUN rustup target add x86_64-unknown-linux-musl
 WORKDIR /static-php
-RUN curl -fsSL "https://github.com/crazywhalecc/static-php-cli/archive/${STATIC_PHP_CLI_REF}.tar.gz" \
+RUN --mount=type=cache,target=/tmp/composer-cache \
+    curl -fsSL "https://github.com/crazywhalecc/static-php-cli/archive/${STATIC_PHP_CLI_REF}.tar.gz" \
     | tar -xz --strip-components=1 -C /static-php \
-    && composer install --no-dev --no-progress --no-interaction --classmap-authoritative
+    && COMPOSER_CACHE_DIR=/tmp/composer-cache composer install --no-dev --no-progress --no-interaction --classmap-authoritative
 RUN mkdir -p /opt/md4c-extension \
     && curl -fsSL "https://pecl.php.net/get/md4c-${MD4C_VERSION}.tgz" \
     | tar -xz --strip-components=1 -C /opt/md4c-extension
-RUN composer create-project --no-dev --no-progress --no-interaction yiipress/highlighter /opt/yiipress-highlighter dev-master
+RUN --mount=type=cache,target=/tmp/composer-cache \
+    COMPOSER_CACHE_DIR=/tmp/composer-cache composer create-project --no-dev --no-progress --no-interaction yiipress/highlighter /opt/yiipress-highlighter dev-master
+RUN cd /opt/yiipress-highlighter && rustup target add x86_64-unknown-linux-musl
 COPY build/static-php/patch-extension-config.php /opt/patch-extension-config.php
 COPY build/static-php/patch-source-config.php /opt/patch-source-config.php
 COPY build/static-php/register-yiipress-highlighter.php /opt/register-yiipress-highlighter.php
 RUN mkdir -p /artifacts
-RUN php /opt/patch-extension-config.php /static-php/config/ext.json \
+RUN --mount=type=cache,target=/root/.cargo/git \
+    --mount=type=cache,target=/root/.cargo/registry \
+    php /opt/patch-extension-config.php /static-php/config/ext.json \
     && php /opt/patch-source-config.php /static-php/config/source.json /static-php/config/lib.json \
     && bin/spc download --for-extensions="${STATIC_PHP_EXTENSIONS}" --with-php="${PHP_VERSION}" --without-suggestions \
     && mkdir -p buildroot/bin \
@@ -183,6 +191,23 @@ COPY --from=phar-builder /app/dist/yiipress.phar /artifacts/yiipress.phar
 RUN bin/spc micro:combine /artifacts/yiipress.phar -O /artifacts/yiipress \
     && chmod +x /artifacts/yiipress
 
-FROM scratch AS package-artifacts
+FROM scratch AS package-linux-artifacts
 COPY --from=static-package /artifacts/yiipress /yiipress
 COPY --from=static-package /artifacts/yiipress.phar /yiipress.phar
+
+FROM package-linux-artifacts AS package-artifacts
+
+FROM gcr.io/distroless/static-debian12:nonroot AS distroless
+LABEL org.opencontainers.image.licenses="BSD-3-Clause" \
+    org.opencontainers.image.title="YiiPress static binary" \
+    org.opencontainers.image.description="YiiPress static website builder packaged as a distroless image with only the static binary copied in" \
+    org.opencontainers.image.source="https://github.com/yiipress/engine" \
+    org.opencontainers.image.url="https://github.com/yiipress/engine" \
+    org.opencontainers.image.vendor="Alexander Makarov" \
+    org.opencontainers.image.created="" \
+    org.opencontainers.image.revision="" \
+    org.opencontainers.image.version=""
+COPY --from=static-package /artifacts/yiipress /yiipress
+WORKDIR /site
+ENTRYPOINT ["/yiipress"]
+CMD ["--help"]

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -141,22 +141,23 @@ YiiPress can be packaged as reproducible artifacts:
 make package
 ```
 
-The command builds the Linux artifacts and writes them to `dist/linux-amd64/`:
+The command builds the Linux static executable and writes it to `dist/linux-amd64/`:
 
-- `yiipress.phar` — PHP archive for environments that already have PHP 8.5 and required extensions.
 - `yiipress` — static Linux executable built with static-php-cli micro SAPI and the YiiPress PHAR embedded.
 
 Additional package targets are available:
 
 ```bash
+make package-phar
 make package-linux
 make package-windows
 make package-distroless
 make package-distroless-push
 ```
 
-- `make package-linux` is the explicit Linux artifact target. Set `PACKAGE_PLATFORM=linux/amd64` and `PACKAGE_LINUX_DIST=...` to override the defaults.
-- `make package-windows` builds `dist/windows-amd64/yiipress.exe` and `yiipress.phar` with the PowerShell packaging script. It is intended for Windows hosts with PowerShell 7 (`pwsh`), PHP, Composer, Rust, and the Visual Studio C++ toolchain available.
+- `make package-phar` builds `dist/phar/yiipress.phar` separately for environments that already have PHP 8.5 and required extensions. Set `PACKAGE_PHAR_DIST=...` to override the output directory.
+- `make package-linux` is the explicit Linux static executable target. Set `PACKAGE_PLATFORM=linux/amd64` and `PACKAGE_LINUX_DIST=...` to override the defaults.
+- `make package-windows` builds only `dist/windows-amd64/yiipress.exe` with the PowerShell packaging script. It is intended for Windows hosts with PowerShell 7 (`pwsh`), PHP, Composer, Rust, and the Visual Studio C++ toolchain available. The intermediate PHAR used by `static-php-cli` is kept under `runtime/package-windows/` and is not part of the Windows artifact.
 - `make package-distroless` builds a local `${IMAGE}-static:${IMAGE_TAG}` image from the `distroless` Docker target. The image copies only the static `yiipress` binary into a distroless base and runs it as the entrypoint.
 - `make package-distroless-push` builds and pushes the same image.
 
@@ -165,4 +166,4 @@ The static executable includes `ext-highlighter`, so syntax highlighting does no
 Relative `content-dir`, `output-dir`, `new`, `clean`, `serve`, and `import` paths are resolved from the directory where you run `yiipress`, not from the packaged executable location.
 PHAR and static binary runs keep build cache and incremental manifests under the OS temp directory, keyed by the current project directory, instead of writing to `runtime/` in the site checkout. `yiipress clean` removes that packaged cache as well as the configured output directory.
 
-GitHub Actions builds the same outputs in the `Package Static Builds` workflow. Commits to `master` publish nightly Linux and Windows workflow artifacts and push the distroless image as `ghcr.io/<owner>/<repo>-static:nightly` plus a commit-specific `nightly-<sha>` tag. Version tags publish release archives to the GitHub release and push semver tags for the distroless image.
+GitHub Actions builds the same outputs in the `Package Static Builds` workflow. Commits to `master` publish separate nightly PHAR, Linux, and Windows workflow artifacts and push the distroless image as `ghcr.io/<owner>/<repo>-static:nightly` plus a commit-specific `nightly-<sha>` tag. Version tags publish the standalone `yiipress.phar`, Linux archive, and Windows archive to the GitHub release and push semver tags for the distroless image.

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -133,22 +133,36 @@ Your site will be available at `http://localhost:3000`.
 
 To deploy, push the image to any container registry and run it on any platform that supports Docker — a VPS, Fly.io, Railway, Render, or any Kubernetes cluster.
 
-## YiiPress PHAR and Static Binary
+## YiiPress PHAR, Static Binary, and Distroless Image
 
-YiiPress can be packaged as reproducible Docker-built artifacts:
+YiiPress can be packaged as reproducible artifacts:
 
 ```bash
 make package
 ```
 
-The command writes artifacts to `dist/`:
+The command builds the Linux artifacts and writes them to `dist/linux-amd64/`:
 
 - `yiipress.phar` — PHP archive for environments that already have PHP 8.5 and required extensions.
 - `yiipress` — static Linux executable built with static-php-cli micro SAPI and the YiiPress PHAR embedded.
+
+Additional package targets are available:
+
+```bash
+make package-linux
+make package-windows
+make package-distroless
+make package-distroless-push
+```
+
+- `make package-linux` is the explicit Linux artifact target. Set `PACKAGE_PLATFORM=linux/amd64` and `PACKAGE_LINUX_DIST=...` to override the defaults.
+- `make package-windows` builds `dist/windows-amd64/yiipress.exe` and `yiipress.phar` with the PowerShell packaging script. It is intended for Windows hosts with PowerShell 7 (`pwsh`), PHP, Composer, Rust, and the Visual Studio C++ toolchain available.
+- `make package-distroless` builds a local `${IMAGE}-static:${IMAGE_TAG}` image from the `distroless` Docker target. The image copies only the static `yiipress` binary into a distroless base and runs it as the entrypoint.
+- `make package-distroless-push` builds and pushes the same image.
 
 The PHAR builder copies only runtime inputs into the build stage: `config/`, `public/`, `src/`, `themes/`, `yii`, Composer metadata, and the PHAR build script. Dependencies are installed with `--no-dev` inside that stage before the PHAR is assembled.
 The static executable includes `ext-highlighter`, so syntax highlighting does not need FFI or an external shared library. `serve` uses ReactPHP stream sockets with preforked worker processes, serves built files and live reload SSE in the server loop, keeps one shared live reload watcher per worker, and does not require PHP's native `sockets` extension.
 Relative `content-dir`, `output-dir`, `new`, `clean`, `serve`, and `import` paths are resolved from the directory where you run `yiipress`, not from the packaged executable location.
 PHAR and static binary runs keep build cache and incremental manifests under the OS temp directory, keyed by the current project directory, instead of writing to `runtime/` in the site checkout. `yiipress clean` removes that packaged cache as well as the configured output directory.
 
-GitHub Actions builds the same artifacts in the `Package Static Binary` workflow and uploads them as a workflow artifact.
+GitHub Actions builds the same outputs in the `Package Static Builds` workflow. Commits to `master` publish nightly Linux and Windows workflow artifacts and push the distroless image as `ghcr.io/<owner>/<repo>-static:nightly` plus a commit-specific `nightly-<sha>` tag. Version tags publish release archives to the GitHub release and push semver tags for the distroless image.

--- a/roadmap.md
+++ b/roadmap.md
@@ -47,6 +47,7 @@
 - [x] Live reload / file watching during `yiipress serve`
 - [x] PHAR and static PHP binary packaging
 - [x] Worker-mode serving for PHAR and static PHP binary packages
+- [x] Linux, Windows, and distroless Docker release packaging
 - [x] `yiipress new` command — scaffold new entries from archetypes/templates
 - [x] `yiipress init` command — scaffold initial content structure
 - [x] Incremental builds (only rebuild changed files)

--- a/src/Build/ParallelEntryWriter.php
+++ b/src/Build/ParallelEntryWriter.php
@@ -17,6 +17,7 @@ use function array_slice;
 use function ceil;
 use function count;
 use function dirname;
+use function function_exists;
 use function min;
 use function pcntl_fork;
 use function pcntl_wexitstatus;
@@ -137,7 +138,7 @@ final readonly class ParallelEntryWriter
 
     public function workerCountFor(int $taskCount, int $requestedWorkerCount): int
     {
-        if ($requestedWorkerCount <= 1 || $taskCount < self::MIN_TASKS_PER_WORKER * 2) {
+        if (!function_exists('pcntl_fork') || $requestedWorkerCount <= 1 || $taskCount < self::MIN_TASKS_PER_WORKER * 2) {
             return 1;
         }
 

--- a/src/Build/ParallelTaskRunner.php
+++ b/src/Build/ParallelTaskRunner.php
@@ -11,6 +11,7 @@ use function ceil;
 use function count;
 use function file_get_contents;
 use function file_put_contents;
+use function function_exists;
 use function is_dir;
 use function mkdir;
 use function min;
@@ -100,7 +101,7 @@ final class ParallelTaskRunner
 
     private function effectiveWorkerCount(int $taskCount, int $requestedWorkerCount, int $minTasksPerWorker): int
     {
-        if ($requestedWorkerCount <= 1) {
+        if (!function_exists('pcntl_fork') || $requestedWorkerCount <= 1) {
             return 1;
         }
 

--- a/tests/Unit/Packaging/ConfigurationPackagingTest.php
+++ b/tests/Unit/Packaging/ConfigurationPackagingTest.php
@@ -95,8 +95,11 @@ final class ConfigurationPackagingTest extends TestCase
         $makefile = file_get_contents(dirname(__DIR__, 3) . '/Makefile');
         self::assertIsString($makefile);
 
+        self::assertStringContainsString('package-phar:', $makefile);
+        self::assertStringContainsString('--target package-phar-artifacts', $makefile);
         self::assertStringContainsString('package-linux:', $makefile);
         self::assertStringContainsString('--target package-linux-artifacts', $makefile);
+        self::assertStringContainsString('rm -f $(PACKAGE_LINUX_DIST)/yiipress.phar', $makefile);
         self::assertStringContainsString('package-windows:', $makefile);
         self::assertStringContainsString('build/package-windows.ps1', $makefile);
         self::assertStringContainsString('PowerShell 7 (pwsh) is required for package-windows.', $makefile);
@@ -117,8 +120,37 @@ final class ConfigurationPackagingTest extends TestCase
         self::assertStringContainsString('COPY --from=static-package /artifacts/yiipress /yiipress', $stage);
         self::assertStringContainsString('ENTRYPOINT ["/yiipress"]', $stage);
         self::assertStringNotContainsString('COPY --from=static-package /artifacts/yiipress.phar', $stage);
+        self::assertStringNotContainsString('micro.sfx', $stage);
         self::assertStringNotContainsString('/bin/sh', $stage);
         self::assertStringNotContainsString('apt-get', $stage);
+    }
+
+    #[Test]
+    public function platformArtifactsDoNotIncludeStandalonePhar(): void
+    {
+        $dockerfile = file_get_contents(dirname(__DIR__, 3) . '/docker/Dockerfile');
+        $script = file_get_contents(dirname(__DIR__, 3) . '/build/package-windows.ps1');
+        self::assertIsString($dockerfile);
+        self::assertIsString($script);
+
+        $pharStart = strpos($dockerfile, 'FROM scratch AS package-phar-artifacts');
+        $linuxStart = strpos($dockerfile, 'FROM scratch AS package-linux-artifacts');
+        $aliasStart = strpos($dockerfile, 'FROM package-linux-artifacts AS package-artifacts');
+
+        self::assertIsInt($pharStart);
+        self::assertIsInt($linuxStart);
+        self::assertIsInt($aliasStart);
+
+        $pharStage = substr($dockerfile, $pharStart, $linuxStart - $pharStart);
+        $linuxStage = substr($dockerfile, $linuxStart, $aliasStart - $linuxStart);
+
+        self::assertStringContainsString('COPY --from=phar-builder /app/dist/yiipress.phar /yiipress.phar', $pharStage);
+        self::assertStringContainsString('COPY --from=static-package /artifacts/yiipress /yiipress', $linuxStage);
+        self::assertStringNotContainsString('yiipress.phar', $linuxStage);
+        self::assertStringContainsString('$pharPath = Join-Path $workPath "yiipress.phar"', $script);
+        self::assertStringNotContainsString('$pharPath = Join-Path $distPath "yiipress.phar"', $script);
+        self::assertStringContainsString('$legacyDistPharPath = Join-Path $distPath "yiipress.phar"', $script);
+        self::assertStringContainsString('Remove-Item $legacyDistPharPath -Force', $script);
     }
 
     #[Test]
@@ -154,18 +186,24 @@ final class ConfigurationPackagingTest extends TestCase
         $workflow = file_get_contents(dirname(__DIR__, 3) . '/.github/workflows/package-static.yml');
         self::assertIsString($workflow);
 
+        self::assertStringContainsString('target: package-phar-artifacts', $workflow);
+        self::assertStringContainsString('name: yiipress-phar', $workflow);
+        self::assertStringContainsString('path: dist/phar/yiipress.phar', $workflow);
         self::assertStringContainsString('target: package-linux-artifacts', $workflow);
         self::assertStringContainsString('Smoke test Linux binary', $workflow);
         self::assertStringContainsString('./dist/linux-amd64/yiipress --help', $workflow);
+        self::assertStringContainsString('path: dist/linux-amd64/yiipress', $workflow);
         self::assertStringContainsString('build/package-windows.ps1 -DistDir dist/windows-amd64', $workflow);
         self::assertStringContainsString('Cache Windows package dependencies', $workflow);
         self::assertStringContainsString('runtime\package-windows\yiipress-highlighter', $workflow);
         self::assertStringContainsString('Smoke test Windows binary', $workflow);
         self::assertStringContainsString('./dist/windows-amd64/yiipress.exe --help', $workflow);
+        self::assertStringContainsString('path: dist/windows-amd64/yiipress.exe', $workflow);
         self::assertStringContainsString('target: distroless', $workflow);
         self::assertStringContainsString("github.ref == 'refs/heads/master' || startsWith(github.ref, 'refs/tags/')", $workflow);
         self::assertStringContainsString('type=raw,value=nightly', $workflow);
         self::assertStringContainsString('type=semver,pattern={{version}}', $workflow);
+        self::assertStringContainsString('cp release/yiipress-phar/yiipress.phar yiipress.phar', $workflow);
         self::assertStringContainsString('softprops/action-gh-release', $workflow);
     }
 

--- a/tests/Unit/Packaging/ConfigurationPackagingTest.php
+++ b/tests/Unit/Packaging/ConfigurationPackagingTest.php
@@ -115,7 +115,10 @@ final class ConfigurationPackagingTest extends TestCase
         $dockerfile = file_get_contents(dirname(__DIR__, 3) . '/docker/Dockerfile');
         self::assertIsString($dockerfile);
 
-        $start = strpos($dockerfile, 'FROM gcr.io/distroless/static-debian12:nonroot AS distroless');
+        $start = strpos(
+            $dockerfile,
+            'FROM gcr.io/distroless/static-debian12:nonroot@sha256:d093aa3e30dbadd3efe1310db061a14da60299baff8450a17fe0ccc514a16639 AS distroless',
+        );
         self::assertIsInt($start);
         $stage = substr($dockerfile, $start);
 
@@ -220,6 +223,7 @@ final class ConfigurationPackagingTest extends TestCase
         self::assertStringContainsString('softprops/action-gh-release', $workflow);
         self::assertDoesNotMatchRegularExpression('/uses:\s+[^@\s]+@v\d+/', $workflow);
         self::assertStringNotContainsString('dtolnay/rust-toolchain@stable', $workflow);
+        self::assertSame(3, substr_count($workflow, 'persist-credentials: false'));
     }
 
     #[Test]

--- a/tests/Unit/Packaging/ConfigurationPackagingTest.php
+++ b/tests/Unit/Packaging/ConfigurationPackagingTest.php
@@ -105,6 +105,8 @@ final class ConfigurationPackagingTest extends TestCase
         self::assertStringContainsString('PowerShell 7 (pwsh) is required for package-windows.', $makefile);
         self::assertStringContainsString('package-distroless:', $makefile);
         self::assertStringContainsString('--target distroless', $makefile);
+        self::assertStringContainsString('package-distroless-push:', $makefile);
+        self::assertStringContainsString('--push -t $(PACKAGE_IMAGE):$(IMAGE_TAG)', $makefile);
     }
 
     #[Test]
@@ -118,6 +120,8 @@ final class ConfigurationPackagingTest extends TestCase
         $stage = substr($dockerfile, $start);
 
         self::assertStringContainsString('COPY --from=static-package /artifacts/yiipress /yiipress', $stage);
+        self::assertStringContainsString('org.opencontainers.image.title="YiiPress"', $stage);
+        self::assertStringContainsString('org.opencontainers.image.description="YiiPress static website builder"', $stage);
         self::assertStringContainsString('ENTRYPOINT ["/yiipress"]', $stage);
         self::assertStringNotContainsString('COPY --from=static-package /artifacts/yiipress.phar', $stage);
         self::assertStringNotContainsString('micro.sfx', $stage);
@@ -168,6 +172,9 @@ final class ConfigurationPackagingTest extends TestCase
         self::assertStringContainsString('function Test-NativeCommand', $script);
         self::assertStringContainsString('foreach ($command in @("php", "composer", "tar", "rustup", "cargo"))', $script);
         self::assertStringContainsString('foreach ($command in @("cl", "nmake"))', $script);
+        self::assertStringNotContainsString('if ($IsWindows)', $script);
+        self::assertStringContainsString('Invoke-WebRequest -Uri $Url -OutFile $archive -TimeoutSec 300', $script);
+        self::assertStringContainsString('finally {', $script);
         self::assertStringContainsString('--ignore-platform-req=ext-inotify', $script);
         self::assertStringContainsString('--ignore-platform-req=ext-pcntl', $script);
         self::assertStringContainsString('--ignore-platform-req=ext-posix', $script);
@@ -194,6 +201,10 @@ final class ConfigurationPackagingTest extends TestCase
         self::assertStringContainsString('./dist/linux-amd64/yiipress --help', $workflow);
         self::assertStringContainsString('path: dist/linux-amd64/yiipress', $workflow);
         self::assertStringContainsString('build/package-windows.ps1 -DistDir dist/windows-amd64', $workflow);
+        self::assertStringContainsString(
+            "github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository",
+            $workflow,
+        );
         self::assertStringContainsString('Cache Windows package dependencies', $workflow);
         self::assertStringContainsString('runtime\package-windows\yiipress-highlighter', $workflow);
         self::assertStringContainsString('Smoke test Windows binary', $workflow);
@@ -323,7 +334,8 @@ final class ConfigurationPackagingTest extends TestCase
         self::assertIsString($dockerfile);
         self::assertIsString($windowsScript);
 
-        self::assertStringContainsString(
+        self::assertStringContainsString('RUN rustup target add x86_64-unknown-linux-musl', $dockerfile);
+        self::assertStringNotContainsString(
             'RUN cd /opt/yiipress-highlighter && rustup target add x86_64-unknown-linux-musl',
             $dockerfile,
         );
@@ -358,7 +370,9 @@ final class ConfigurationPackagingTest extends TestCase
         self::assertStringContainsString('ARG_ENABLE("highlighter"', $registrationPatch);
         self::assertStringContainsString('ARG_ENABLE("md4c"', $registrationPatch);
         self::assertStringContainsString('EXTENSION("highlighter", "highlighter.c", false);', $registrationPatch);
+        self::assertStringContainsString('$highlighterWindowsConfigReplacementCount !== 1', $registrationPatch);
         self::assertStringContainsString('EXTENSION("md4c", "md4c.c", false);', $registrationPatch);
+        self::assertStringContainsString('md4c config.w32 was not found.', $registrationPatch);
         self::assertStringContainsString('php_md4c.h', $registrationPatch);
         self::assertStringContainsString('phpext_md4c_ptr', $registrationPatch);
     }

--- a/tests/Unit/Packaging/ConfigurationPackagingTest.php
+++ b/tests/Unit/Packaging/ConfigurationPackagingTest.php
@@ -143,6 +143,8 @@ final class ConfigurationPackagingTest extends TestCase
         self::assertStringContainsString('log/spc.output.log', $script);
         self::assertStringContainsString('log/spc.shell.log', $script);
         self::assertStringNotContainsString('--with-micro-fake-cli', $script);
+        self::assertStringContainsString('buildroot/lib', $script);
+        self::assertStringContainsString('highlighter.lib', $script);
     }
 
     #[Test]

--- a/tests/Unit/Packaging/ConfigurationPackagingTest.php
+++ b/tests/Unit/Packaging/ConfigurationPackagingTest.php
@@ -145,6 +145,7 @@ final class ConfigurationPackagingTest extends TestCase
         self::assertStringNotContainsString('--with-micro-fake-cli', $script);
         self::assertStringContainsString('buildroot/lib', $script);
         self::assertStringContainsString('highlighter.lib', $script);
+        self::assertStringContainsString('$env:RUSTFLAGS = "-C target-feature=+crt-static"', $script);
     }
 
     #[Test]

--- a/tests/Unit/Packaging/ConfigurationPackagingTest.php
+++ b/tests/Unit/Packaging/ConfigurationPackagingTest.php
@@ -142,6 +142,7 @@ final class ConfigurationPackagingTest extends TestCase
         self::assertStringContainsString('function Write-LogTail', $script);
         self::assertStringContainsString('log/spc.output.log', $script);
         self::assertStringContainsString('log/spc.shell.log', $script);
+        self::assertStringNotContainsString('--with-micro-fake-cli', $script);
     }
 
     #[Test]
@@ -304,12 +305,19 @@ final class ConfigurationPackagingTest extends TestCase
     #[Test]
     public function customStaticExtensionsAreAvailableForWindowsBuilds(): void
     {
-        $script = file_get_contents(dirname(__DIR__, 3) . '/build/static-php/patch-extension-config.php');
-        self::assertIsString($script);
+        $extensionConfigPatch = file_get_contents(dirname(__DIR__, 3) . '/build/static-php/patch-extension-config.php');
+        $registrationPatch = file_get_contents(dirname(__DIR__, 3) . '/build/static-php/register-yiipress-highlighter.php');
+        self::assertIsString($extensionConfigPatch);
+        self::assertIsString($registrationPatch);
 
-        self::assertStringContainsString("'highlighter'", $script);
-        self::assertStringContainsString("'md4c'", $script);
-        self::assertStringNotContainsString("'unix-only' => true", $script);
+        self::assertStringContainsString("'highlighter'", $extensionConfigPatch);
+        self::assertStringContainsString("'md4c'", $extensionConfigPatch);
+        self::assertStringNotContainsString("'unix-only' => true", $extensionConfigPatch);
+        self::assertStringContainsString("patch_point() !== 'after-exts-extract'", $registrationPatch);
+        self::assertStringContainsString('ARG_ENABLE("highlighter"', $registrationPatch);
+        self::assertStringContainsString('ARG_ENABLE("md4c"', $registrationPatch);
+        self::assertStringContainsString('EXTENSION("highlighter", "highlighter.c", false);', $registrationPatch);
+        self::assertStringContainsString('EXTENSION("md4c", "md4c.c", false);', $registrationPatch);
     }
 
     #[Test]

--- a/tests/Unit/Packaging/ConfigurationPackagingTest.php
+++ b/tests/Unit/Packaging/ConfigurationPackagingTest.php
@@ -339,7 +339,7 @@ final class ConfigurationPackagingTest extends TestCase
         self::assertIsString($windowsScript);
 
         self::assertStringContainsString('RUN rustup target add x86_64-unknown-linux-musl', $dockerfile);
-        self::assertStringNotContainsString(
+        self::assertStringContainsString(
             'RUN cd /opt/yiipress-highlighter && rustup target add x86_64-unknown-linux-musl',
             $dockerfile,
         );

--- a/tests/Unit/Packaging/ConfigurationPackagingTest.php
+++ b/tests/Unit/Packaging/ConfigurationPackagingTest.php
@@ -175,6 +175,8 @@ final class ConfigurationPackagingTest extends TestCase
         self::assertStringNotContainsString('if ($IsWindows)', $script);
         self::assertStringContainsString('Invoke-WebRequest -Uri $Url -OutFile $archive -TimeoutSec 300', $script);
         self::assertStringContainsString('finally {', $script);
+        self::assertStringContainsString('[string] $HighlighterVersion = "1.0.1"', $script);
+        self::assertStringNotContainsString('"dev-master"', $script);
         self::assertStringContainsString('--ignore-platform-req=ext-inotify', $script);
         self::assertStringContainsString('--ignore-platform-req=ext-pcntl', $script);
         self::assertStringContainsString('--ignore-platform-req=ext-posix', $script);
@@ -216,6 +218,8 @@ final class ConfigurationPackagingTest extends TestCase
         self::assertStringContainsString('type=semver,pattern={{version}}', $workflow);
         self::assertStringContainsString('cp release/yiipress-phar/yiipress.phar yiipress.phar', $workflow);
         self::assertStringContainsString('softprops/action-gh-release', $workflow);
+        self::assertDoesNotMatchRegularExpression('/uses:\s+[^@\s]+@v\d+/', $workflow);
+        self::assertStringNotContainsString('dtolnay/rust-toolchain@stable', $workflow);
     }
 
     #[Test]
@@ -351,6 +355,9 @@ final class ConfigurationPackagingTest extends TestCase
         self::assertStringContainsString('--mount=type=cache,target=/tmp/composer-cache', $dockerfile);
         self::assertStringContainsString('COMPOSER_CACHE_DIR=/tmp/composer-cache composer install', $dockerfile);
         self::assertStringContainsString('COMPOSER_CACHE_DIR=/tmp/composer-cache composer create-project', $dockerfile);
+        self::assertStringContainsString('ARG HIGHLIGHTER_VERSION=1.0.1', $dockerfile);
+        self::assertStringNotContainsString('yiipress/highlighter /build/highlighter-extension dev-master', $dockerfile);
+        self::assertStringNotContainsString('yiipress/highlighter /opt/yiipress-highlighter dev-master', $dockerfile);
         self::assertStringContainsString('--mount=type=cache,target=/root/.cargo/git', $dockerfile);
         self::assertStringContainsString('--mount=type=cache,target=/root/.cargo/registry', $dockerfile);
     }

--- a/tests/Unit/Packaging/ConfigurationPackagingTest.php
+++ b/tests/Unit/Packaging/ConfigurationPackagingTest.php
@@ -321,6 +321,8 @@ final class ConfigurationPackagingTest extends TestCase
         self::assertStringContainsString('ARG_ENABLE("md4c"', $registrationPatch);
         self::assertStringContainsString('EXTENSION("highlighter", "highlighter.c", false);', $registrationPatch);
         self::assertStringContainsString('EXTENSION("md4c", "md4c.c", false);', $registrationPatch);
+        self::assertStringContainsString('php_md4c.h', $registrationPatch);
+        self::assertStringContainsString('phpext_md4c_ptr', $registrationPatch);
     }
 
     #[Test]

--- a/tests/Unit/Packaging/ConfigurationPackagingTest.php
+++ b/tests/Unit/Packaging/ConfigurationPackagingTest.php
@@ -86,6 +86,79 @@ final class ConfigurationPackagingTest extends TestCase
         self::assertStringNotContainsString('sockets', $dockerfile);
         self::assertStringNotContainsString('php_sockets', $registrationPatch);
         self::assertStringNotContainsString('sockets_module_entry', $registrationPatch);
+        self::assertStringContainsString("DIRECTORY_SEPARATOR === '\\\\'", $registrationPatch);
+    }
+
+    #[Test]
+    public function makefileExposesAllPackageBuilds(): void
+    {
+        $makefile = file_get_contents(dirname(__DIR__, 3) . '/Makefile');
+        self::assertIsString($makefile);
+
+        self::assertStringContainsString('package-linux:', $makefile);
+        self::assertStringContainsString('--target package-linux-artifacts', $makefile);
+        self::assertStringContainsString('package-windows:', $makefile);
+        self::assertStringContainsString('build/package-windows.ps1', $makefile);
+        self::assertStringContainsString('PowerShell 7 (pwsh) is required for package-windows.', $makefile);
+        self::assertStringContainsString('package-distroless:', $makefile);
+        self::assertStringContainsString('--target distroless', $makefile);
+    }
+
+    #[Test]
+    public function distrolessImageCopiesOnlyStaticBinary(): void
+    {
+        $dockerfile = file_get_contents(dirname(__DIR__, 3) . '/docker/Dockerfile');
+        self::assertIsString($dockerfile);
+
+        $start = strpos($dockerfile, 'FROM gcr.io/distroless/static-debian12:nonroot AS distroless');
+        self::assertIsInt($start);
+        $stage = substr($dockerfile, $start);
+
+        self::assertStringContainsString('COPY --from=static-package /artifacts/yiipress /yiipress', $stage);
+        self::assertStringContainsString('ENTRYPOINT ["/yiipress"]', $stage);
+        self::assertStringNotContainsString('COPY --from=static-package /artifacts/yiipress.phar', $stage);
+        self::assertStringNotContainsString('/bin/sh', $stage);
+        self::assertStringNotContainsString('apt-get', $stage);
+    }
+
+    #[Test]
+    public function windowsPackageScriptBuildsPharAndExecutable(): void
+    {
+        $script = file_get_contents(dirname(__DIR__, 3) . '/build/package-windows.ps1');
+        self::assertIsString($script);
+
+        self::assertStringContainsString('build/package-phar.php', $script);
+        self::assertStringContainsString('yiipress.exe', $script);
+        self::assertStringContainsString('x86_64-pc-windows-msvc', $script);
+        self::assertStringContainsString('micro:combine', $script);
+        self::assertStringContainsString('$appPath = Join-Path $workPath "app"', $script);
+        self::assertStringContainsString('Push-Location $appPath', $script);
+        self::assertStringContainsString('function Test-NativeCommand', $script);
+        self::assertStringContainsString('foreach ($command in @("php", "composer", "tar", "rustup", "cargo"))', $script);
+        self::assertStringContainsString('foreach ($command in @("cl", "nmake"))', $script);
+        self::assertStringContainsString('--ignore-platform-req=ext-inotify', $script);
+        self::assertStringContainsString('--ignore-platform-req=ext-pcntl', $script);
+        self::assertStringContainsString('--ignore-platform-req=ext-posix', $script);
+    }
+
+    #[Test]
+    public function packageWorkflowPublishesNightlyAndReleaseBuilds(): void
+    {
+        $workflow = file_get_contents(dirname(__DIR__, 3) . '/.github/workflows/package-static.yml');
+        self::assertIsString($workflow);
+
+        self::assertStringContainsString('target: package-linux-artifacts', $workflow);
+        self::assertStringContainsString('Smoke test Linux binary', $workflow);
+        self::assertStringContainsString('./dist/linux-amd64/yiipress --help', $workflow);
+        self::assertStringContainsString('build/package-windows.ps1 -DistDir dist/windows-amd64', $workflow);
+        self::assertStringContainsString('Cache Windows package dependencies', $workflow);
+        self::assertStringContainsString('runtime\package-windows\yiipress-highlighter', $workflow);
+        self::assertStringContainsString('Smoke test Windows binary', $workflow);
+        self::assertStringContainsString('./dist/windows-amd64/yiipress.exe --help', $workflow);
+        self::assertStringContainsString('target: distroless', $workflow);
+        self::assertStringContainsString('type=raw,value=nightly', $workflow);
+        self::assertStringContainsString('type=semver,pattern={{version}}', $workflow);
+        self::assertStringContainsString('softprops/action-gh-release', $workflow);
     }
 
     #[Test]
@@ -194,6 +267,45 @@ final class ConfigurationPackagingTest extends TestCase
         self::assertStringContainsString('COPY themes /app/themes', $stage);
         self::assertStringContainsString('COPY build/package-phar.php build/PharArchiveFilter.php /app/build/', $stage);
         self::assertStringContainsString('COPY yii composer.json composer.lock /app/', $stage);
+    }
+
+    #[Test]
+    public function staticPackageInstallsRustTargetForHighlighterToolchain(): void
+    {
+        $dockerfile = file_get_contents(dirname(__DIR__, 3) . '/docker/Dockerfile');
+        $windowsScript = file_get_contents(dirname(__DIR__, 3) . '/build/package-windows.ps1');
+        self::assertIsString($dockerfile);
+        self::assertIsString($windowsScript);
+
+        self::assertStringContainsString(
+            'RUN cd /opt/yiipress-highlighter && rustup target add x86_64-unknown-linux-musl',
+            $dockerfile,
+        );
+        self::assertStringContainsString('Invoke-NativeCommand "rustup" @("target", "add", $env:CARGO_BUILD_TARGET)', $windowsScript);
+    }
+
+    #[Test]
+    public function dockerPackageBuildUsesComposerAndCargoCaches(): void
+    {
+        $dockerfile = file_get_contents(dirname(__DIR__, 3) . '/docker/Dockerfile');
+        self::assertIsString($dockerfile);
+
+        self::assertStringContainsString('--mount=type=cache,target=/tmp/composer-cache', $dockerfile);
+        self::assertStringContainsString('COMPOSER_CACHE_DIR=/tmp/composer-cache composer install', $dockerfile);
+        self::assertStringContainsString('COMPOSER_CACHE_DIR=/tmp/composer-cache composer create-project', $dockerfile);
+        self::assertStringContainsString('--mount=type=cache,target=/root/.cargo/git', $dockerfile);
+        self::assertStringContainsString('--mount=type=cache,target=/root/.cargo/registry', $dockerfile);
+    }
+
+    #[Test]
+    public function customStaticExtensionsAreAvailableForWindowsBuilds(): void
+    {
+        $script = file_get_contents(dirname(__DIR__, 3) . '/build/static-php/patch-extension-config.php');
+        self::assertIsString($script);
+
+        self::assertStringContainsString("'highlighter'", $script);
+        self::assertStringContainsString("'md4c'", $script);
+        self::assertStringNotContainsString("'unix-only' => true", $script);
     }
 
     #[Test]

--- a/tests/Unit/Packaging/ConfigurationPackagingTest.php
+++ b/tests/Unit/Packaging/ConfigurationPackagingTest.php
@@ -156,6 +156,7 @@ final class ConfigurationPackagingTest extends TestCase
         self::assertStringContainsString('Smoke test Windows binary', $workflow);
         self::assertStringContainsString('./dist/windows-amd64/yiipress.exe --help', $workflow);
         self::assertStringContainsString('target: distroless', $workflow);
+        self::assertStringContainsString("github.ref == 'refs/heads/master' || startsWith(github.ref, 'refs/tags/')", $workflow);
         self::assertStringContainsString('type=raw,value=nightly', $workflow);
         self::assertStringContainsString('type=semver,pattern={{version}}', $workflow);
         self::assertStringContainsString('softprops/action-gh-release', $workflow);

--- a/tests/Unit/Packaging/ConfigurationPackagingTest.php
+++ b/tests/Unit/Packaging/ConfigurationPackagingTest.php
@@ -139,6 +139,9 @@ final class ConfigurationPackagingTest extends TestCase
         self::assertStringContainsString('--ignore-platform-req=ext-inotify', $script);
         self::assertStringContainsString('--ignore-platform-req=ext-pcntl', $script);
         self::assertStringContainsString('--ignore-platform-req=ext-posix', $script);
+        self::assertStringContainsString('function Write-LogTail', $script);
+        self::assertStringContainsString('log/spc.output.log', $script);
+        self::assertStringContainsString('log/spc.shell.log', $script);
     }
 
     #[Test]


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * New distinct packaging targets for PHAR, Linux, Windows, and distroless images; Windows executable builds and distroless images published as artifacts/releases
  * Nightly and tag-driven release packing/publishing of platform artifacts

* **Chores**
  * CI workflow concurrency and artifact/job split; improved build caching and packaging flow
  * Makefile targets and packaging commands refined

* **Documentation**
  * Deployment docs and common commands updated with new packaging targets and behaviors

* **Tests**
  * Added packaging and workflow validation tests covering platform artifacts and build steps

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/yiipress/engine/pull/33?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->