### PR TITLE
Use yiisoft/files for support filesystem tasks

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -60,6 +60,7 @@
         "yiisoft/definitions": "^3.4.1",
         "yiisoft/di": "^1.4.1",
         "yiisoft/error-handler": "^4.3.2",
+        "yiisoft/files": "^2.1",
         "yiisoft/log": "^2.2.1",
         "yiisoft/middleware-dispatcher": "^5.4",
         "yiisoft/router": "^4.0.2",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "699ce3e3d0a838017a426d5ee3b2e04b",
+    "content-hash": "1fb1d16af938f2d891fd30746b21e859",
     "packages": [
         {
             "name": "alexkart/curl-builder",
@@ -2430,6 +2430,74 @@
                 }
             ],
             "time": "2022-10-27T12:02:21+00:00"
+        },
+        {
+            "name": "yiisoft/files",
+            "version": "2.1.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/yiisoft/files.git",
+                "reference": "465650fd9e4295669f42ab7e9fec2386700540a7"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/yiisoft/files/zipball/465650fd9e4295669f42ab7e9fec2386700540a7",
+                "reference": "465650fd9e4295669f42ab7e9fec2386700540a7",
+                "shasum": ""
+            },
+            "require": {
+                "php": "8.0 - 8.5",
+                "yiisoft/strings": "^2.0"
+            },
+            "require-dev": {
+                "bamarni/composer-bin-plugin": "^1.8.3",
+                "ext-zlib": "*",
+                "maglnet/composer-require-checker": "^4.4",
+                "phpunit/phpunit": "^9.6.22",
+                "rector/rector": "^2.0.10",
+                "spatie/phpunit-watcher": "^1.23.6"
+            },
+            "type": "library",
+            "extra": {
+                "bamarni-bin": {
+                    "bin-links": true,
+                    "forward-command": true,
+                    "target-directory": "tools"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Yiisoft\\Files\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "description": "Helper to manage files and directories",
+            "homepage": "https://www.yiiframework.com/",
+            "keywords": [
+                "files"
+            ],
+            "support": {
+                "chat": "https://t.me/yii3en",
+                "forum": "https://www.yiiframework.com/forum/",
+                "irc": "ircs://irc.libera.chat:6697/yii",
+                "issues": "https://github.com/yiisoft/files/issues?state=open",
+                "source": "https://github.com/yiisoft/files",
+                "wiki": "https://www.yiiframework.com/wiki/"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sponsors/yiisoft",
+                    "type": "github"
+                },
+                {
+                    "url": "https://opencollective.com/yiisoft",
+                    "type": "opencollective"
+                }
+            ],
+            "time": "2025-12-01T06:30:27+00:00"
         },
         {
             "name": "yiisoft/friendly-exception",

--- a/docs/engine.md
+++ b/docs/engine.md
@@ -146,6 +146,8 @@ Writers turn page objects and indexed aggregate data into files:
 
 Entry pages and standalone pages can be rendered and written in parallel because each page writes to its own destination path.
 
+Scaffolding commands, cleanup commands, and importer media copying use `yiisoft/files` helpers for consistent filesystem errors and cross-platform directory removal. Build-path directory setup, page writes, output preparation, and bulk asset writer loops keep direct filesystem operations on their hot paths unless benchmarks show a helper abstraction is neutral or faster.
+
 ## Performance Model
 
 Performance is handled by doing less work, keeping expensive work native, and letting PHP orchestrate the pipeline:

--- a/src/Console/CleanCommand.php
+++ b/src/Console/CleanCommand.php
@@ -5,15 +5,12 @@ declare(strict_types=1);
 namespace YiiPress\Console;
 
 use YiiPress\RuntimePaths;
-use FilesystemIterator;
-use RecursiveDirectoryIterator;
-use RecursiveIteratorIterator;
-use SplFileInfo;
 use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
+use Yiisoft\Files\FileHelper;
 use Yiisoft\Yii\Console\ExitCode;
 
 use function str_starts_with;
@@ -76,21 +73,7 @@ final class CleanCommand extends Command
             return false;
         }
 
-        $iterator = new RecursiveIteratorIterator(
-            new RecursiveDirectoryIterator($path, FilesystemIterator::SKIP_DOTS),
-            RecursiveIteratorIterator::CHILD_FIRST,
-        );
-
-        foreach ($iterator as $item) {
-            /** @var SplFileInfo $item */
-            if ($item->isDir()) {
-                rmdir($item->getPathname());
-            } else {
-                unlink($item->getPathname());
-            }
-        }
-
-        rmdir($path);
+        FileHelper::removeDirectory($path);
 
         return true;
     }

--- a/src/Console/InitCommand.php
+++ b/src/Console/InitCommand.php
@@ -10,14 +10,13 @@ use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
+use Yiisoft\Files\FileHelper;
 use Yiisoft\Yii\Console\ExitCode;
 
 use function array_keys;
 use function dirname;
 use function file_exists;
 use function file_put_contents;
-use function is_dir;
-use function mkdir;
 use function sprintf;
 use function str_starts_with;
 
@@ -65,10 +64,7 @@ final class InitCommand extends Command
         }
 
         foreach ($files as $filePath => $contents) {
-            $directory = dirname($filePath);
-            if (!is_dir($directory) && !mkdir($directory, 0o755, true) && !is_dir($directory)) {
-                throw new RuntimeException(sprintf('Directory "%s" was not created', $directory));
-            }
+            FileHelper::ensureDirectory(dirname($filePath), 0o755);
 
             if (file_put_contents($filePath, $contents) === false) {
                 throw new RuntimeException(sprintf('File "%s" was not written', $filePath));

--- a/src/Console/NewCommand.php
+++ b/src/Console/NewCommand.php
@@ -6,13 +6,13 @@ namespace YiiPress\Console;
 
 use YiiPress\Content\Parser\CollectionConfigParser;
 use YiiPress\Content\Parser\SiteConfigParser;
-use RuntimeException;
 use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
+use Yiisoft\Files\FileHelper;
 use Yiisoft\Yii\Console\ExitCode;
 
 use function dirname;
@@ -127,10 +127,7 @@ final class NewCommand extends Command
         }
         $frontMatter .= "---\n\n";
 
-        $dir = dirname($filePath);
-        if (!is_dir($dir) && !mkdir($dir, 0o755, true) && !is_dir($dir)) {
-            throw new RuntimeException(sprintf('Directory "%s" was not created', $dir));
-        }
+        FileHelper::ensureDirectory(dirname($filePath), 0o755);
 
         file_put_contents($filePath, $frontMatter);
 

--- a/src/Import/Telegram/TelegramContentImporter.php
+++ b/src/Import/Telegram/TelegramContentImporter.php
@@ -7,7 +7,7 @@ namespace YiiPress\Import\Telegram;
 use YiiPress\Import\ContentImporterInterface;
 use YiiPress\Import\ImporterOption;
 use YiiPress\Import\ImportResult;
-use RuntimeException;
+use Yiisoft\Files\FileHelper;
 
 use function count;
 use function is_array;
@@ -91,9 +91,7 @@ final class TelegramContentImporter implements ContentImporterInterface
 
         $collectionDir = $targetDirectory . '/' . $collection;
 
-        if (!is_dir($collectionDir) && !mkdir($collectionDir, 0o755, true) && !is_dir($collectionDir)) {
-            throw new RuntimeException(sprintf('Directory "%s" was not created', $collectionDir));
-        }
+        FileHelper::ensureDirectory($collectionDir, 0o755);
 
         $assetsDir = $collectionDir . '/assets';
 
@@ -223,22 +221,18 @@ final class TelegramContentImporter implements ContentImporterInterface
 
         $realSourceDir = realpath($sourceDirectory);
         $realSourcePath = realpath($sourcePath);
-        if (
-            $realSourceDir === false
-            || $realSourcePath === false
-            || !str_starts_with($realSourcePath, $realSourceDir . DIRECTORY_SEPARATOR)
-        ) {
+        if ($realSourceDir === false || $realSourcePath === false) {
             return '';
         }
 
-        if (!is_dir($assetsDir) && !mkdir($assetsDir, 0o755, true) && !is_dir($assetsDir)) {
-            throw new RuntimeException(sprintf('Directory "%s" was not created', $assetsDir));
+        if (!str_starts_with($realSourcePath, $realSourceDir . DIRECTORY_SEPARATOR)) {
+            return '';
         }
 
         $info = pathinfo($relativePath);
         $targetPath = $assetsDir . '/' . ($info['filename'] ?? 'file') . '.' . ($info['extension'] ?? '');
 
-        copy($realSourcePath, $targetPath);
+        FileHelper::copyFile($realSourcePath, $targetPath, ['dirMode' => 0o755]);
 
         return $targetPath;
     }


### PR DESCRIPTION
## Summary
- add yiisoft/files as a direct dependency
- use FileHelper for cleanup, scaffolding directory creation, and Telegram media copying
- document that build hot paths keep direct filesystem operations unless benchmarks prove helper usage is neutral or faster

## Performance
SmallSiteBuildBench was compared against a fresh master worktree after avoiding FileHelper in build hot paths:

| Subject | master | branch |
|---|---:|---:|
| Full rebuild sequential | 3.324s | 3.237s |
| Full rebuild 4 workers | 2.399s | 2.390s |
| No-write sequential | 1.677s | 1.673s |
| No-write 4 workers | 1.266s | 1.276s |
| Incremental no changes | 222.601ms | 222.786ms |
| Incremental single changed entry | 221.036ms | 224.298ms |

## Tests
- make test
- BENCH_FILTER=SmallSiteBuildBench make bench

## Notes
- make composer-dependency-analyser still reports existing unrelated findings: YiiPress\Build\PharArchiveFilter, evenement/evenement, and react/stream.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved filesystem operations with enhanced cross-platform compatibility.
  * Added dependency for consistent file and directory management utilities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->