### PR TITLE
Use yiisoft/strings for new command slugs

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -65,6 +65,7 @@
         "yiisoft/middleware-dispatcher": "^5.4",
         "yiisoft/router": "^4.0.2",
         "yiisoft/router-fastroute": "^4.0.3",
+        "yiisoft/strings": "^2.7",
         "yiisoft/yii-console": "^2.4.2",
         "yiisoft/yii-event": "^2.2",
         "yiisoft/yii-http": "^1.1.1",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "1fb1d16af938f2d891fd30746b21e859",
+    "content-hash": "656f9ea792f6815d4fe2a08950d82b4a",
     "packages": [
         {
             "name": "alexkart/curl-builder",

--- a/docs/engine.md
+++ b/docs/engine.md
@@ -85,6 +85,8 @@ The index is built once per build and then treated as read-only.
 
 Entries store raw Markdown, not rendered HTML. The index keeps references rather than copies; for example, taxonomy terms reference entry objects instead of duplicating entry data.
 
+The `yiipress new` command normalizes generated entry filenames through `Slugifier`, which keeps Unicode letters in output paths and uses `yiisoft/strings` for UTF-8 casing.
+
 ## Rendering
 
 Rendering converts indexed entries and pages into final HTML:

--- a/src/Console/NewCommand.php
+++ b/src/Console/NewCommand.php
@@ -6,6 +6,7 @@ namespace YiiPress\Console;
 
 use YiiPress\Content\Parser\CollectionConfigParser;
 use YiiPress\Content\Parser\SiteConfigParser;
+use YiiPress\Content\Slugifier;
 use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputArgument;
@@ -163,10 +164,7 @@ final class NewCommand extends Command
 
     private function slugify(string $title): string
     {
-        $slug = mb_strtolower($title);
-        $slug = preg_replace('/[^\p{L}\p{N}\s-]/u', '', $slug);
-        $slug = preg_replace('/[\s-]+/', '-', (string) $slug);
-        return trim((string) $slug, '-');
+        return Slugifier::slugify($title);
     }
 
     private function yamlEscape(string $value): string

--- a/src/Content/Slugifier.php
+++ b/src/Content/Slugifier.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types=1);
+
+namespace YiiPress\Content;
+
+use Yiisoft\Strings\StringHelper;
+
+final class Slugifier
+{
+    public static function slugify(string $title, ?int $maxLength = null, string $fallback = ''): string
+    {
+        $slug = StringHelper::lowercase($title);
+        $slug = preg_replace('/[^\p{L}\p{N}\s-]/u', '', $slug);
+        $slug = preg_replace('/[\s-]+/', '-', (string) $slug);
+        $slug = trim((string) $slug, '-');
+
+        if ($maxLength !== null && StringHelper::length($slug) > $maxLength) {
+            $slug = StringHelper::substring($slug, 0, $maxLength);
+            $slug = rtrim($slug, '-');
+        }
+
+        return $slug !== '' ? $slug : $fallback;
+    }
+}

--- a/tests/Unit/Content/SlugifierTest.php
+++ b/tests/Unit/Content/SlugifierTest.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+namespace YiiPress\Tests\Unit\Content;
+
+use YiiPress\Content\Slugifier;
+use PHPUnit\Framework\TestCase;
+
+use function PHPUnit\Framework\assertSame;
+
+final class SlugifierTest extends TestCase
+{
+    public function testSlugifiesAsciiTitle(): void
+    {
+        assertSame('hello-from-telegram-channel', Slugifier::slugify('Hello from Telegram channel'));
+    }
+
+    public function testPreservesUnicodeLetters(): void
+    {
+        assertSame('привет-мир', Slugifier::slugify('Привет, мир!'));
+    }
+
+    public function testAppliesMaxLengthWithoutTrailingSeparator(): void
+    {
+        assertSame('very-long', Slugifier::slugify('Very long title', maxLength: 10));
+    }
+
+    public function testUsesFallbackForEmptySlug(): void
+    {
+        assertSame('post', Slugifier::slugify('!!!', fallback: 'post'));
+    }
+}


### PR DESCRIPTION
## Summary
- add yiisoft/strings as a direct dependency
- add a shared Slugifier for Unicode-preserving filename slugs
- use Slugifier in the yiipress new command
- document the new-command slug boundary in engine docs

## Performance
Benchmarked before and after on this branch. I also tried using Slugifier in the Telegram importer path, but TelegramImporterBench showed overhead on the small-message case, so that path was restored to its existing implementation.

| Benchmark | Before | After |
|---|---:|---:|
| Full rebuild sequential | 3.275s | 3.263s |
| Full rebuild 4 workers | 2.358s | 2.412s |
| No-write sequential | 1.680s | 1.679s |
| No-write 4 workers | 1.287s | 1.297s |
| Incremental no changes | 219.174ms | 224.434ms |
| Incremental single changed | 221.756ms | 223.922ms |
| Telegram import 100 | 489.597us | 492.726us |
| Telegram import 1000 | 6.830ms | 6.993ms |

## Tests
- make test
- BENCH_FILTER=SmallSiteBuildBench make bench
- BENCH_FILTER=TelegramImporterBench make bench

## Notes
- make composer-dependency-analyser still reports existing unrelated findings: YiiPress\Build\PharArchiveFilter, evenement/evenement, and react/stream.
