### PR TITLE
Use yiisoft/html for navigation escaping

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -61,6 +61,7 @@
         "yiisoft/di": "^1.4.1",
         "yiisoft/error-handler": "^4.3.2",
         "yiisoft/files": "^2.1",
+        "yiisoft/html": "^4.1",
         "yiisoft/log": "^2.2.1",
         "yiisoft/middleware-dispatcher": "^5.4",
         "yiisoft/router": "^4.0.2",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "1fb1d16af938f2d891fd30746b21e859",
+    "content-hash": "a40486b9137079b4f0efcbb2a512d0a3",
     "packages": [
         {
             "name": "alexkart/curl-builder",
@@ -2568,6 +2568,69 @@
             "time": "2025-11-28T14:51:44+00:00"
         },
         {
+            "name": "yiisoft/html",
+            "version": "4.1.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/yiisoft/html.git",
+                "reference": "315a6582d533d6ab73484c8f982beb9131675909"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/yiisoft/html/zipball/315a6582d533d6ab73484c8f982beb9131675909",
+                "reference": "315a6582d533d6ab73484c8f982beb9131675909",
+                "shasum": ""
+            },
+            "require": {
+                "php": "8.1 - 8.5",
+                "yiisoft/arrays": "^2.0 || ^3.0",
+                "yiisoft/json": "^1.0"
+            },
+            "require-dev": {
+                "friendsofphp/php-cs-fixer": "^3.90",
+                "infection/infection": "^0.27.11 || ^0.32",
+                "maglnet/composer-require-checker": "^4.7.1",
+                "phpunit/phpunit": "^10.5.46",
+                "rector/rector": "^2.0.17",
+                "spatie/phpunit-watcher": "^1.24",
+                "vimeo/psalm": "^5.26.1 || ^6.12"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Yiisoft\\Html\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "description": "Handy library to generate HTML",
+            "homepage": "https://www.yiiframework.com/",
+            "keywords": [
+                "html"
+            ],
+            "support": {
+                "chat": "https://t.me/yii3en",
+                "forum": "https://forum.yiiframework.com/",
+                "irc": "ircs://irc.libera.chat:6697/yii",
+                "issues": "https://github.com/yiisoft/html/issues?state=open",
+                "source": "https://github.com/yiisoft/html",
+                "wiki": "https://www.yiiframework.com/wiki/"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sponsors/yiisoft",
+                    "type": "github"
+                },
+                {
+                    "url": "https://opencollective.com/yiisoft",
+                    "type": "opencollective"
+                }
+            ],
+            "time": "2026-05-19T07:13:29+00:00"
+        },
+        {
             "name": "yiisoft/http",
             "version": "1.3.0",
             "source": {
@@ -2714,6 +2777,74 @@
                 }
             ],
             "time": "2025-12-01T11:14:17+00:00"
+        },
+        {
+            "name": "yiisoft/json",
+            "version": "1.1.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/yiisoft/json.git",
+                "reference": "6af88ed2c653f4b6cbe3ea9114e4aebc5a463c80"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/yiisoft/json/zipball/6af88ed2c653f4b6cbe3ea9114e4aebc5a463c80",
+                "reference": "6af88ed2c653f4b6cbe3ea9114e4aebc5a463c80",
+                "shasum": ""
+            },
+            "require": {
+                "ext-json": "*",
+                "ext-simplexml": "*",
+                "php": "~7.4.0 || 8.0 - 8.5"
+            },
+            "require-dev": {
+                "bamarni/composer-bin-plugin": "^1.8.2",
+                "maglnet/composer-require-checker": "^3.8 || ^4.2",
+                "phpunit/phpunit": "^9.6.22",
+                "rector/rector": "^2.0.8",
+                "spatie/phpunit-watcher": "^1.23.6"
+            },
+            "type": "library",
+            "extra": {
+                "bamarni-bin": {
+                    "bin-links": true,
+                    "forward-command": true,
+                    "target-directory": "tools"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Yiisoft\\Json\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "description": "Yii JSON encoding and decoding",
+            "homepage": "https://www.yiiframework.com/",
+            "keywords": [
+                "json"
+            ],
+            "support": {
+                "chat": "https://t.me/yii3en",
+                "forum": "https://www.yiiframework.com/forum/",
+                "irc": "ircs://irc.libera.chat:6697/yii",
+                "issues": "https://github.com/yiisoft/json/issues?state=open",
+                "source": "https://github.com/yiisoft/json",
+                "wiki": "https://www.yiiframework.com/wiki/"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sponsors/yiisoft",
+                    "type": "github"
+                },
+                {
+                    "url": "https://opencollective.com/yiisoft",
+                    "type": "opencollective"
+                }
+            ],
+            "time": "2025-11-21T19:39:36+00:00"
         },
         {
             "name": "yiisoft/log",

--- a/docs/content.md
+++ b/docs/content.md
@@ -321,6 +321,8 @@ Templates receive a `$nav` variable (a `Navigation` object). Use `NavigationRend
 
 This renders a `<nav><ul><li>` structure with nested lists for children. You can render as many different menus as needed — just use the menu name from `navigation.yaml`.
 
+The renderer escapes menu labels and generated attributes with HTML5-compatible Yii helpers, so navigation titles and URLs can contain special characters without breaking markup.
+
 ## Assets
 
 Assets are stored at two levels:

--- a/docs/templates.md
+++ b/docs/templates.md
@@ -297,6 +297,8 @@ Use `NavigationRenderer` for HTML output:
 
 This renders a `<nav><ul><li>` structure with nested lists for children. Menu names correspond to top-level keys in `content/navigation.yaml`.
 
+`NavigationRenderer` escapes menu labels and generated attributes with HTML5-compatible Yii helpers, so raw menu data can contain characters such as `&`, `<`, `>`, and quotes.
+
 Pass the optional class and current URL arguments when rendering sidebars that need active item styling:
 
 ```php

--- a/src/Render/NavigationRenderer.php
+++ b/src/Render/NavigationRenderer.php
@@ -7,6 +7,7 @@ namespace YiiPress\Render;
 use YiiPress\Build\RelativePathHelper;
 use YiiPress\Content\Model\Navigation;
 use YiiPress\Content\Model\NavigationItem;
+use Yiisoft\Html\Html;
 
 final class NavigationRenderer
 {
@@ -26,7 +27,7 @@ final class NavigationRenderer
 
         [$html] = self::renderItems($items, $rootPath, $language, $defaultLanguage, $currentUrl);
         $classAttribute = $class !== ''
-            ? ' class="' . htmlspecialchars($class, ENT_QUOTES | ENT_SUBSTITUTE, 'UTF-8') . '"'
+            ? ' class="' . Html::encodeAttribute($class) . '"'
             : '';
 
         return '<nav' . $classAttribute . '>' . $html . '</nav>';
@@ -69,7 +70,7 @@ final class NavigationRenderer
                 $classes[] = 'is-active-ancestor';
             }
             $classAttribute = $classes !== []
-                ? ' class="' . htmlspecialchars(implode(' ', $classes), ENT_QUOTES | ENT_SUBSTITUTE, 'UTF-8') . '"'
+                ? ' class="' . Html::encodeAttribute(implode(' ', $classes)) . '"'
                 : '';
 
             $html .= '<li' . $classAttribute . '>';
@@ -84,10 +85,10 @@ final class NavigationRenderer
 
             if ($item->url === '') {
                 $html .= '<span class="nav-section-title"' . $attributes . '>'
-                    . htmlspecialchars($title) . '</span>';
+                    . Html::encode($title) . '</span>';
             } else {
-                $html .= '<a href="' . htmlspecialchars($url) . '"' . $attributes . '>'
-                    . htmlspecialchars($title) . '</a>';
+                $html .= '<a href="' . Html::encodeAttribute($url) . '"' . $attributes . '>'
+                    . Html::encode($title) . '</a>';
             }
             $html .= $childrenHtml;
             $html .= '</li>';
@@ -154,12 +155,12 @@ final class NavigationRenderer
         }
 
         return ' data-ui-menu-title="'
-            . htmlspecialchars((string) json_encode(
+            . Html::encodeAttribute((string) json_encode(
                 $item->titles,
                 JSON_THROW_ON_ERROR | JSON_UNESCAPED_UNICODE | JSON_HEX_TAG | JSON_HEX_AMP | JSON_HEX_APOS | JSON_HEX_QUOT,
-            ), ENT_QUOTES | ENT_SUBSTITUTE, 'UTF-8')
+            ))
             . '" data-ui-menu-default="'
-            . htmlspecialchars($item->title, ENT_QUOTES | ENT_SUBSTITUTE, 'UTF-8')
+            . Html::encodeAttribute($item->title)
             . '"';
     }
 }

--- a/tests/Unit/Render/NavigationRendererTest.php
+++ b/tests/Unit/Render/NavigationRendererTest.php
@@ -104,6 +104,23 @@ final class NavigationRendererTest extends TestCase
         assertStringContainsString('/a&amp;b/', $html);
     }
 
+    public function testRenderEscapesTextAndAttributesWithHtml5Rules(): void
+    {
+        $navigation = new Navigation(menus: [
+            'main' => [
+                new NavigationItem(title: 'Docs "Intro" & <Start>', url: '/docs/<intro>/?q=a&b="c"', children: []),
+            ],
+        ]);
+
+        $html = NavigationRenderer::render($navigation, 'main', './', 'en', 'en', 'docs"sidebar');
+
+        assertStringContainsString('<nav class="docs&quot;sidebar">', $html);
+        assertStringContainsString(
+            '<a href="./docs/&lt;intro&gt;/?q=a&amp;b=&quot;c&quot;">Docs "Intro" &amp; &lt;Start&gt;</a>',
+            $html,
+        );
+    }
+
     public function testRenderMarksCurrentAndAncestorItems(): void
     {
         $navigation = new Navigation(menus: [


### PR DESCRIPTION
## Summary
- add yiisoft/html and use its HTML5-compatible escaping helpers in NavigationRenderer
- keep navigation rendering string-based to avoid tag-builder overhead in the hot path
- document navigation escaping behavior and add focused escaping coverage

## Benchmarks
Before was measured on master d62f527. After was measured on this branch.

- NavigationRendererBench: 3.366μs -> 3.190μs
- SmallSiteBuildBench:
  - full rebuild sequential: 3.285s -> 3.296s
  - full rebuild 4 workers: 2.380s -> 2.377s
  - render no-write sequential: 1.700s -> 1.682s
  - render no-write 4 workers: 1.266s -> 1.311s
  - incremental no changes: 222.012ms -> 224.505ms
  - incremental changed entry: 222.720ms -> 225.347ms

The renderer hot path improves; full build numbers are effectively flat with small noisy deltas in incremental cases.

## Verification
- make test tests/Unit/Render/NavigationRendererTest.php
- make test
- make build-docs
- git diff --check

`make composer-dependency-analyser` was also run. It still fails on existing findings only: unknown `YiiPress\Build\PharArchiveFilter`, plus shadow dependencies `evenement/evenement` and `react/stream`. No new yiisoft/html or yiisoft/json issue was reported.
