### PR TITLE
Optimize docs build hot paths

### DIFF
--- a/benchmarks/NavigationRendererBench.php
+++ b/benchmarks/NavigationRendererBench.php
@@ -43,4 +43,12 @@ final class NavigationRendererBench
     {
         NavigationRenderer::render($this->navigation, 'main', './', 'ru', 'en');
     }
+
+    #[Revs(1000)]
+    #[Iterations(3)]
+    #[Warmup(1)]
+    public function benchRenderLocalizedNavigationWithCurrentUrl(): void
+    {
+        NavigationRenderer::render($this->navigation, 'main', './', 'ru', 'en', '', '/docs/getting-started/');
+    }
 }

--- a/benchmarks/TagLinkProcessorBench.php
+++ b/benchmarks/TagLinkProcessorBench.php
@@ -1,0 +1,71 @@
+<?php
+
+declare(strict_types=1);
+
+namespace YiiPress\Benchmarks;
+
+use YiiPress\Content\Model\Entry;
+use YiiPress\Processor\TagLinkProcessor;
+use DateTimeImmutable;
+use PhpBench\Attributes\Iterations;
+use PhpBench\Attributes\Revs;
+use PhpBench\Attributes\Warmup;
+
+final class TagLinkProcessorBench
+{
+    private TagLinkProcessor $processor;
+    private Entry $entry;
+    private string $hashNoiseHtml;
+    private string $hashtagHtml;
+
+    public function __construct()
+    {
+        $this->processor = new TagLinkProcessor('/');
+        $this->entry = new Entry(
+            filePath: __FILE__,
+            collection: 'bench',
+            slug: 'tag-link',
+            title: 'Tag Link',
+            date: new DateTimeImmutable('2024-01-01'),
+            draft: false,
+            tags: [],
+            categories: [],
+            authors: [],
+            summary: '',
+            permalink: '',
+            layout: '',
+            theme: '',
+            weight: 0,
+            language: '',
+            redirectTo: '',
+            extra: [],
+            bodyOffset: 0,
+            bodyLength: 0,
+        );
+        $this->hashNoiseHtml = str_repeat(
+            '<p><a href="/docs/#section">Docs</a> <span style="color: #fff">Text</span></p>'
+            . '<pre><span style="color:#323232;">#code</span></pre>',
+            20,
+        );
+        $this->hashtagHtml = str_repeat(
+            '<p>Follow #yii3 and #php for release notes.</p>',
+            20,
+        );
+    }
+
+    #[Revs(1000)]
+    #[Iterations(3)]
+    #[Warmup(1)]
+    public function benchHashNoiseWithoutConvertibleTags(): void
+    {
+        $this->processor->process($this->hashNoiseHtml, $this->entry);
+    }
+
+    #[Revs(1000)]
+    #[Iterations(3)]
+    #[Warmup(1)]
+    public function benchConvertibleHashtags(): void
+    {
+        $this->processor->process($this->hashtagHtml, $this->entry);
+    }
+}

--- a/composer.json
+++ b/composer.json
@@ -61,6 +61,7 @@
         "yiisoft/di": "^1.4.1",
         "yiisoft/error-handler": "^4.3.2",
         "yiisoft/files": "^2.1",
+        "yiisoft/html": "^4.1",
         "yiisoft/log": "^2.2.1",
         "yiisoft/middleware-dispatcher": "^5.4",
         "yiisoft/router": "^4.0.2",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "656f9ea792f6815d4fe2a08950d82b4a",
+    "content-hash": "eed032f4be611e0d4de06a241b7722b6",
     "packages": [
         {
             "name": "alexkart/curl-builder",
@@ -2568,6 +2568,69 @@
             "time": "2025-11-28T14:51:44+00:00"
         },
         {
+            "name": "yiisoft/html",
+            "version": "4.1.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/yiisoft/html.git",
+                "reference": "315a6582d533d6ab73484c8f982beb9131675909"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/yiisoft/html/zipball/315a6582d533d6ab73484c8f982beb9131675909",
+                "reference": "315a6582d533d6ab73484c8f982beb9131675909",
+                "shasum": ""
+            },
+            "require": {
+                "php": "8.1 - 8.5",
+                "yiisoft/arrays": "^2.0 || ^3.0",
+                "yiisoft/json": "^1.0"
+            },
+            "require-dev": {
+                "friendsofphp/php-cs-fixer": "^3.90",
+                "infection/infection": "^0.27.11 || ^0.32",
+                "maglnet/composer-require-checker": "^4.7.1",
+                "phpunit/phpunit": "^10.5.46",
+                "rector/rector": "^2.0.17",
+                "spatie/phpunit-watcher": "^1.24",
+                "vimeo/psalm": "^5.26.1 || ^6.12"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Yiisoft\\Html\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "description": "Handy library to generate HTML",
+            "homepage": "https://www.yiiframework.com/",
+            "keywords": [
+                "html"
+            ],
+            "support": {
+                "chat": "https://t.me/yii3en",
+                "forum": "https://forum.yiiframework.com/",
+                "irc": "ircs://irc.libera.chat:6697/yii",
+                "issues": "https://github.com/yiisoft/html/issues?state=open",
+                "source": "https://github.com/yiisoft/html",
+                "wiki": "https://www.yiiframework.com/wiki/"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sponsors/yiisoft",
+                    "type": "github"
+                },
+                {
+                    "url": "https://opencollective.com/yiisoft",
+                    "type": "opencollective"
+                }
+            ],
+            "time": "2026-05-19T07:13:29+00:00"
+        },
+        {
             "name": "yiisoft/http",
             "version": "1.3.0",
             "source": {
@@ -2714,6 +2777,74 @@
                 }
             ],
             "time": "2025-12-01T11:14:17+00:00"
+        },
+        {
+            "name": "yiisoft/json",
+            "version": "1.1.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/yiisoft/json.git",
+                "reference": "6af88ed2c653f4b6cbe3ea9114e4aebc5a463c80"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/yiisoft/json/zipball/6af88ed2c653f4b6cbe3ea9114e4aebc5a463c80",
+                "reference": "6af88ed2c653f4b6cbe3ea9114e4aebc5a463c80",
+                "shasum": ""
+            },
+            "require": {
+                "ext-json": "*",
+                "ext-simplexml": "*",
+                "php": "~7.4.0 || 8.0 - 8.5"
+            },
+            "require-dev": {
+                "bamarni/composer-bin-plugin": "^1.8.2",
+                "maglnet/composer-require-checker": "^3.8 || ^4.2",
+                "phpunit/phpunit": "^9.6.22",
+                "rector/rector": "^2.0.8",
+                "spatie/phpunit-watcher": "^1.23.6"
+            },
+            "type": "library",
+            "extra": {
+                "bamarni-bin": {
+                    "bin-links": true,
+                    "forward-command": true,
+                    "target-directory": "tools"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Yiisoft\\Json\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "description": "Yii JSON encoding and decoding",
+            "homepage": "https://www.yiiframework.com/",
+            "keywords": [
+                "json"
+            ],
+            "support": {
+                "chat": "https://t.me/yii3en",
+                "forum": "https://www.yiiframework.com/forum/",
+                "irc": "ircs://irc.libera.chat:6697/yii",
+                "issues": "https://github.com/yiisoft/json/issues?state=open",
+                "source": "https://github.com/yiisoft/json",
+                "wiki": "https://www.yiiframework.com/wiki/"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sponsors/yiisoft",
+                    "type": "github"
+                },
+                {
+                    "url": "https://opencollective.com/yiisoft",
+                    "type": "opencollective"
+                }
+            ],
+            "time": "2025-11-21T19:39:36+00:00"
         },
         {
             "name": "yiisoft/log",

--- a/docs/content.md
+++ b/docs/content.md
@@ -321,6 +321,8 @@ Templates receive a `$nav` variable (a `Navigation` object). Use `NavigationRend
 
 This renders a `<nav><ul><li>` structure with nested lists for children. You can render as many different menus as needed — just use the menu name from `navigation.yaml`.
 
+The renderer escapes menu labels and generated attributes with HTML5-compatible Yii helpers, so navigation titles and URLs can contain special characters without breaking markup.
+
 ## Assets
 
 Assets are stored at two levels:

--- a/docs/templates.md
+++ b/docs/templates.md
@@ -297,6 +297,8 @@ Use `NavigationRenderer` for HTML output:
 
 This renders a `<nav><ul><li>` structure with nested lists for children. Menu names correspond to top-level keys in `content/navigation.yaml`.
 
+`NavigationRenderer` escapes menu labels and generated attributes with HTML5-compatible Yii helpers, so raw menu data can contain characters such as `&`, `<`, `>`, and quotes.
+
 Pass the optional class and current URL arguments when rendering sidebars that need active item styling:
 
 ```php

--- a/src/Processor/TagLinkProcessor.php
+++ b/src/Processor/TagLinkProcessor.php
@@ -6,10 +6,21 @@ namespace YiiPress\Processor;
 
 use YiiPress\Content\Model\Entry;
 
+use function htmlspecialchars;
+use function mb_strtolower;
+use function preg_match;
+use function preg_replace;
+use function preg_replace_callback;
+use function preg_split;
 use function str_contains;
+use function strip_tags;
 
 final readonly class TagLinkProcessor implements ContentProcessorInterface
 {
+    private const HASHTAG_PATTERN = '/(?<!\w)#(\w+(?:-\w+)*)(?![\w-])/';
+    private const PROTECTED_BLOCK_PATTERN = '/<pre[^>]*>.*?<\/pre>|<code[^>]*>.*?<\/code>|<a[^>]*>.*?<\/a>/is';
+    private const HTML_SPLIT_PATTERN = '/(<pre[^>]*>.*?<\/pre>|<code[^>]*>.*?<\/code>|<a[^>]*>.*?<\/a>|<[^>]+>)/s';
+
     public function __construct(
         private string $rootPath = '/',
     ) {}
@@ -20,9 +31,13 @@ final readonly class TagLinkProcessor implements ContentProcessorInterface
             return $content;
         }
 
+        if (!$this->hasConvertibleHashtag($content)) {
+            return $content;
+        }
+
         // Protect pre/code/a blocks (their content shouldn't have hashtags converted)
         // Then split by remaining HTML tags to exclude hashtags in attributes
-        $parts = preg_split('/(<pre[^>]*>.*?<\/pre>|<code[^>]*>.*?<\/code>|<a[^>]*>.*?<\/a>|<[^>]+>)/s', $content, -1, PREG_SPLIT_DELIM_CAPTURE);
+        $parts = preg_split(self::HTML_SPLIT_PATTERN, $content, -1, PREG_SPLIT_DELIM_CAPTURE);
 
         if ($parts === false) {
             return $content;
@@ -50,8 +65,8 @@ final readonly class TagLinkProcessor implements ContentProcessorInterface
 
     private function convertHashtags(string $text): string
     {
-        return preg_replace_callback(
-            '/(?<!\w)#(\w+(?:-\w+)*)(?![\w-])/',
+        $result = preg_replace_callback(
+            self::HASHTAG_PATTERN,
             function (array $matches): string {
                 $tagDisplay = $matches[1];
                 $tagUrl = mb_strtolower($tagDisplay);
@@ -60,5 +75,17 @@ final readonly class TagLinkProcessor implements ContentProcessorInterface
             },
             $text
         );
+
+        return $result ?? $text;
+    }
+
+    private function hasConvertibleHashtag(string $content): bool
+    {
+        $visibleContent = preg_replace(self::PROTECTED_BLOCK_PATTERN, '', $content);
+        if ($visibleContent === null) {
+            return true;
+        }
+
+        return preg_match(self::HASHTAG_PATTERN, strip_tags($visibleContent)) === 1;
     }
 }

--- a/src/Processor/TagLinkProcessor.php
+++ b/src/Processor/TagLinkProcessor.php
@@ -19,7 +19,7 @@ final readonly class TagLinkProcessor implements ContentProcessorInterface
 {
     private const HASHTAG_PATTERN = '/(?<!\w)#(\w+(?:-\w+)*)(?![\w-])/';
     private const PROTECTED_BLOCK_PATTERN = '/<pre[^>]*>.*?<\/pre>|<code[^>]*>.*?<\/code>|<a[^>]*>.*?<\/a>/is';
-    private const HTML_SPLIT_PATTERN = '/(<pre[^>]*>.*?<\/pre>|<code[^>]*>.*?<\/code>|<a[^>]*>.*?<\/a>|<[^>]+>)/s';
+    private const HTML_SPLIT_PATTERN = '/(<pre[^>]*>.*?<\/pre>|<code[^>]*>.*?<\/code>|<a[^>]*>.*?<\/a>|<[^>]+>)/is';
 
     public function __construct(
         private string $rootPath = '/',

--- a/src/Render/NavigationRenderer.php
+++ b/src/Render/NavigationRenderer.php
@@ -25,7 +25,7 @@ final class NavigationRenderer
             return '';
         }
 
-        [$html] = self::renderItems($items, $rootPath, $language, $defaultLanguage, $currentUrl);
+        [$html] = self::renderItems($items, $rootPath, $language, $defaultLanguage, self::normalizeUrl($currentUrl));
         $classAttribute = $class !== ''
             ? ' class="' . Html::encodeAttribute($class) . '"'
             : '';
@@ -39,7 +39,7 @@ final class NavigationRenderer
             return false;
         }
 
-        return self::itemsContainCurrent($navigation->menu($menuName), $currentUrl);
+        return self::itemsContainCurrent($navigation->menu($menuName), self::normalizeUrl($currentUrl));
     }
 
     /**
@@ -51,16 +51,16 @@ final class NavigationRenderer
         string $rootPath,
         string $language,
         string $defaultLanguage,
-        string $currentUrl,
+        string $normalizedCurrentUrl,
     ): array
     {
         $html = '<ul>';
         $hasCurrent = false;
         foreach ($items as $item) {
             [$childrenHtml, $childHasCurrent] = $item->children !== []
-                ? self::renderItems($item->children, $rootPath, $language, $defaultLanguage, $currentUrl)
+                ? self::renderItems($item->children, $rootPath, $language, $defaultLanguage, $normalizedCurrentUrl)
                 : ['', false];
-            $isCurrent = self::isCurrentUrl($item->url, $currentUrl);
+            $isCurrent = self::isCurrentUrl($item->url, $normalizedCurrentUrl);
             $hasCurrent = $hasCurrent || $isCurrent || $childHasCurrent;
             $classes = [];
             if ($isCurrent) {
@@ -101,12 +101,12 @@ final class NavigationRenderer
     /**
      * @param list<NavigationItem> $items
      */
-    private static function itemsContainCurrent(array $items, string $currentUrl): bool
+    private static function itemsContainCurrent(array $items, string $normalizedCurrentUrl): bool
     {
         foreach ($items as $item) {
             if (
-                self::isCurrentUrl($item->url, $currentUrl)
-                || self::itemsContainCurrent($item->children, $currentUrl)
+                self::isCurrentUrl($item->url, $normalizedCurrentUrl)
+                || self::itemsContainCurrent($item->children, $normalizedCurrentUrl)
             ) {
                 return true;
             }
@@ -115,10 +115,9 @@ final class NavigationRenderer
         return false;
     }
 
-    private static function isCurrentUrl(string $url, string $currentUrl): bool
+    private static function isCurrentUrl(string $url, string $normalizedCurrentUrl): bool
     {
         $normalizedUrl = self::normalizeUrl($url);
-        $normalizedCurrentUrl = self::normalizeUrl($currentUrl);
 
         return $normalizedUrl !== '' && $normalizedUrl === $normalizedCurrentUrl;
     }
@@ -155,7 +154,7 @@ final class NavigationRenderer
         }
 
         return ' data-ui-menu-title="'
-            . Html::encodeAttribute((string) json_encode(
+            . Html::encodeAttribute(json_encode(
                 $item->titles,
                 JSON_THROW_ON_ERROR | JSON_UNESCAPED_UNICODE | JSON_HEX_TAG | JSON_HEX_AMP | JSON_HEX_APOS | JSON_HEX_QUOT,
             ))

--- a/src/Render/NavigationRenderer.php
+++ b/src/Render/NavigationRenderer.php
@@ -7,6 +7,7 @@ namespace YiiPress\Render;
 use YiiPress\Build\RelativePathHelper;
 use YiiPress\Content\Model\Navigation;
 use YiiPress\Content\Model\NavigationItem;
+use Yiisoft\Html\Html;
 
 final class NavigationRenderer
 {
@@ -26,7 +27,7 @@ final class NavigationRenderer
 
         [$html] = self::renderItems($items, $rootPath, $language, $defaultLanguage, $currentUrl);
         $classAttribute = $class !== ''
-            ? ' class="' . htmlspecialchars($class, ENT_QUOTES | ENT_SUBSTITUTE, 'UTF-8') . '"'
+            ? ' class="' . Html::encodeAttribute($class) . '"'
             : '';
 
         return '<nav' . $classAttribute . '>' . $html . '</nav>';
@@ -69,7 +70,7 @@ final class NavigationRenderer
                 $classes[] = 'is-active-ancestor';
             }
             $classAttribute = $classes !== []
-                ? ' class="' . htmlspecialchars(implode(' ', $classes), ENT_QUOTES | ENT_SUBSTITUTE, 'UTF-8') . '"'
+                ? ' class="' . Html::encodeAttribute(implode(' ', $classes)) . '"'
                 : '';
 
             $html .= '<li' . $classAttribute . '>';
@@ -84,10 +85,10 @@ final class NavigationRenderer
 
             if ($item->url === '') {
                 $html .= '<span class="nav-section-title"' . $attributes . '>'
-                    . htmlspecialchars($title) . '</span>';
+                    . Html::encode($title) . '</span>';
             } else {
-                $html .= '<a href="' . htmlspecialchars($url) . '"' . $attributes . '>'
-                    . htmlspecialchars($title) . '</a>';
+                $html .= '<a href="' . Html::encodeAttribute($url) . '"' . $attributes . '>'
+                    . Html::encode($title) . '</a>';
             }
             $html .= $childrenHtml;
             $html .= '</li>';
@@ -154,12 +155,12 @@ final class NavigationRenderer
         }
 
         return ' data-ui-menu-title="'
-            . htmlspecialchars((string) json_encode(
+            . Html::encodeAttribute((string) json_encode(
                 $item->titles,
                 JSON_THROW_ON_ERROR | JSON_UNESCAPED_UNICODE | JSON_HEX_TAG | JSON_HEX_AMP | JSON_HEX_APOS | JSON_HEX_QUOT,
-            ), ENT_QUOTES | ENT_SUBSTITUTE, 'UTF-8')
+            ))
             . '" data-ui-menu-default="'
-            . htmlspecialchars($item->title, ENT_QUOTES | ENT_SUBSTITUTE, 'UTF-8')
+            . Html::encodeAttribute($item->title)
             . '"';
     }
 }

--- a/tests/Unit/Processor/TagLinkProcessorTest.php
+++ b/tests/Unit/Processor/TagLinkProcessorTest.php
@@ -210,6 +210,20 @@ final class TagLinkProcessorTest extends TestCase
         assertSame($content, $processor->process($content, $this->createEntry()));
     }
 
+    public function testDoesNotConvertHashtagsInUppercaseProtectedTags(): void
+    {
+        $processor = new TagLinkProcessor('/');
+        $content = '<PRE>#pre-tag</PRE>'
+            . '<p><CODE>#code-tag</CODE></p>'
+            . '<A href="/docs/#section">#link-tag</A>'
+            . '<p>#outside</p>';
+
+        assertSame(
+            '<PRE>#pre-tag</PRE><p><CODE>#code-tag</CODE></p><A href="/docs/#section">#link-tag</A><p><a href="/tags/outside/" class="tag-link">#outside</a></p>',
+            $processor->process($content, $this->createEntry()),
+        );
+    }
+
     private function createEntry(): Entry
     {
         $tmp = tempnam(sys_get_temp_dir(), 'yiipress_taglink_test_');

--- a/tests/Unit/Processor/TagLinkProcessorTest.php
+++ b/tests/Unit/Processor/TagLinkProcessorTest.php
@@ -199,6 +199,17 @@ final class TagLinkProcessorTest extends TestCase
         );
     }
 
+    public function testSkipsHashCharactersInProtectedBlocksAndAttributes(): void
+    {
+        $processor = new TagLinkProcessor('/');
+        $content = '<p><a href="/docs/#section">Docs</a></p>'
+            . '<p style="color: #fff">White text</p>'
+            . '<pre>#hashtag in code</pre>'
+            . '<p>Use # for comments.</p>';
+
+        assertSame($content, $processor->process($content, $this->createEntry()));
+    }
+
     private function createEntry(): Entry
     {
         $tmp = tempnam(sys_get_temp_dir(), 'yiipress_taglink_test_');

--- a/tests/Unit/Render/NavigationRendererTest.php
+++ b/tests/Unit/Render/NavigationRendererTest.php
@@ -104,6 +104,23 @@ final class NavigationRendererTest extends TestCase
         assertStringContainsString('/a&amp;b/', $html);
     }
 
+    public function testRenderEscapesTextAndAttributesWithHtml5Rules(): void
+    {
+        $navigation = new Navigation(menus: [
+            'main' => [
+                new NavigationItem(title: 'Docs "Intro" & <Start>', url: '/docs/<intro>/?q=a&b="c"', children: []),
+            ],
+        ]);
+
+        $html = NavigationRenderer::render($navigation, 'main', './', 'en', 'en', 'docs"sidebar');
+
+        assertStringContainsString('<nav class="docs&quot;sidebar">', $html);
+        assertStringContainsString(
+            '<a href="./docs/&lt;intro&gt;/?q=a&amp;b=&quot;c&quot;">Docs "Intro" &amp; &lt;Start&gt;</a>',
+            $html,
+        );
+    }
+
     public function testRenderMarksCurrentAndAncestorItems(): void
     {
         $navigation = new Navigation(menus: [


### PR DESCRIPTION
## Summary
- use Yii HTML escaping in navigation rendering and normalize current URLs once per render
- skip expensive tag-link HTML splitting when hash characters are only in protected blocks, links, tags, or attributes
- add tag-link and navigation benchmarks for the optimized paths

## Verification
- make test -- tests/Unit/Processor/TagLinkProcessorTest.php tests/Unit/Render/NavigationRendererTest.php
- make psalm -- src/Processor/TagLinkProcessor.php src/Render/NavigationRenderer.php
- make build-docs

Note: full `make psalm` still reports existing repository-wide issues unrelated to this branch.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Navigation rendering now properly escapes special characters in menu items and attributes.
  * Tag link processor preserves hashtags in code blocks, existing links, and style attributes.

* **Documentation**
  * Clarified HTML escaping behavior for safe handling of special characters in navigation and tag links.

* **Tests**
  * Added unit tests for HTML escaping and protected block handling.
  * Added performance benchmarks for navigation and tag link processing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->