### PR TITLE
Fix #26: Link entries to author pages

### DIFF
--- a/benchmarks/EntryAuthorLinksBench.php
+++ b/benchmarks/EntryAuthorLinksBench.php
@@ -1,0 +1,151 @@
+<?php
+
+declare(strict_types=1);
+
+namespace YiiPress\Benchmarks;
+
+use YiiPress\Build\EntryRenderer;
+use YiiPress\Build\TemplateResolver;
+use YiiPress\Build\Theme;
+use YiiPress\Build\ThemeRegistry;
+use YiiPress\Content\Model\Author;
+use YiiPress\Content\Model\Entry;
+use YiiPress\Content\Model\SiteConfig;
+use YiiPress\Processor\ContentProcessorPipeline;
+use DateTimeImmutable;
+use FilesystemIterator;
+use PhpBench\Attributes\AfterMethods;
+use PhpBench\Attributes\BeforeMethods;
+use PhpBench\Attributes\Iterations;
+use PhpBench\Attributes\Revs;
+use PhpBench\Attributes\Warmup;
+use RecursiveDirectoryIterator;
+use RecursiveIteratorIterator;
+use SplFileInfo;
+
+#[BeforeMethods('setUp')]
+#[AfterMethods('tearDown')]
+final class EntryAuthorLinksBench
+{
+    private string $tempDir;
+    private EntryRenderer $renderer;
+    private Entry $entry;
+    private SiteConfig $siteConfig;
+    private SiteConfig $siteConfigWithoutAuthorPages;
+
+    public function setUp(): void
+    {
+        $this->tempDir = sys_get_temp_dir() . '/yiipress-author-links-bench-' . uniqid();
+        mkdir($this->tempDir . '/content/blog', 0o755, true);
+        mkdir($this->tempDir . '/theme', 0o755, true);
+
+        file_put_contents(
+            $this->tempDir . '/theme/entry.php',
+            <<<'PHP'
+<?php /** @var list<array{slug: string, title: string, url: string}> $entryAuthors */ ?>
+<?php foreach ($entryAuthors as $entryAuthor): ?>
+<?= $entryAuthor['url'] === '' ? $h($entryAuthor['title']) : '<a href="' . $h($entryAuthor['url']) . '">' . $h($entryAuthor['title']) . '</a>' ?>
+<?php endforeach; ?>
+PHP,
+        );
+
+        $entryFile = $this->tempDir . '/content/blog/post.md';
+        file_put_contents($entryFile, "---\ntitle: Author Links\n---\n\nBody.\n");
+
+        $registry = new ThemeRegistry();
+        $registry->register(new Theme('bench', $this->tempDir . '/theme'));
+
+        $this->renderer = new EntryRenderer(
+            new ContentProcessorPipeline(),
+            new TemplateResolver($registry),
+            contentDir: $this->tempDir . '/content',
+            authors: [
+                'john-doe' => new Author('john-doe', 'John Doe', '', '', '', 0, 0, ''),
+                'jane-doe' => new Author('jane-doe', 'Jane Doe', '', '', '', 0, 0, ''),
+            ],
+        );
+
+        $this->entry = new Entry(
+            filePath: $entryFile,
+            collection: 'blog',
+            slug: 'post',
+            title: 'Author Links',
+            date: new DateTimeImmutable('2024-01-01'),
+            draft: false,
+            tags: [],
+            categories: [],
+            authors: ['john-doe', 'jane-doe'],
+            summary: '',
+            permalink: '',
+            layout: '',
+            theme: 'bench',
+            weight: 0,
+            language: '',
+            redirectTo: '',
+            extra: [],
+            bodyOffset: 29,
+            bodyLength: 6,
+        );
+
+        $this->siteConfig = $this->createSiteConfig(authorPages: true);
+        $this->siteConfigWithoutAuthorPages = $this->createSiteConfig(authorPages: false);
+    }
+
+    public function tearDown(): void
+    {
+        if (!is_dir($this->tempDir)) {
+            return;
+        }
+
+        $iterator = new RecursiveIteratorIterator(
+            new RecursiveDirectoryIterator($this->tempDir, FilesystemIterator::SKIP_DOTS),
+            RecursiveIteratorIterator::CHILD_FIRST,
+        );
+
+        foreach ($iterator as $item) {
+            /** @var SplFileInfo $item */
+            if ($item->isDir()) {
+                rmdir($item->getPathname());
+            } else {
+                unlink($item->getPathname());
+            }
+        }
+
+        rmdir($this->tempDir);
+    }
+
+    #[Revs(500)]
+    #[Iterations(3)]
+    #[Warmup(1)]
+    public function benchRenderLinkedEntryAuthors(): void
+    {
+        $this->renderer->render($this->siteConfig, $this->entry, '/blog/post/');
+    }
+
+    #[Revs(500)]
+    #[Iterations(3)]
+    #[Warmup(1)]
+    public function benchRenderPlainEntryAuthors(): void
+    {
+        $this->renderer->render($this->siteConfigWithoutAuthorPages, $this->entry, '/blog/post/');
+    }
+
+    private function createSiteConfig(bool $authorPages): SiteConfig
+    {
+        return new SiteConfig(
+            title: 'Bench',
+            description: '',
+            baseUrl: 'https://example.com',
+            defaultLanguage: 'en',
+            charset: 'UTF-8',
+            defaultAuthor: '',
+            dateFormat: 'Y-m-d',
+            entriesPerPage: 10,
+            permalink: '/:collection/:slug/',
+            taxonomies: [],
+            params: [],
+            theme: 'bench',
+            authorPages: $authorPages,
+        );
+    }
+}

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -16,6 +16,7 @@ languages: [en]
 charset: UTF-8
 
 default_author: john-doe
+author_pages: false
 
 date_format: Y.m.d
 entries_per_page: 10
@@ -58,6 +59,7 @@ editor: code
 - **languages** — site language codes. The first language is the default language (e.g., `[en]`, `[en, ru]`)
 - **charset** — character encoding (default: `UTF-8`)
 - **default_author** — author slug (referencing a file in `content/authors/`), used when entries have no explicit `authors` field
+- **author_pages** — set to `true` to generate `/authors/` and `/authors/:slug/` pages and link known entry authors to them (default: `false`)
 - **date_format** — PHP date format string for displaying dates in templates (e.g., `Y.m.d` for "2026.03.23", `F j, Y` for "March 23, 2026"). See [PHP date format](https://www.php.net/manual/en/datetime.format.php) for all available format characters
 - **entries_per_page** — default pagination size (overridden by collection `_collection.yaml`)
 - **permalink** — default permalink pattern (overridden by collection or entry)

--- a/docs/content.md
+++ b/docs/content.md
@@ -228,12 +228,12 @@ Author bio in markdown.
 
 Author slugs (filenames without `.md`) are referenced from entry front matter.
 
-Author pages are generated automatically:
+Set `author_pages: true` in `content/config.yaml` to generate author pages:
 
 - `/authors/` — index page listing all authors with avatars
 - `/authors/:slug/` — individual author page with bio (rendered from markdown body), contact info, and a list of their entries
 
-Author pages are included in the sitemap.
+When enabled, known authors are linked from entry metadata to their author pages, and author pages are included in the sitemap. With the default `author_pages: false`, author names remain plain text and no author pages are generated.
 
 ## Date-based archives
 

--- a/docs/templates.md
+++ b/docs/templates.md
@@ -134,6 +134,7 @@ Built-in templates and partials expect `$ui` to be passed by the renderer; `Page
 | `$date`       | `string`      | Formatted date using `date_format` from `config.yaml` or empty   |
 | `$dateISO`    | `string`      | ISO 8601 date (`Y-m-d`) for HTML5 `datetime` attribute or empty |
 | `$author`     | `string`      | Comma-separated author names                                     |
+| `$entryAuthors` | `list<array{slug: string, title: string, url: string}>` | Entry authors; `url` links to the author page when `author_pages` is enabled and the author file exists |
 | `$collection` | `string`      | Collection name the entry belongs to                             |
 | `$extra`      | `array<string, mixed>` | Custom front matter under `extra`                         |
 | `$showTitle`  | `bool`        | Whether the bundled entry template renders the generated `<h1>`  |
@@ -156,8 +157,17 @@ Example:
 <?php if ($date !== ''): ?>
     <time datetime="<?= $h($dateISO) ?>"><?= $h($date) ?></time>
 <?php endif; ?>
-<?php if ($author !== ''): ?>
-    <span class="author"><?= $h($author) ?></span>
+<?php if ($entryAuthors !== []): ?>
+    <span class="author">
+<?php foreach ($entryAuthors as $index => $entryAuthor): ?>
+        <?= $index > 0 ? ', ' : '' ?>
+<?php if ($entryAuthor['url'] !== ''): ?>
+        <a href="<?= $h($entryAuthor['url']) ?>"><?= $h($entryAuthor['title']) ?></a>
+<?php else: ?>
+        <?= $h($entryAuthor['title']) ?>
+<?php endif; ?>
+<?php endforeach; ?>
+    </span>
 <?php endif; ?>
     <div class="content"><?= $content ?></div>
 </article>
@@ -415,7 +425,7 @@ layout: wide
 
 The build process looks for `wide.php` in the active theme, then falls back to the built-in `entry.php` if not found.
 
-Custom layout templates receive the same variables as the default entry template (`$siteTitle`, `$entryTitle`, `$content`, `$date`, `$author`, `$collection`, `$extra`, `$showTitle`, `$nav`).
+Custom layout templates receive the same variables as the default entry template (`$siteTitle`, `$entryTitle`, `$content`, `$date`, `$author`, `$entryAuthors`, `$collection`, `$extra`, `$showTitle`, `$nav`).
 
 ### Example
 

--- a/src/Build/EntryRenderer.php
+++ b/src/Build/EntryRenderer.php
@@ -6,6 +6,7 @@ namespace YiiPress\Build;
 
 use YiiPress\Content\CrossReferenceResolver;
 use YiiPress\Content\I18n\TranslationIndex;
+use YiiPress\Content\Model\Author;
 use YiiPress\Content\Model\Entry;
 use YiiPress\Content\Model\Navigation;
 use YiiPress\Content\Model\SiteConfig;
@@ -36,6 +37,9 @@ final class EntryRenderer
     /** @var array<string, Closure> */
     private array $partialClosures = [];
 
+    /**
+     * @param array<string, Author> $authors
+     */
     public function __construct(
         private readonly ContentProcessorPipeline $pipeline,
         private readonly TemplateResolver $templateResolver,
@@ -179,10 +183,8 @@ final class EntryRenderer
             'date' => $entry->date?->format($siteConfig->dateFormat) ?? '',
             'dateISO' => $entry->date?->format('Y-m-d') ?? '',
             'draft' => $entry->draft,
-            'author' => implode(', ', array_map(
-                fn (string $authorSlug) => $this->authors[$authorSlug]->title ?? $authorSlug,
-                $entry->authors
-            )),
+            'author' => $this->authorText($entry),
+            'entryAuthors' => $this->entryAuthors($siteConfig, $entry, $rootPath),
             'tags' => array_values(array_filter(
                 $entry->tags,
                 static fn (string $tag) => !in_array(mb_strtolower($tag), $entry->inlineTags, true),
@@ -215,6 +217,35 @@ final class EntryRenderer
         $html = ($this->templateClosures[$templatePath])($variables);
 
         return $templateContext->rewriteHtml($html, $rootPath);
+    }
+
+    private function authorText(Entry $entry): string
+    {
+        return implode(', ', array_map(
+            fn (string $authorSlug) => $this->authors[$authorSlug]->title ?? $authorSlug,
+            $entry->authors,
+        ));
+    }
+
+    /**
+     * @return list<array{slug: string, title: string, url: string}>
+     */
+    private function entryAuthors(SiteConfig $siteConfig, Entry $entry, string $rootPath): array
+    {
+        $entryAuthors = [];
+
+        foreach ($entry->authors as $authorSlug) {
+            $author = $this->authors[$authorSlug] ?? null;
+            $entryAuthors[] = [
+                'slug' => $authorSlug,
+                'title' => $author instanceof Author ? $author->title : $authorSlug,
+                'url' => $siteConfig->authorPages && $author instanceof Author
+                    ? $rootPath . 'authors/' . $authorSlug . '/'
+                    : '',
+            ];
+        }
+
+        return $entryAuthors;
     }
 
     /**

--- a/src/Console/BuildCommand.php
+++ b/src/Console/BuildCommand.php
@@ -739,7 +739,15 @@ final class BuildCommand extends Command
 
         $profile->switchTo('write sitemap');
         $sitemapGenerator = new SitemapGenerator();
-        $sitemapGenerator->generate($siteConfig, $collections, $entriesByCollection, $outputDir, $standalonePages, $authors, $noWrite);
+        $sitemapGenerator->generate(
+            $siteConfig,
+            $collections,
+            $entriesByCollection,
+            $outputDir,
+            $standalonePages,
+            $siteConfig->authorPages ? $authors : [],
+            $noWrite,
+        );
         $output->writeln('  Sitemap generated.');
 
         $profile->switchTo('write support files');
@@ -771,7 +779,7 @@ final class BuildCommand extends Command
             $output->writeln("  Taxonomy pages: <comment>$taxonomyPageCount</comment>");
         }
 
-        if ($authors !== []) {
+        if ($siteConfig->authorPages && $authors !== []) {
             $profile->switchTo('write author pages');
             $allEntries ??= array_merge(...array_values($entriesByCollection));
             $entriesByAuthor = [];
@@ -1139,7 +1147,7 @@ final class BuildCommand extends Command
             }
         }
 
-        if ($authors !== []) {
+        if ($siteConfig->authorPages && $authors !== []) {
             $files[] = $outputDir . '/authors/index.html';
             foreach (array_keys($authors) as $slug) {
                 $files[] = $outputDir . '/authors/' . $slug . '/index.html';

--- a/src/Content/Model/SiteConfig.php
+++ b/src/Content/Model/SiteConfig.php
@@ -36,5 +36,6 @@ final readonly class SiteConfig
         public bool $lastUpdated = false,
         public ?string $editPageUrl = null,
         public ?string $reportIssueUrl = null,
+        public bool $authorPages = false,
     ) {}
 }

--- a/src/Content/Parser/SiteConfigParser.php
+++ b/src/Content/Parser/SiteConfigParser.php
@@ -65,6 +65,7 @@ final class SiteConfigParser
             lastUpdated: (bool) ($data['last_updated'] ?? false),
             editPageUrl: self::parseOptionalString($data['edit_page'] ?? null),
             reportIssueUrl: self::parseOptionalString($data['report_issue'] ?? null),
+            authorPages: (bool) ($data['author_pages'] ?? false),
         );
     }
 

--- a/tests/Support/Data/content/config.yaml
+++ b/tests/Support/Data/content/config.yaml
@@ -4,6 +4,7 @@ base_url: "https://test.example.com"
 languages: ["en"]
 charset: "UTF-8"
 default_author: "john-doe"
+author_pages: true
 date_format: "F j, Y"
 entries_per_page: 5
 permalink: "/:collection/:slug/"

--- a/tests/Unit/Build/EntryRendererTest.php
+++ b/tests/Unit/Build/EntryRendererTest.php
@@ -10,6 +10,7 @@ use YiiPress\Build\EntryRenderer;
 use YiiPress\Build\Theme;
 use YiiPress\Build\ThemeRegistry;
 use YiiPress\Build\TemplateResolver;
+use YiiPress\Content\Model\Author;
 use YiiPress\Content\Model\Entry;
 use YiiPress\Content\Model\I18nConfig;
 use YiiPress\Content\Model\SearchConfig;
@@ -141,6 +142,65 @@ final class EntryRendererTest extends TestCase
 
         assertStringNotContainsString('class="entry-page-meta"', $html);
         assertStringNotContainsString('data-ui-key="last_updated"', $html);
+    }
+
+    public function testRendersKnownAuthorAsLinkWhenAuthorPagesAreEnabled(): void
+    {
+        $entryFile = $this->contentDir . '/blog/post.md';
+        file_put_contents($entryFile, "---\ntitle: Authored\n---\n\nBody.\n");
+
+        $entry = $this->createEntry(filePath: $entryFile, title: 'Authored', authors: ['john-doe']);
+        $renderer = new EntryRenderer(
+            $this->createPipeline(),
+            $this->createTemplateResolver(),
+            contentDir: $this->contentDir,
+            authors: [
+                'john-doe' => new Author(
+                    slug: 'john-doe',
+                    title: 'John Doe',
+                    email: '',
+                    url: '',
+                    avatar: '',
+                    bodyOffset: 0,
+                    bodyLength: 0,
+                    filePath: '',
+                ),
+            ],
+        );
+        $html = $renderer->render($this->createSiteConfig(authorPages: true), $entry, '/blog/authored/');
+
+        assertStringContainsString('class="author"', $html);
+        assertStringContainsString('href="../../authors/john-doe/">John Doe</a>', $html);
+    }
+
+    public function testRendersKnownAuthorAsTextWhenAuthorPagesAreDisabled(): void
+    {
+        $entryFile = $this->contentDir . '/blog/post.md';
+        file_put_contents($entryFile, "---\ntitle: Authored\n---\n\nBody.\n");
+
+        $entry = $this->createEntry(filePath: $entryFile, title: 'Authored', authors: ['john-doe']);
+        $renderer = new EntryRenderer(
+            $this->createPipeline(),
+            $this->createTemplateResolver(),
+            contentDir: $this->contentDir,
+            authors: [
+                'john-doe' => new Author(
+                    slug: 'john-doe',
+                    title: 'John Doe',
+                    email: '',
+                    url: '',
+                    avatar: '',
+                    bodyOffset: 0,
+                    bodyLength: 0,
+                    filePath: '',
+                ),
+            ],
+        );
+        $html = $renderer->render($this->createSiteConfig(authorPages: false), $entry, '/blog/authored/');
+
+        assertStringContainsString('class="author"', $html);
+        assertStringContainsString('John Doe', $html);
+        assertStringNotContainsString('href="../../authors/john-doe/"', $html);
     }
 
     public function testRendersEditPageLinkWhenConfigured(): void
@@ -467,6 +527,7 @@ PHP);
         bool $lastUpdated = false,
         ?string $editPageUrl = null,
         ?string $reportIssueUrl = null,
+        bool $authorPages = false,
     ): SiteConfig
     {
         return new SiteConfig(
@@ -487,6 +548,7 @@ PHP);
             lastUpdated: $lastUpdated,
             editPageUrl: $editPageUrl,
             reportIssueUrl: $reportIssueUrl,
+            authorPages: $authorPages,
         );
     }
 

--- a/tests/Unit/Console/BuildCommandTest.php
+++ b/tests/Unit/Console/BuildCommandTest.php
@@ -686,6 +686,25 @@ final class BuildCommandTest extends TestCase
         assertStringContainsString('/authors/john-doe/', $sitemap);
     }
 
+    public function testBuildCanDisableAuthorPages(): void
+    {
+        $contentDir = $this->copyContentFixture();
+        file_put_contents($contentDir . '/config.yaml', "\nauthor_pages: false\n", FILE_APPEND);
+
+        $this->runBuild($contentDir);
+
+        assertFalse(is_dir($this->outputDir . '/authors'));
+
+        $entryHtml = file_get_contents($this->outputDir . '/blog/test-post/index.html');
+        assertStringContainsString('class="author"', $entryHtml);
+        assertStringContainsString('John Doe', $entryHtml);
+        assertStringNotContainsString('href="../../authors/john-doe/"', $entryHtml);
+
+        $sitemap = file_get_contents($this->outputDir . '/sitemap.xml');
+        assertStringNotContainsString('/authors/', $sitemap);
+        assertStringNotContainsString('/authors/john-doe/', $sitemap);
+    }
+
     public function testBuildRendersNavigationInOutput(): void
     {
         $yii = dirname(__DIR__, 3) . '/yii';

--- a/tests/Unit/Content/Parser/SiteConfigParserTest.php
+++ b/tests/Unit/Content/Parser/SiteConfigParserTest.php
@@ -27,6 +27,7 @@ final class SiteConfigParserTest extends TestCase
         assertSame('en', $config->defaultLanguage);
         assertSame('UTF-8', $config->charset);
         assertSame('john-doe', $config->defaultAuthor);
+        assertTrue($config->authorPages);
         assertSame('F j, Y', $config->dateFormat);
         assertSame(5, $config->entriesPerPage);
         assertSame('/:collection/:slug/', $config->permalink);
@@ -85,6 +86,32 @@ final class SiteConfigParserTest extends TestCase
         $config = $parser->parse($filePath);
 
         assertSame('https://example.com/issues/new?title={title}', $config->reportIssueUrl);
+
+        unlink($filePath);
+    }
+
+    public function testDisablesAuthorPagesByDefault(): void
+    {
+        $filePath = sys_get_temp_dir() . '/yiipress-site-config-' . uniqid() . '.yaml';
+        file_put_contents($filePath, "title: Test\nlanguages: [en]\n");
+
+        $parser = new SiteConfigParser();
+        $config = $parser->parse($filePath);
+
+        assertFalse($config->authorPages);
+
+        unlink($filePath);
+    }
+
+    public function testParsesAuthorPagesConfig(): void
+    {
+        $filePath = sys_get_temp_dir() . '/yiipress-site-config-' . uniqid() . '.yaml';
+        file_put_contents($filePath, "title: Test\nlanguages: [en]\nauthor_pages: true\n");
+
+        $parser = new SiteConfigParser();
+        $config = $parser->parse($filePath);
+
+        assertTrue($config->authorPages);
 
         unlink($filePath);
     }

--- a/themes/minimal/entry.php
+++ b/themes/minimal/entry.php
@@ -10,6 +10,7 @@ declare(strict_types=1);
  * @var string $dateISO
  * @var bool $draft
  * @var string $author
+ * @var list<array{slug: string, title: string, url: string}> $entryAuthors
  * @var list<string> $tags
  * @var list<string> $categories
  * @var string $collection
@@ -44,6 +45,7 @@ use YiiPress\Render\NavigationRenderer;
 $language ??= 'en';
 $uiLanguage ??= 'en';
 $translations ??= [];
+$entryAuthors ??= [];
 $permalink ??= '';
 $hasToc = $toc !== [];
 $hasDocsSidebar = $nav !== null && NavigationRenderer::menuContainsUrl($nav, 'sidebar', $permalink);
@@ -94,7 +96,18 @@ $useLegacyTocSidebar = !$useDocsLayout && $hasToc;
 <?php elseif ($date !== ''): ?>
                 <time datetime="<?= $h($dateISO) ?>"><?= $h($date) ?></time>
 <?php endif; ?>
-<?php if ($author !== ''): ?>
+<?php if ($entryAuthors !== []): ?>
+                <span class="author">
+<?php foreach ($entryAuthors as $index => $entryAuthor): ?>
+                    <?= $index > 0 ? ', ' : '' ?>
+<?php if ($entryAuthor['url'] !== ''): ?>
+                    <a href="<?= $h($entryAuthor['url']) ?>"><?= $h($entryAuthor['title']) ?></a>
+<?php else: ?>
+                    <?= $h($entryAuthor['title']) ?>
+<?php endif; ?>
+<?php endforeach; ?>
+                </span>
+<?php elseif ($author !== ''): ?>
                 <span class="author"><?= $h($author) ?></span>
 <?php endif; ?>
             </div>


### PR DESCRIPTION
Closes #26

## Summary
- add author_pages config to control generated author pages and sitemap entries
- expose structured entryAuthors metadata while preserving the legacy author string
- link known authors in the minimal entry template
- document the option and template variable
- add PHPUnit coverage and an author-link phpbench benchmark

## Verification
- make test
- BENCH_FILTER=EntryAuthorLinksBench make bench
- git diff --check

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added `author_pages` configuration option (defaults to `false`) to enable/disable author page generation at `/authors/` and `/authors/:slug/`
  * Authors in blog entries now render as links when author pages are enabled, or as plain text when disabled

* **Documentation**
  * Updated configuration and template documentation to explain the new `author_pages` setting and author rendering behavior

* **Tests**
  * Added test coverage for author page rendering configurations

* **Chores**
  * Added performance benchmarks for author rendering scenarios

<!-- end of auto-generated comment: release notes by coderabbit.ai -->