### PR TITLE
Fix docs deployment after release workflow merge

### DIFF
--- a/.github/actions/build/action.yml
+++ b/.github/actions/build/action.yml
@@ -23,9 +23,9 @@ inputs:
     required: false
     default: --no-cache
   binary-path:
-    description: Path where the downloaded yiipress binary is installed.
+    description: Path where the downloaded yiipress binary is installed. Defaults to the runner temp directory.
     required: false
-    default: yiipress
+    default: ""
   github-token:
     description: Token used to resolve the latest release through the GitHub API.
     required: false
@@ -62,6 +62,8 @@ runs:
 
         repository="${ACTION_REPOSITORY:-yiipress/engine}"
         version="${VERSION}"
+        work_dir="$(mktemp -d)"
+        trap 'rm -rf "${work_dir}"' EXIT
 
         if [ "${version}" = "latest" ]; then
           headers=(-H "Accept: application/vnd.github+json")
@@ -69,20 +71,29 @@ runs:
             headers+=(-H "Authorization: Bearer ${GH_TOKEN}")
           fi
 
+          latest_release="${work_dir}/latest-release.json"
+          if ! curl -fsSL "${headers[@]}" "https://api.github.com/repos/${repository}/releases/latest" -o "${latest_release}"; then
+            echo "Could not resolve the latest YiiPress release for ${repository}. Pin the version input to an existing release." >&2
+            exit 1
+          fi
+
           version="$(
-            curl -fsSL "${headers[@]}" "https://api.github.com/repos/${repository}/releases/latest" \
-              | python3 -c 'import json, sys; print(json.load(sys.stdin)["tag_name"])'
+            python3 -c 'import json, sys; print(json.load(sys.stdin)["tag_name"])' < "${latest_release}"
           )"
         fi
 
-        if [[ "${BINARY_PATH}" = /* ]]; then
+        if [ -z "${version}" ]; then
+          echo "YiiPress release version must not be empty." >&2
+          exit 1
+        fi
+
+        if [ -z "${BINARY_PATH}" ]; then
+          binary_path="${RUNNER_TEMP}/yiipress"
+        elif [[ "${BINARY_PATH}" = /* ]]; then
           binary_path="${BINARY_PATH}"
         else
           binary_path="${GITHUB_WORKSPACE}/${BINARY_PATH}"
         fi
-
-        work_dir="$(mktemp -d)"
-        trap 'rm -rf "${work_dir}"' EXIT
 
         archive="${work_dir}/yiipress-linux-amd64.tar.gz"
         checksums="${work_dir}/SHA256SUMS"
@@ -94,9 +105,12 @@ runs:
         curl "${curl_args[@]}" \
           "https://github.com/${repository}/releases/download/${version}/yiipress-linux-amd64.tar.gz" \
           -o "${archive}"
-        curl "${curl_args[@]}" \
+        if ! curl "${curl_args[@]}" \
           "https://github.com/${repository}/releases/download/${version}/SHA256SUMS" \
-          -o "${checksums}"
+          -o "${checksums}"; then
+          echo "Could not download SHA256SUMS for ${repository} ${version}. Use a YiiPress release created by the release workflow." >&2
+          exit 1
+        fi
 
         checksum="$(awk '$2 ~ /(^|\/)yiipress-linux-amd64\.tar\.gz$/ { print $1; exit }' "${checksums}")"
         if [ -z "${checksum}" ]; then

--- a/.github/workflows/build-docs.yml
+++ b/.github/workflows/build-docs.yml
@@ -24,12 +24,16 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
+        with:
+          persist-credentials: false
 
       - name: Build documentation
         run: |
+          mkdir -p _site
+          user_id="$(id -u):$(id -g)"
           docker run --rm \
-            --user=root \
+            --user "${user_id}" \
             -v ${{ github.workspace }}/docs:/site/docs \
             -v ${{ github.workspace }}/_site:/site/_site \
             ghcr.io/yiipress/engine-static:nightly \

--- a/.github/workflows/build-docs.yml
+++ b/.github/workflows/build-docs.yml
@@ -1,9 +1,12 @@
 name: Build and Deploy Documentation
 
 on:
-  push:
+  workflow_run:
+    workflows: ["Package Static Builds"]
     branches:
       - master
+    types:
+      - completed
   workflow_dispatch:
 
 permissions:
@@ -17,20 +20,26 @@ concurrency:
 
 jobs:
   build:
+    if: ${{ github.event_name == 'workflow_dispatch' || github.event.workflow_run.conclusion == 'success' }}
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
         uses: actions/checkout@v6
 
       - name: Build documentation
-        uses: ./.github/actions/build
-        with:
-          content-dir: docs
+        run: |
+          docker run --rm \
+            --user=root \
+            -v ${{ github.workspace }}/docs:/site/docs \
+            -v ${{ github.workspace }}/_site:/site/_site \
+            ghcr.io/yiipress/engine-static:nightly \
+            build --content-dir=docs --output-dir=_site --no-cache
 
       - name: Upload artifact
         uses: actions/upload-pages-artifact@7b1f4a764d45c48632c6b24a0339c27f5614fb0b
 
   deploy:
+    if: ${{ github.event_name == 'workflow_run' || github.event_name == 'workflow_dispatch' }}
     environment:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -88,7 +88,7 @@ Enable GitHub Pages in your repository settings: go to **Settings → Pages** an
 
 > **Tip:** Replace `X.Y.Z` with a real YiiPress version tag for reproducible, stable builds. The action builds to `_site` by default for GitHub Pages. See [GitHub Actions](github-actions.md) for custom output directories and other inputs.
 
-> **Real-world example:** This is exactly how the YiiPress documentation itself is built and deployed — see [`.github/workflows/build-docs.yml`](https://github.com/yiipress/engine/blob/master/.github/workflows/build-docs.yml) in this repository.
+> **Real-world example:** YiiPress documentation is built from the nightly binary image after the package workflow succeeds — see [`.github/workflows/build-docs.yml`](https://github.com/yiipress/engine/blob/master/.github/workflows/build-docs.yml) in this repository. Site repositories should use the release action above with a fixed version.
 
 ## Cloudflare Pages
 
@@ -97,7 +97,10 @@ Enable GitHub Pages in your repository settings: go to **Settings → Pages** an
 1. Push your project to a GitHub or GitLab repository.
 2. In the [Cloudflare dashboard](https://dash.cloudflare.com/), go to **Workers & Pages → Create application → Pages → Connect to Git**.
 3. Select your repository and configure the build settings:
-   - **Install command:** `curl -fsSL https://github.com/yiipress/engine/releases/download/X.Y.Z/yiipress-linux-amd64.tar.gz | tar -xz && chmod +x yiipress`
+   - **Install command:**
+     ```bash
+     curl -fsSLO https://github.com/yiipress/engine/releases/download/X.Y.Z/yiipress-linux-amd64.tar.gz && curl -fsSLO https://github.com/yiipress/engine/releases/download/X.Y.Z/SHA256SUMS && checksum="$(awk '$2 ~ /(^|\/)yiipress-linux-amd64\.tar\.gz$/ { print $1; exit }' SHA256SUMS)" && test -n "$checksum" && printf '%s  yiipress-linux-amd64.tar.gz\n' "$checksum" | sha256sum -c - && tar -xzf yiipress-linux-amd64.tar.gz && chmod +x yiipress
+     ```
    - **Build command:** `./yiipress build --output-dir=_site --no-cache`
    - **Build output directory:** `_site`
 4. Click **Save and Deploy**.

--- a/docs/github-actions.md
+++ b/docs/github-actions.md
@@ -30,10 +30,12 @@ The action accepts these inputs:
 | `output-dir` | `_site` | Output directory passed to `yiipress build`. Change it when the host expects a custom output directory. |
 | `working-directory` | `.` | Repository subdirectory where the build runs. |
 | `args` | `--no-cache` | Extra arguments appended to `yiipress build`, one argument per line. |
-| `binary-path` | `yiipress` | Path where the downloaded binary is installed. |
+| `binary-path` | runner temp directory | Path where the downloaded binary is installed. Leave it unset unless later steps need the binary at a fixed path. |
 | `github-token` | workflow token | Token used when resolving `version: latest` through the GitHub API. |
 
 The action exposes `version` and `binary-path` outputs if later workflow steps need to report or reuse the downloaded binary.
+
+The downloaded archive is verified against the release `SHA256SUMS` asset. Use a YiiPress release produced by the official release workflow, and pin `version` to that release for reproducible builds.
 
 ## GitHub Pages
 

--- a/tests/Unit/Packaging/ConfigurationPackagingTest.php
+++ b/tests/Unit/Packaging/ConfigurationPackagingTest.php
@@ -288,7 +288,10 @@ final class ConfigurationPackagingTest extends TestCase
         $action = file_get_contents(dirname(__DIR__, 3) . '/.github/actions/build/action.yml');
         self::assertIsString($action);
 
-        self::assertStringContainsString('default: ""', $action);
+        self::assertMatchesRegularExpression(
+            '/binary-path:\n\s+description: [^\n]+\n\s+required: false\n\s+default: ""/',
+            $action,
+        );
         self::assertStringContainsString('binary_path="${RUNNER_TEMP}/yiipress"', $action);
         self::assertStringContainsString('elif [[ "${BINARY_PATH}" = /* ]]; then', $action);
         self::assertStringContainsString('printf \'binary-path=%s\n\' "${binary_path}"', $action);
@@ -303,9 +306,15 @@ final class ConfigurationPackagingTest extends TestCase
         self::assertStringContainsString('workflow_run:', $workflow);
         self::assertStringContainsString('workflows: ["Package Static Builds"]', $workflow);
         self::assertStringContainsString("github.event.workflow_run.conclusion == 'success'", $workflow);
+        self::assertStringContainsString('uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5', $workflow);
+        self::assertStringContainsString('persist-credentials: false', $workflow);
+        self::assertStringContainsString('mkdir -p _site', $workflow);
+        self::assertStringContainsString('user_id="$(id -u):$(id -g)"', $workflow);
+        self::assertStringContainsString('--user "${user_id}"', $workflow);
         self::assertStringContainsString('ghcr.io/yiipress/engine-static:nightly', $workflow);
         self::assertStringContainsString('build --content-dir=docs --output-dir=_site --no-cache', $workflow);
         self::assertStringNotContainsString('uses: ./.github/actions/build', $workflow);
+        self::assertStringNotContainsString('--user=root', $workflow);
     }
 
     #[Test]

--- a/tests/Unit/Packaging/ConfigurationPackagingTest.php
+++ b/tests/Unit/Packaging/ConfigurationPackagingTest.php
@@ -283,6 +283,45 @@ final class ConfigurationPackagingTest extends TestCase
     }
 
     #[Test]
+    public function buildActionInstallsBinaryOutsideCheckoutByDefault(): void
+    {
+        $action = file_get_contents(dirname(__DIR__, 3) . '/.github/actions/build/action.yml');
+        self::assertIsString($action);
+
+        self::assertStringContainsString('default: ""', $action);
+        self::assertStringContainsString('binary_path="${RUNNER_TEMP}/yiipress"', $action);
+        self::assertStringContainsString('elif [[ "${BINARY_PATH}" = /* ]]; then', $action);
+        self::assertStringContainsString('printf \'binary-path=%s\n\' "${binary_path}"', $action);
+    }
+
+    #[Test]
+    public function documentationWorkflowUsesNightlyBinaryAfterPackageWorkflow(): void
+    {
+        $workflow = file_get_contents(dirname(__DIR__, 3) . '/.github/workflows/build-docs.yml');
+        self::assertIsString($workflow);
+
+        self::assertStringContainsString('workflow_run:', $workflow);
+        self::assertStringContainsString('workflows: ["Package Static Builds"]', $workflow);
+        self::assertStringContainsString("github.event.workflow_run.conclusion == 'success'", $workflow);
+        self::assertStringContainsString('ghcr.io/yiipress/engine-static:nightly', $workflow);
+        self::assertStringContainsString('build --content-dir=docs --output-dir=_site --no-cache', $workflow);
+        self::assertStringNotContainsString('uses: ./.github/actions/build', $workflow);
+    }
+
+    #[Test]
+    public function cloudflareDeploymentVerifiesDownloadedBinaryChecksum(): void
+    {
+        $documentation = file_get_contents(dirname(__DIR__, 3) . '/docs/deployment.md');
+        self::assertIsString($documentation);
+
+        self::assertStringContainsString('SHA256SUMS', $documentation);
+        self::assertStringContainsString('test -n "$checksum"', $documentation);
+        self::assertStringContainsString('sha256sum -c -', $documentation);
+        self::assertStringContainsString('yiipress-linux-amd64.tar.gz', $documentation);
+        self::assertStringNotContainsString('curl -fsSL https://github.com/yiipress/engine/releases/download/X.Y.Z/yiipress-linux-amd64.tar.gz | tar -xz', $documentation);
+    }
+
+    #[Test]
     public function staticBinaryBuildTrimsUnusedServerSource(): void
     {
         $root = dirname(__DIR__, 3);


### PR DESCRIPTION
## Summary
- build project docs from the nightly binary image after Package Static Builds succeeds
- keep reusable action binaries out of consumer checkouts by default
- document checksum requirements and verify Cloudflare binary downloads

## Tests
- make test

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated deployment guide with enhanced binary download and verification procedures using SHA256 checksums.
  * Clarified GitHub Actions configuration documentation with input parameters and security verification details.

* **Improvements**
  * Strengthened binary installation verification with explicit checksum validation across deployment methods.
  * Refined documentation build workflow automation for improved consistency and reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->