### PR TITLE
Add coverage and static analysis badges

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -1,0 +1,42 @@
+name: Coverage
+
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+    branches:
+      - master
+  workflow_dispatch:
+
+jobs:
+  coverage:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    env:
+      CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
+        with:
+          persist-credentials: false
+
+      - name: Install dependencies
+        run: make -- composer install --no-progress --no-interaction
+
+      - name: Generate Clover coverage
+        run: make test-coverage-clover
+
+      - name: Upload coverage to Codecov
+        if: env.CODECOV_TOKEN != ''
+        uses: codecov/codecov-action@e79a6962e0d4c0c17b229090214935d2e33f8354
+        with:
+          token: ${{ env.CODECOV_TOKEN }}
+          files: runtime/coverage/clover.xml
+          fail_ci_if_error: true
+
+      - name: Skip Codecov upload
+        if: env.CODECOV_TOKEN == ''
+        run: echo "CODECOV_TOKEN is not configured; generated coverage but skipped Codecov upload."

--- a/.github/workflows/static-analysis.yml
+++ b/.github/workflows/static-analysis.yml
@@ -1,0 +1,31 @@
+name: Static Analysis
+
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+    branches:
+      - master
+  workflow_dispatch:
+
+jobs:
+  static-analysis:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
+        with:
+          persist-credentials: false
+
+      - name: Install dependencies
+        run: make -- composer install --no-progress --no-interaction
+
+      - name: Run Psalm
+        run: make psalm
+
+      - name: Run Composer Dependency Analyser
+        run: make composer-dependency-analyser

--- a/Makefile
+++ b/Makefile
@@ -31,7 +31,7 @@ PACKAGE_IMAGE ?= ${IMAGE}-static
 MACOS_PACKAGE_ARGS ?=
 WINDOWS_PACKAGE_ARGS ?=
 
-.PHONY: build up open down stop clear shell yii composer rector cs-fix test test-coverage psalm composer-dependency-analyser bench-generate bench-generate-realistic bench bench-baseline bench-compare bench-profile profile-build php build-docs package package-phar package-linux package-macos package-windows package-distroless package-distroless-push prod-build prod-push prod-deploy help
+.PHONY: build up open down stop clear shell yii composer rector cs-fix test test-coverage test-coverage-clover psalm composer-dependency-analyser bench-generate bench-generate-realistic bench bench-baseline bench-compare bench-profile profile-build php build-docs package package-phar package-linux package-macos package-windows package-distroless package-distroless-push prod-build prod-push prod-deploy help
 
 #
 # Development
@@ -139,6 +139,11 @@ endif
 ifeq ($(PRIMARY_GOAL),test-coverage)
 test-coverage: ## Run tests with coverage
 	$(DOCKER_COMPOSE_TEST) run --rm app ./vendor/bin/phpunit --coverage-html runtime/coverage $(CLI_ARGS)
+endif
+
+ifeq ($(PRIMARY_GOAL),test-coverage-clover)
+test-coverage-clover: ## Run tests with Clover coverage
+	$(DOCKER_COMPOSE_TEST) run --rm app bash -lc 'mkdir -p runtime/coverage && ./vendor/bin/phpunit --coverage-clover runtime/coverage/clover.xml $(CLI_ARGS)'
 endif
 
 ifeq ($(PRIMARY_GOAL),psalm)

--- a/README.md
+++ b/README.md
@@ -9,6 +9,8 @@
 [![Latest Stable Version](https://poser.pugx.org/yiipress/engine/v)](https://packagist.org/packages/yiipress/engine)
 [![Total Downloads](https://poser.pugx.org/yiipress/engine/downloads)](https://packagist.org/packages/yiipress/engine)
 [![Tests](https://github.com/yiipress/engine/actions/workflows/run-tests.yml/badge.svg)](https://github.com/yiipress/engine/actions/workflows/run-tests.yml)
+[![Static Analysis](https://github.com/yiipress/engine/actions/workflows/static-analysis.yml/badge.svg)](https://github.com/yiipress/engine/actions/workflows/static-analysis.yml)
+[![Coverage](https://codecov.io/gh/yiipress/engine/branch/master/graph/badge.svg)](https://codecov.io/gh/yiipress/engine)
 [![Package](https://github.com/yiipress/engine/actions/workflows/package-static.yml/badge.svg)](https://github.com/yiipress/engine/actions/workflows/package-static.yml)
 
 YiiPress is a fast, file-based static website engine powered by [Yii3](https://www.yiiframework.com/).

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -1,0 +1,379 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<files psalm-version="6.16.1@f1f5de594dc76faf8784e02d3dc4716c91c6f6ac">
+  <file src="src/Build/AssetFingerprintManifest.php">
+    <PossiblyFalseArgument>
+      <code><![CDATA[hash_file('xxh128', $sourceFilePath)]]></code>
+    </PossiblyFalseArgument>
+  </file>
+  <file src="src/Build/BuildDiagnostics.php">
+    <InvalidNullableReturnType>
+      <code><![CDATA[string]]></code>
+    </InvalidNullableReturnType>
+    <NullableReturnStatement>
+      <code><![CDATA[preg_replace('/`[^`]+`/', '', (string) $body)]]></code>
+    </NullableReturnStatement>
+  </file>
+  <file src="src/Build/BuildManifest.php">
+    <MixedPropertyTypeCoercion>
+      <code><![CDATA[$data]]></code>
+      <code><![CDATA[$data['entries']]]></code>
+      <code><![CDATA[isset($data['configFiles']) && is_array($data['configFiles']) ? array_values($data['configFiles']) : []]]></code>
+      <code><![CDATA[isset($data['trackedDirectories']) && is_array($data['trackedDirectories']) ? $data['trackedDirectories'] : []]]></code>
+    </MixedPropertyTypeCoercion>
+    <PropertyTypeCoercion>
+      <code><![CDATA[$this->entries]]></code>
+    </PropertyTypeCoercion>
+    <RedundantCast>
+      <code><![CDATA[(int) $mtime]]></code>
+    </RedundantCast>
+    <RedundantFunctionCall>
+      <code><![CDATA[array_values]]></code>
+    </RedundantFunctionCall>
+  </file>
+  <file src="src/Build/DateArchiveWriter.php">
+    <PossiblyNullArgument>
+      <code><![CDATA[$task['month']]]></code>
+      <code><![CDATA[$task['months']]]></code>
+      <code><![CDATA[$task['years']]]></code>
+    </PossiblyNullArgument>
+    <PossiblyUndefinedArrayOffset>
+      <code><![CDATA[$task['month']]]></code>
+      <code><![CDATA[$task['months']]]></code>
+      <code><![CDATA[$task['years']]]></code>
+    </PossiblyUndefinedArrayOffset>
+    <RedundantCastGivenDocblockType>
+      <code><![CDATA[(string) $month]]></code>
+      <code><![CDATA[(string) $year]]></code>
+      <code><![CDATA[(string) $year]]></code>
+    </RedundantCastGivenDocblockType>
+  </file>
+  <file src="src/Build/EntryRenderer.php">
+    <FalsableReturnStatement>
+      <code><![CDATA[ob_get_clean()]]></code>
+    </FalsableReturnStatement>
+    <InvalidFalsableReturnType>
+      <code><![CDATA[string]]></code>
+    </InvalidFalsableReturnType>
+    <MixedArgument>
+      <code><![CDATA[$html]]></code>
+    </MixedArgument>
+    <MixedArgumentTypeCoercion>
+      <code><![CDATA[$navigationPager]]></code>
+    </MixedArgumentTypeCoercion>
+    <PossiblyUndefinedArrayOffset>
+      <code><![CDATA[$navigationPager[$key]]]></code>
+    </PossiblyUndefinedArrayOffset>
+    <UnresolvableInclude>
+      <code><![CDATA[require $templatePath]]></code>
+    </UnresolvableInclude>
+  </file>
+  <file src="src/Build/FeedGenerator.php">
+    <MixedArgument>
+      <code><![CDATA[$authorName]]></code>
+    </MixedArgument>
+    <MixedPropertyFetch>
+      <code><![CDATA[$this->authors[$authorSlug]->title]]></code>
+    </MixedPropertyFetch>
+  </file>
+  <file src="src/Build/NavigationPager.php">
+    <InvalidArrayOffset>
+      <code><![CDATA[$items[$index - 1]]]></code>
+    </InvalidArrayOffset>
+    <MixedReturnTypeCoercion>
+      <code><![CDATA[[
+                'previous' => $items[$index - 1] ?? null,
+                'next' => $items[$index + 1] ?? null,
+            ]]]></code>
+      <code><![CDATA[array{previous: array{title: string, url: string}|null, next: array{title: string, url: string}|null}|null]]></code>
+    </MixedReturnTypeCoercion>
+  </file>
+  <file src="src/Build/NotFoundPageWriter.php">
+    <MixedArgumentTypeCoercion>
+      <code><![CDATA[$params]]></code>
+    </MixedArgumentTypeCoercion>
+    <UnresolvableInclude>
+      <code><![CDATA[require $this->templateResolver->resolve('errors/404', $siteConfig->theme)]]></code>
+    </UnresolvableInclude>
+  </file>
+  <file src="src/Build/PageTemplateRenderer.php">
+    <MixedArgument>
+      <code><![CDATA[$html]]></code>
+    </MixedArgument>
+    <UnresolvableInclude>
+      <code><![CDATA[require $templatePath]]></code>
+    </UnresolvableInclude>
+  </file>
+  <file src="src/Build/ParallelEntryWriter.php">
+    <MixedArgumentTypeCoercion>
+      <code><![CDATA[$authors]]></code>
+      <code><![CDATA[$authors]]></code>
+    </MixedArgumentTypeCoercion>
+  </file>
+  <file src="src/Build/TaxonomyPageWriter.php">
+    <RedundantCastGivenDocblockType>
+      <code><![CDATA[(string) $term]]></code>
+    </RedundantCastGivenDocblockType>
+  </file>
+  <file src="src/Build/TemplateContext.php">
+    <FalsableReturnStatement>
+      <code><![CDATA[ob_get_clean()]]></code>
+    </FalsableReturnStatement>
+    <InvalidFalsableReturnType>
+      <code><![CDATA[string]]></code>
+    </InvalidFalsableReturnType>
+    <MixedReturnStatement>
+      <code><![CDATA[($this->closureCache[$name])($variables)]]></code>
+    </MixedReturnStatement>
+    <UnresolvableInclude>
+      <code><![CDATA[require $path]]></code>
+    </UnresolvableInclude>
+  </file>
+  <file src="src/Build/TemplateHelpers.php">
+    <MixedArgumentTypeCoercion>
+      <code><![CDATA[$params]]></code>
+    </MixedArgumentTypeCoercion>
+  </file>
+  <file src="src/Console/BuildCommand.php">
+    <DocblockTypeContradiction>
+      <code><![CDATA[$quota === null]]></code>
+    </DocblockTypeContradiction>
+    <ForbiddenCode>
+      <code><![CDATA[shell_exec('nproc 2>/dev/null')]]></code>
+    </ForbiddenCode>
+    <InvalidArgument>
+      <code><![CDATA[$standaloneTasks]]></code>
+      <code><![CDATA[$tasksToWrite]]></code>
+    </InvalidArgument>
+    <MixedArgument>
+      <code><![CDATA[$period]]></code>
+    </MixedArgument>
+    <MixedArgumentTypeCoercion>
+      <code><![CDATA[$entriesByAuthor]]></code>
+    </MixedArgumentTypeCoercion>
+    <MixedArrayOffset>
+      <code><![CDATA[$entriesByAuthor[$authorSlug]]]></code>
+    </MixedArrayOffset>
+    <MixedMethodCall>
+      <code><![CDATA[write]]></code>
+    </MixedMethodCall>
+    <MixedPropertyFetch>
+      <code><![CDATA[$entry->authors]]></code>
+    </MixedPropertyFetch>
+    <NoValue>
+      <code><![CDATA[$collection]]></code>
+    </NoValue>
+    <RedundantCastGivenDocblockType>
+      <code><![CDATA[(string) pathinfo($item->getFilename(), PATHINFO_EXTENSION)]]></code>
+    </RedundantCastGivenDocblockType>
+    <RedundantConditionGivenDocblockType>
+      <code><![CDATA[explode(',', $cpuList)]]></code>
+    </RedundantConditionGivenDocblockType>
+    <TypeDoesNotContainType>
+      <code><![CDATA[$collection !== null]]></code>
+    </TypeDoesNotContainType>
+  </file>
+  <file src="src/Console/ImportCommand.php">
+    <RedundantCast>
+      <code><![CDATA[(string) $token]]></code>
+      <code><![CDATA[(string) $token]]></code>
+    </RedundantCast>
+  </file>
+  <file src="src/Content/CrossReferenceResolver.php">
+    <InvalidNullableReturnType>
+      <code><![CDATA[string]]></code>
+    </InvalidNullableReturnType>
+    <NullableReturnStatement>
+      <code><![CDATA[preg_replace_callback(
+            '/\[([^\]]*)\]\(([^)#]+\.md)(#[^)]*)?\)/',
+            function (array $matches): string {
+                $text = $matches[1];
+                $path = $matches[2];
+                $fragment = $matches[3] ?? '';
+
+                $resolved = $this->resolvePath($path);
+                $permalink = $this->fileToPermalink[$resolved] ?? null;
+
+                if ($permalink === null) {
+                    return $matches[0];
+                }
+
+                if ($this->currentPermalink !== '') {
+                    $rootPath = RelativePathHelper::rootPath($this->currentPermalink);
+                    $permalink = RelativePathHelper::relativize($permalink, $rootPath);
+                }
+
+                return '[' . $text . '](' . $permalink . $fragment . ')';
+            },
+            $markdown,
+        )]]></code>
+    </NullableReturnStatement>
+  </file>
+  <file src="src/Content/Model/Entry.php">
+    <RedundantCast>
+      <code><![CDATA[(string) $text]]></code>
+    </RedundantCast>
+    <RedundantCastGivenDocblockType>
+      <code><![CDATA[(string) $text]]></code>
+    </RedundantCastGivenDocblockType>
+  </file>
+  <file src="src/Content/Parser/CollectionConfigParser.php">
+    <MixedArgument>
+      <code><![CDATA[$data['order']]]></code>
+    </MixedArgument>
+    <MixedArrayAccess>
+      <code><![CDATA[$data['description']]]></code>
+      <code><![CDATA[$data['entries_per_page']]]></code>
+      <code><![CDATA[$data['feed']]]></code>
+      <code><![CDATA[$data['listing']]]></code>
+      <code><![CDATA[$data['navigation_pager']]]></code>
+      <code><![CDATA[$data['permalink']]]></code>
+      <code><![CDATA[$data['sort_by']]]></code>
+      <code><![CDATA[$data['sort_order']]]></code>
+      <code><![CDATA[$data['title']]]></code>
+    </MixedArrayAccess>
+  </file>
+  <file src="src/Content/Parser/ContentParser.php">
+    <PossiblyNullArgument>
+      <code><![CDATA[$this->filenameParser]]></code>
+      <code><![CDATA[$this->filenameParser]]></code>
+      <code><![CDATA[$this->frontMatterParser]]></code>
+      <code><![CDATA[$this->frontMatterParser]]></code>
+    </PossiblyNullArgument>
+  </file>
+  <file src="src/Content/Parser/EntryParser.php">
+    <MixedArgumentTypeCoercion>
+      <code><![CDATA[isset($fields['extra']) && is_array($fields['extra'])
+                ? $fields['extra']
+                : []]]></code>
+    </MixedArgumentTypeCoercion>
+  </file>
+  <file src="src/Content/Parser/FrontMatterParser.php">
+    <MixedArgumentTypeCoercion>
+      <code><![CDATA[$result]]></code>
+    </MixedArgumentTypeCoercion>
+    <MixedReturnTypeCoercion>
+      <code><![CDATA[$result]]></code>
+      <code><![CDATA[array{frontMatter: array<string, mixed>, bodyOffset: int, bodyLength: int}]]></code>
+    </MixedReturnTypeCoercion>
+  </file>
+  <file src="src/Content/Parser/NavigationParser.php">
+    <ArgumentTypeCoercion>
+      <code><![CDATA[$item['children']]]></code>
+      <code><![CDATA[$items]]></code>
+    </ArgumentTypeCoercion>
+    <DocblockTypeContradiction>
+      <code><![CDATA[is_array($item)]]></code>
+    </DocblockTypeContradiction>
+    <RedundantCast>
+      <code><![CDATA[(string) reset($titles)]]></code>
+    </RedundantCast>
+  </file>
+  <file src="src/Content/Parser/SiteConfigParser.php">
+    <MixedArgument>
+      <code><![CDATA[$data]]></code>
+    </MixedArgument>
+    <MixedArgumentTypeCoercion>
+      <code><![CDATA[isset($data['params']) && is_array($data['params'])
+                ? $data['params']
+                : []]]></code>
+    </MixedArgumentTypeCoercion>
+  </file>
+  <file src="src/Import/Telegram/Channel.php">
+    <MixedArgument>
+      <code><![CDATA[$this->message['action']]]></code>
+      <code><![CDATA[$this->message['type']]]></code>
+    </MixedArgument>
+    <MixedReturnStatement>
+      <code><![CDATA[$this->message['title']]]></code>
+    </MixedReturnStatement>
+  </file>
+  <file src="src/Import/Telegram/Message.php">
+    <ArgumentTypeCoercion>
+      <code><![CDATA[$this->message['text']]]></code>
+    </ArgumentTypeCoercion>
+    <DocblockTypeContradiction>
+      <code><![CDATA[empty($lines)]]></code>
+      <code><![CDATA[empty($lines)]]></code>
+    </DocblockTypeContradiction>
+    <MixedArgument>
+      <code><![CDATA[$text]]></code>
+      <code><![CDATA[$text]]></code>
+      <code><![CDATA[$text]]></code>
+      <code><![CDATA[$text]]></code>
+      <code><![CDATA[$text]]></code>
+      <code><![CDATA[$text]]></code>
+      <code><![CDATA[$this->message['text']]]></code>
+      <code><![CDATA[$this->message['text_entities']]]></code>
+      <code><![CDATA[$this->message['text_entities']]]></code>
+    </MixedArgument>
+    <MixedArrayAccess>
+      <code><![CDATA[$entity['href']]]></code>
+      <code><![CDATA[$entity['language']]]></code>
+      <code><![CDATA[$entity['length']]]></code>
+      <code><![CDATA[$entity['offset']]]></code>
+      <code><![CDATA[$entity['text']]]></code>
+      <code><![CDATA[$entity['type']]]></code>
+      <code><![CDATA[$entity['type']]]></code>
+    </MixedArrayAccess>
+    <MixedOperand>
+      <code><![CDATA[$annotation['href']]]></code>
+      <code><![CDATA[$annotation['language'] ?? '']]></code>
+      <code><![CDATA[$markdown]]></code>
+      <code><![CDATA[$markdown]]></code>
+    </MixedOperand>
+    <PropertyNotSetInConstructor>
+      <code><![CDATA[$date]]></code>
+      <code><![CDATA[$edited]]></code>
+      <code><![CDATA[$file]]></code>
+      <code><![CDATA[$forwardedFrom]]></code>
+      <code><![CDATA[$id]]></code>
+      <code><![CDATA[$markdown]]></code>
+      <code><![CDATA[$photo]]></code>
+      <code><![CDATA[$slug]]></code>
+      <code><![CDATA[$tags]]></code>
+      <code><![CDATA[$telegramLink]]></code>
+      <code><![CDATA[$title]]></code>
+    </PropertyNotSetInConstructor>
+  </file>
+  <file src="src/Import/Telegram/TelegramContentImporter.php">
+    <MixedArgument>
+      <code><![CDATA[$dataMessage]]></code>
+      <code><![CDATA[$dataMessage]]></code>
+    </MixedArgument>
+    <MixedArgumentTypeCoercion>
+      <code><![CDATA[$skippedFiles]]></code>
+    </MixedArgumentTypeCoercion>
+    <MixedArrayAccess>
+      <code><![CDATA[$dataMessage['id']]]></code>
+      <code><![CDATA[$dataMessage['id']]]></code>
+      <code><![CDATA[$dataMessage['id']]]></code>
+      <code><![CDATA[$dataMessage['text']]]></code>
+      <code><![CDATA[$dataMessage['type']]]></code>
+      <code><![CDATA[$dataMessage['type']]]></code>
+    </MixedArrayAccess>
+    <MixedOperand>
+      <code><![CDATA[$tag]]></code>
+    </MixedOperand>
+    <PossiblyFalseArgument>
+      <code><![CDATA[$json]]></code>
+      <code><![CDATA[mb_detect_encoding($json, ['UTF-16LE', 'UTF-16BE', 'UTF-8', 'Windows-1251'], true)]]></code>
+    </PossiblyFalseArgument>
+  </file>
+  <file src="src/Processor/OEmbed/OEmbedProcessor.php">
+    <PropertyTypeCoercion>
+      <code><![CDATA[$providers]]></code>
+    </PropertyTypeCoercion>
+  </file>
+  <file src="src/Processor/Shortcode/YouTubeProcessor.php">
+    <MixedArgumentTypeCoercion>
+      <code><![CDATA[$params]]></code>
+      <code><![CDATA[$params]]></code>
+      <code><![CDATA[$params]]></code>
+    </MixedArgumentTypeCoercion>
+  </file>
+  <file src="src/Render/MarkdownRenderer.php">
+    <MixedReturnStatement>
+      <code><![CDATA[md4c_toHtml($markdown, $this->flags)]]></code>
+    </MixedReturnStatement>
+  </file>
+</files>

--- a/psalm.xml
+++ b/psalm.xml
@@ -9,6 +9,7 @@
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
     xmlns="https://getpsalm.org/schema/config"
     xsi:schemaLocation="https://getpsalm.org/schema/config vendor/vimeo/psalm/config.xsd"
+    errorBaseline="psalm-baseline.xml"
 >
     <projectFiles>
         <directory name="src" />

--- a/tests/Unit/Packaging/ConfigurationPackagingTest.php
+++ b/tests/Unit/Packaging/ConfigurationPackagingTest.php
@@ -331,6 +331,69 @@ final class ConfigurationPackagingTest extends TestCase
     }
 
     #[Test]
+    public function readmeExposesStaticAnalysisAndCoverageBadges(): void
+    {
+        $readme = file_get_contents(dirname(__DIR__, 3) . '/README.md');
+        self::assertIsString($readme);
+
+        self::assertStringContainsString(
+            '[![Static Analysis](https://github.com/yiipress/engine/actions/workflows/static-analysis.yml/badge.svg)]',
+            $readme,
+        );
+        self::assertStringContainsString(
+            '[![Coverage](https://codecov.io/gh/yiipress/engine/branch/master/graph/badge.svg)]',
+            $readme,
+        );
+    }
+
+    #[Test]
+    public function staticAnalysisWorkflowRunsProjectAnalysisTargets(): void
+    {
+        $workflow = file_get_contents(dirname(__DIR__, 3) . '/.github/workflows/static-analysis.yml');
+        $psalmConfiguration = file_get_contents(dirname(__DIR__, 3) . '/psalm.xml');
+        $psalmBaseline = file_get_contents(dirname(__DIR__, 3) . '/psalm-baseline.xml');
+        self::assertIsString($workflow);
+        self::assertIsString($psalmConfiguration);
+        self::assertIsString($psalmBaseline);
+
+        self::assertStringContainsString('name: Static Analysis', $workflow);
+        self::assertStringContainsString('uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5', $workflow);
+        self::assertStringContainsString('persist-credentials: false', $workflow);
+        self::assertStringContainsString('make -- composer install --no-progress --no-interaction', $workflow);
+        self::assertStringContainsString('make psalm', $workflow);
+        self::assertStringContainsString('make composer-dependency-analyser', $workflow);
+        self::assertDoesNotMatchRegularExpression('/uses:\s+[^@\s]+@v\d+/', $workflow);
+        self::assertStringContainsString('errorBaseline="psalm-baseline.xml"', $psalmConfiguration);
+        self::assertStringContainsString('<files psalm-version=', $psalmBaseline);
+    }
+
+    #[Test]
+    public function coverageWorkflowPublishesRealCloverReport(): void
+    {
+        $workflow = file_get_contents(dirname(__DIR__, 3) . '/.github/workflows/coverage.yml');
+        $makefile = file_get_contents(dirname(__DIR__, 3) . '/Makefile');
+        self::assertIsString($workflow);
+        self::assertIsString($makefile);
+
+        self::assertStringContainsString('name: Coverage', $workflow);
+        self::assertStringContainsString('uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5', $workflow);
+        self::assertStringContainsString('persist-credentials: false', $workflow);
+        self::assertStringContainsString('make -- composer install --no-progress --no-interaction', $workflow);
+        self::assertStringContainsString('make test-coverage-clover', $workflow);
+        self::assertStringContainsString('runtime/coverage/clover.xml', $workflow);
+        self::assertStringContainsString('CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}', $workflow);
+        self::assertStringContainsString("if: env.CODECOV_TOKEN != ''", $workflow);
+        self::assertStringContainsString('token: ${{ env.CODECOV_TOKEN }}', $workflow);
+        self::assertStringContainsString('uses: codecov/codecov-action@e79a6962e0d4c0c17b229090214935d2e33f8354', $workflow);
+        self::assertStringContainsString('fail_ci_if_error: true', $workflow);
+        self::assertStringContainsString("if: env.CODECOV_TOKEN == ''", $workflow);
+        self::assertStringContainsString('generated coverage but skipped Codecov upload', $workflow);
+        self::assertDoesNotMatchRegularExpression('/uses:\s+[^@\s]+@v\d+/', $workflow);
+        self::assertStringContainsString('test-coverage-clover: ## Run tests with Clover coverage', $makefile);
+        self::assertStringContainsString('--coverage-clover runtime/coverage/clover.xml', $makefile);
+    }
+
+    #[Test]
     public function staticBinaryBuildTrimsUnusedServerSource(): void
     {
         $root = dirname(__DIR__, 3);


### PR DESCRIPTION
## Summary
- add README badges for static analysis and Codecov coverage
- add static-analysis and coverage GitHub workflows
- add Clover coverage make target and initial Psalm baseline so static analysis gates new issues

## Tests
- make test
- make test-coverage-clover
- make psalm
- make composer-dependency-analyser

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Integrated automated static analysis checks into the continuous integration pipeline
  * Added code coverage tracking and reporting capabilities to the continuous integration pipeline
  * Added status badges to documentation for visibility into code quality metrics
  * Updated project configuration and test assertions to support enhanced code quality assurance processes

<!-- end of auto-generated comment: release notes by coderabbit.ai -->