### PR TITLE
Make content config errors friendly

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -62,6 +62,7 @@
         "yiisoft/di": "^1.4.1",
         "yiisoft/error-handler": "^4.3.2",
         "yiisoft/files": "^2.1",
+        "yiisoft/friendly-exception": "^1.2",
         "yiisoft/html": "^4.1",
         "yiisoft/log": "^2.2.1",
         "yiisoft/middleware-dispatcher": "^5.4",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "df3a7b256bbd497135bdabdd8519e2b1",
+    "content-hash": "722c70a91dc001aeed9460cd3f729544",
     "packages": [
         {
             "name": "alexkart/curl-builder",

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -80,6 +80,11 @@ editor: code
 - **params** — arbitrary key-value pairs for use in templates
 - **markdown** — markdown extensions configuration (see below)
 
+If `content/config.yaml` is missing required values or is not valid YAML, `yiipress build`
+prints the configuration file, the problem, and a suggested fix. For example, a missing
+or empty `languages` option is reported with a `languages: [en]` example instead of a PHP
+stack trace.
+
 ### Search
 
 Client-side search is opt-in. Enable it in `content/config.yaml`:

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -216,22 +216,6 @@
       <code><![CDATA[(string) $text]]></code>
     </RedundantCastGivenDocblockType>
   </file>
-  <file src="src/Content/Parser/CollectionConfigParser.php">
-    <MixedArgument>
-      <code><![CDATA[$data['order']]]></code>
-    </MixedArgument>
-    <MixedArrayAccess>
-      <code><![CDATA[$data['description']]]></code>
-      <code><![CDATA[$data['entries_per_page']]]></code>
-      <code><![CDATA[$data['feed']]]></code>
-      <code><![CDATA[$data['listing']]]></code>
-      <code><![CDATA[$data['navigation_pager']]]></code>
-      <code><![CDATA[$data['permalink']]]></code>
-      <code><![CDATA[$data['sort_by']]]></code>
-      <code><![CDATA[$data['sort_order']]]></code>
-      <code><![CDATA[$data['title']]]></code>
-    </MixedArrayAccess>
-  </file>
   <file src="src/Content/Parser/ContentParser.php">
     <PossiblyNullArgument>
       <code><![CDATA[$this->filenameParser]]></code>
@@ -269,9 +253,6 @@
     </RedundantCast>
   </file>
   <file src="src/Content/Parser/SiteConfigParser.php">
-    <MixedArgument>
-      <code><![CDATA[$data]]></code>
-    </MixedArgument>
     <MixedArgumentTypeCoercion>
       <code><![CDATA[isset($data['params']) && is_array($data['params'])
                 ? $data['params']

--- a/src/Console/BuildCommand.php
+++ b/src/Console/BuildCommand.php
@@ -36,6 +36,7 @@ use YiiPress\Content\Model\Navigation;
 use YiiPress\Content\Model\SiteConfig;
 use YiiPress\Content\I18n\TranslationIndex;
 use YiiPress\Content\Parser\ContentParser;
+use YiiPress\Content\Parser\InvalidContentConfigException;
 use YiiPress\Content\PermalinkResolver;
 use YiiPress\Content\Related\RelatedIndex;
 use YiiPress\Content\TaxonomyCollector;
@@ -56,9 +57,11 @@ use RuntimeException;
 use SplFileInfo;
 use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Formatter\OutputFormatter;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
+use Yiisoft\FriendlyException\FriendlyExceptionInterface;
 use Yiisoft\Yii\Console\ExitCode;
 
 use function count;
@@ -319,14 +322,21 @@ final class BuildCommand extends Command
         $profile->switchTo('parse content');
 
         $parser = new ContentParser();
-        $siteConfig = $parser->parseSiteConfig($contentDir);
-        $this->contentPipeline->applySiteConfig($siteConfig);
-        $this->feedPipeline->applySiteConfig($siteConfig);
-        $navigation = $parser->parseNavigation($contentDir);
-        $collections = $parser->parseCollections($contentDir);
-        $rootCollection = $parser->parseRootCollection($contentDir);
-        $authors = iterator_to_array($parser->parseAuthors($contentDir));
-        $parser->setAuthors($authors);
+        try {
+            $siteConfig = $parser->parseSiteConfig($contentDir);
+            $this->contentPipeline->applySiteConfig($siteConfig);
+            $this->feedPipeline->applySiteConfig($siteConfig);
+            $navigation = $parser->parseNavigation($contentDir);
+            $collections = $parser->parseCollections($contentDir);
+            $rootCollection = $parser->parseRootCollection($contentDir);
+            $authors = iterator_to_array($parser->parseAuthors($contentDir));
+            $parser->setAuthors($authors);
+        } catch (FriendlyExceptionInterface $e) {
+            $this->writeFriendlyException($output, $e);
+            $this->writeProfile($output, $profile);
+
+            return ExitCode::DATAERR;
+        }
 
         $assetManifest = null;
 
@@ -830,6 +840,27 @@ final class BuildCommand extends Command
         }
 
         return sprintf('%.1fms', round($milliseconds, 1));
+    }
+
+    private function writeFriendlyException(OutputInterface $output, FriendlyExceptionInterface $e): void
+    {
+        $output->writeln('<error>' . OutputFormatter::escape($e->getName()) . '</error>');
+
+        if ($e instanceof InvalidContentConfigException) {
+            $output->writeln('  <comment>File:</comment> ' . OutputFormatter::escape($e->filePath()));
+        }
+
+        $output->writeln('  <comment>Problem:</comment> ' . OutputFormatter::escape($e->getMessage()));
+
+        $solution = $e->getSolution();
+        if ($solution === null || trim($solution) === '') {
+            return;
+        }
+
+        $output->writeln('  <comment>Solution:</comment>');
+        foreach (explode("\n", trim($solution)) as $line) {
+            $output->writeln('    ' . OutputFormatter::escape($line));
+        }
     }
 
     private function writeProfile(OutputInterface $output, BuildProfile $profile): void

--- a/src/Content/Parser/CollectionConfigParser.php
+++ b/src/Content/Parser/CollectionConfigParser.php
@@ -5,9 +5,10 @@ declare(strict_types=1);
 namespace YiiPress\Content\Parser;
 
 use YiiPress\Content\Model\Collection;
-use RuntimeException;
 
+use function array_is_list;
 use function file_get_contents;
+use function implode;
 use function is_array;
 use function yaml_parse;
 
@@ -17,12 +18,32 @@ final class CollectionConfigParser
     {
         $content = file_get_contents($filePath);
         if ($content === false) {
-            throw new RuntimeException("Cannot read file: $filePath");
+            throw new InvalidContentConfigException(
+                "Cannot read collection configuration file: $filePath",
+                $filePath,
+                'Check that the file exists and is readable by the build process.',
+            );
         }
 
         $data = yaml_parse($content);
         if ($data === false) {
-            throw new RuntimeException("Invalid YAML in file: $filePath");
+            throw new InvalidContentConfigException(
+                "Invalid YAML in collection configuration file: $filePath",
+                $filePath,
+                "Fix the YAML syntax in $filePath, then run the build again.",
+            );
+        }
+
+        if (!is_array($data) || array_is_list($data)) {
+            throw new InvalidContentConfigException(
+                'The collection configuration file must contain YAML key-value pairs.',
+                $filePath,
+                implode("\n", [
+                    'Use mappings such as:',
+                    'title: Blog',
+                    'permalink: /blog/:slug/',
+                ]),
+            );
         }
 
         return new Collection(

--- a/src/Content/Parser/InvalidContentConfigException.php
+++ b/src/Content/Parser/InvalidContentConfigException.php
@@ -1,0 +1,34 @@
+<?php
+
+declare(strict_types=1);
+
+namespace YiiPress\Content\Parser;
+
+use RuntimeException;
+use Yiisoft\FriendlyException\FriendlyExceptionInterface;
+
+final class InvalidContentConfigException extends RuntimeException implements FriendlyExceptionInterface
+{
+    public function __construct(
+        string $message,
+        private readonly string $filePath,
+        private readonly ?string $solution = null,
+    ) {
+        parent::__construct($message);
+    }
+
+    public function getName(): string
+    {
+        return 'Invalid content configuration';
+    }
+
+    public function getSolution(): ?string
+    {
+        return $this->solution;
+    }
+
+    public function filePath(): string
+    {
+        return $this->filePath;
+    }
+}

--- a/src/Content/Parser/NavigationParser.php
+++ b/src/Content/Parser/NavigationParser.php
@@ -6,11 +6,12 @@ namespace YiiPress\Content\Parser;
 
 use YiiPress\Content\Model\Navigation;
 use YiiPress\Content\Model\NavigationItem;
-use RuntimeException;
 
 use function array_filter;
+use function array_is_list;
 use function explode;
 use function file_get_contents;
+use function implode;
 use function is_array;
 use function is_scalar;
 use function reset;
@@ -24,12 +25,33 @@ final class NavigationParser
     {
         $content = file_get_contents($filePath);
         if ($content === false) {
-            throw new RuntimeException("Cannot read file: $filePath");
+            throw new InvalidContentConfigException(
+                "Cannot read navigation configuration file: $filePath",
+                $filePath,
+                'Check that the file exists and is readable by the build process.',
+            );
         }
 
         $data = yaml_parse($content);
         if ($data === false) {
-            throw new RuntimeException("Invalid YAML in file: $filePath");
+            throw new InvalidContentConfigException(
+                "Invalid YAML in navigation configuration file: $filePath",
+                $filePath,
+                "Fix the YAML syntax in $filePath, then run the build again.",
+            );
+        }
+
+        if (!is_array($data) || array_is_list($data)) {
+            throw new InvalidContentConfigException(
+                'The navigation configuration file must contain YAML key-value pairs.',
+                $filePath,
+                implode("\n", [
+                    'Use menu mappings such as:',
+                    'main:',
+                    '  - title: Home',
+                    '    url: /',
+                ]),
+            );
         }
 
         $menus = [];

--- a/src/Content/Parser/SiteConfigParser.php
+++ b/src/Content/Parser/SiteConfigParser.php
@@ -12,10 +12,12 @@ use YiiPress\Content\Model\RobotsTxtConfig;
 use YiiPress\Content\Model\RobotsTxtRule;
 use YiiPress\Content\Model\SearchConfig;
 use YiiPress\Content\Model\SiteConfig;
-use RuntimeException;
 
+use function array_is_list;
 use function file_get_contents;
+use function implode;
 use function is_array;
+use function is_string;
 use function trim;
 use function yaml_parse;
 
@@ -25,15 +27,35 @@ final class SiteConfigParser
     {
         $content = file_get_contents($filePath);
         if ($content === false) {
-            throw new RuntimeException("Cannot read file: $filePath");
+            throw new InvalidContentConfigException(
+                "Cannot read site configuration file: $filePath",
+                $filePath,
+                'Check that the file exists and is readable by the build process.',
+            );
         }
 
         $data = yaml_parse($content);
         if ($data === false) {
-            throw new RuntimeException("Invalid YAML in file: $filePath");
+            throw new InvalidContentConfigException(
+                "Invalid YAML in site configuration file: $filePath",
+                $filePath,
+                'Fix the YAML syntax in content/config.yaml, then run the build again.',
+            );
         }
 
-        $i18n = self::parseI18nConfig($data);
+        if (!is_array($data) || array_is_list($data)) {
+            throw new InvalidContentConfigException(
+                'The site configuration file must contain YAML key-value pairs.',
+                $filePath,
+                implode("\n", [
+                    'Use mappings such as:',
+                    'title: My Site',
+                    'languages: [en]',
+                ]),
+            );
+        }
+
+        $i18n = self::parseI18nConfig($data, $filePath);
 
         return new SiteConfig(
             title: (string) ($data['title'] ?? ''),
@@ -163,19 +185,51 @@ final class SiteConfigParser
     /**
      * @param array<mixed, mixed> $data
      */
-    private static function parseI18nConfig(array $data): I18nConfig
+    private static function parseI18nConfig(array $data, string $filePath): I18nConfig
     {
-        if (!isset($data['languages']) || !is_array($data['languages'])) {
-            throw new RuntimeException('The "languages" option must be a non-empty list.');
+        if (!isset($data['languages'])) {
+            throw self::invalidLanguages($filePath);
         }
 
-        $languages = array_values(array_unique(array_map(strval(...), $data['languages'])));
+        if (!is_array($data['languages']) || !array_is_list($data['languages'])) {
+            throw self::invalidLanguages($filePath);
+        }
 
+        $languages = [];
+        foreach ($data['languages'] as $language) {
+            if (!is_string($language)) {
+                throw self::invalidLanguages($filePath);
+            }
+
+            $language = trim($language);
+            if ($language === '') {
+                throw self::invalidLanguages($filePath);
+            }
+
+            $languages[] = $language;
+        }
+
+        $languages = array_values(array_unique($languages));
         if ($languages === []) {
-            throw new RuntimeException('The "languages" option must be a non-empty list.');
+            throw self::invalidLanguages($filePath);
         }
 
         return new I18nConfig(languages: $languages, defaultLanguage: $languages[0]);
+    }
+
+    private static function invalidLanguages(string $filePath): InvalidContentConfigException
+    {
+        return new InvalidContentConfigException(
+            'The "languages" option in site configuration must be a non-empty list of language codes.',
+            $filePath,
+            implode("\n", [
+                'Add at least one language to content/config.yaml:',
+                'languages: [en]',
+                'For multiple languages, put the default language first:',
+                'languages: [en, ru]',
+                'If you currently have i18n.languages, move it to the top-level languages option.',
+            ]),
+        );
     }
 
     private static function parseRelatedConfig(mixed $data): ?RelatedConfig

--- a/tests/Unit/Console/BuildCommandTest.php
+++ b/tests/Unit/Console/BuildCommandTest.php
@@ -24,6 +24,7 @@ use Symfony\Component\Console\Tester\CommandTester;
 use Yiisoft\EventDispatcher\Dispatcher\Dispatcher;
 use Yiisoft\EventDispatcher\Provider\ListenerCollection;
 use Yiisoft\EventDispatcher\Provider\Provider;
+use Yiisoft\Yii\Console\ExitCode;
 
 use function PHPUnit\Framework\assertDirectoryExists;
 use function PHPUnit\Framework\assertFalse;
@@ -140,6 +141,40 @@ final class BuildCommandTest extends TestCase
         assertSame(0, $exitCode, $tester->getDisplay());
         assertSame(['build.started:Hook Site', 'build.finished:' . $outputDir], $events);
         assertFileExists($outputDir . '/index/index.html');
+    }
+
+    public function testBuildReportsInvalidSiteConfigWithoutTrace(): void
+    {
+        $tempDir = sys_get_temp_dir() . '/yiipress-build-invalid-config-test-' . uniqid();
+        $contentDir = $tempDir . '/content';
+        $outputDir = $tempDir . '/output';
+        mkdir($contentDir, 0o755, true);
+        $this->tempContentDirs[] = $tempDir;
+
+        file_put_contents($contentDir . '/config.yaml', "title: Broken Site\n");
+        file_put_contents($contentDir . '/index.md', "---\ntitle: Home\n---\n\nHello.\n");
+
+        $yii = dirname(__DIR__, 3) . '/yii';
+        exec(
+            $yii . ' build'
+            . ' --content-dir=' . escapeshellarg($contentDir)
+            . ' --output-dir=' . escapeshellarg($outputDir)
+            . ' --no-cache'
+            . ' 2>&1',
+            $output,
+            $exitCode,
+        );
+
+        $outputText = implode("\n", $output);
+
+        assertSame(ExitCode::DATAERR, $exitCode, $outputText);
+        assertStringContainsString('Invalid content configuration', $outputText);
+        assertStringContainsString('Problem: The "languages" option in site configuration must be a non-empty list of language codes.', $outputText);
+        assertStringContainsString('languages: [en]', $outputText);
+        assertStringContainsString('If you currently have i18n.languages, move it to the top-level languages option.', $outputText);
+        assertStringNotContainsString('Stack trace:', $outputText);
+        assertStringNotContainsString('RuntimeException:', $outputText);
+        assertStringNotContainsString('#0 ', $outputText);
     }
 
     public function testBuildOutputContainsRenderedHtml(): void

--- a/tests/Unit/Content/Parser/CollectionConfigParserTest.php
+++ b/tests/Unit/Content/Parser/CollectionConfigParserTest.php
@@ -5,11 +5,14 @@ declare(strict_types=1);
 namespace YiiPress\Tests\Unit\Content\Parser;
 
 use YiiPress\Content\Parser\CollectionConfigParser;
+use YiiPress\Content\Parser\InvalidContentConfigException;
 use PHPUnit\Framework\TestCase;
 
 use function PHPUnit\Framework\assertFalse;
 use function PHPUnit\Framework\assertSame;
+use function PHPUnit\Framework\assertStringContainsString;
 use function PHPUnit\Framework\assertTrue;
+use function PHPUnit\Framework\fail;
 
 final class CollectionConfigParserTest extends TestCase
 {
@@ -63,6 +66,24 @@ final class CollectionConfigParserTest extends TestCase
             $collection = (new CollectionConfigParser())->parse($file, 'docs');
 
             assertTrue($collection->navigationPager);
+        } finally {
+            unlink($file);
+        }
+    }
+
+    public function testThrowsFriendlyExceptionWhenConfigIsNotMapping(): void
+    {
+        $file = tempnam(sys_get_temp_dir(), 'yiipress-collection-');
+        self::assertNotFalse($file);
+        file_put_contents($file, "- title\n");
+
+        try {
+            (new CollectionConfigParser())->parse($file, 'blog');
+            fail('Expected invalid content configuration exception.');
+        } catch (InvalidContentConfigException $e) {
+            assertSame('Invalid content configuration', $e->getName());
+            assertSame('The collection configuration file must contain YAML key-value pairs.', $e->getMessage());
+            assertStringContainsString('permalink: /blog/:slug/', (string) $e->getSolution());
         } finally {
             unlink($file);
         }

--- a/tests/Unit/Content/Parser/NavigationParserTest.php
+++ b/tests/Unit/Content/Parser/NavigationParserTest.php
@@ -4,11 +4,14 @@ declare(strict_types=1);
 
 namespace YiiPress\Tests\Unit\Content\Parser;
 
+use YiiPress\Content\Parser\InvalidContentConfigException;
 use YiiPress\Content\Parser\NavigationParser;
 use PHPUnit\Framework\TestCase;
 
 use function PHPUnit\Framework\assertCount;
 use function PHPUnit\Framework\assertSame;
+use function PHPUnit\Framework\assertStringContainsString;
+use function PHPUnit\Framework\fail;
 use function file_put_contents;
 use function sys_get_temp_dir;
 use function tempnam;
@@ -73,6 +76,23 @@ YAML);
             assertSame('About', $main[0]->title);
             assertSame(['en' => 'About', 'ru' => 'О сайте'], $main[0]->titles);
             assertSame('О сайте', $main[0]->resolveTitle('ru', 'en'));
+        } finally {
+            unlink($file);
+        }
+    }
+
+    public function testThrowsFriendlyExceptionWhenConfigIsNotMapping(): void
+    {
+        $file = tempnam(sys_get_temp_dir(), 'yiipress-nav-');
+        file_put_contents($file, "- title\n");
+
+        try {
+            (new NavigationParser())->parse($file);
+            fail('Expected invalid content configuration exception.');
+        } catch (InvalidContentConfigException $e) {
+            assertSame('Invalid content configuration', $e->getName());
+            assertSame('The navigation configuration file must contain YAML key-value pairs.', $e->getMessage());
+            assertStringContainsString('main:', (string) $e->getSolution());
         } finally {
             unlink($file);
         }

--- a/tests/Unit/Content/Parser/SiteConfigParserTest.php
+++ b/tests/Unit/Content/Parser/SiteConfigParserTest.php
@@ -4,13 +4,16 @@ declare(strict_types=1);
 
 namespace YiiPress\Tests\Unit\Content\Parser;
 
+use YiiPress\Content\Parser\InvalidContentConfigException;
 use YiiPress\Content\Parser\SiteConfigParser;
 use PHPUnit\Framework\TestCase;
 
 use function PHPUnit\Framework\assertSame;
 use function PHPUnit\Framework\assertFalse;
 use function PHPUnit\Framework\assertNotNull;
+use function PHPUnit\Framework\assertStringContainsString;
 use function PHPUnit\Framework\assertTrue;
+use function PHPUnit\Framework\fail;
 
 final class SiteConfigParserTest extends TestCase
 {
@@ -137,9 +140,35 @@ final class SiteConfigParserTest extends TestCase
         $filePath = sys_get_temp_dir() . '/yiipress-site-config-' . uniqid() . '.yaml';
         file_put_contents($filePath, "title: Test\n");
 
-        $this->expectException(\RuntimeException::class);
-        $this->expectExceptionMessage('The "languages" option must be a non-empty list.');
+        try {
+            (new SiteConfigParser())->parse($filePath);
+            fail('Expected invalid content configuration exception.');
+        } catch (InvalidContentConfigException $e) {
+            assertSame('Invalid content configuration', $e->getName());
+            assertSame($filePath, $e->filePath());
+            assertSame(
+                'The "languages" option in site configuration must be a non-empty list of language codes.',
+                $e->getMessage(),
+            );
+            assertStringContainsString('languages: [en]', (string) $e->getSolution());
+        } finally {
+            unlink($filePath);
+        }
+    }
 
-        (new SiteConfigParser())->parse($filePath);
+    public function testThrowsFriendlyExceptionWhenConfigIsNotMapping(): void
+    {
+        $filePath = sys_get_temp_dir() . '/yiipress-site-config-' . uniqid() . '.yaml';
+        file_put_contents($filePath, "- title\n");
+
+        try {
+            (new SiteConfigParser())->parse($filePath);
+            fail('Expected invalid content configuration exception.');
+        } catch (InvalidContentConfigException $e) {
+            assertSame('The site configuration file must contain YAML key-value pairs.', $e->getMessage());
+            assertStringContainsString('title: My Site', (string) $e->getSolution());
+        } finally {
+            unlink($filePath);
+        }
     }
 }


### PR DESCRIPTION
## Summary
- add a friendly content config exception using yiisoft/friendly-exception
- render friendly parser errors in build without stack traces
- validate site, collection, and navigation YAML config shape with actionable solutions
- document the friendly config error behavior

## Tests
- make -- test --filter SiteConfigParserTest
- make -- test --filter CollectionConfigParserTest
- make -- test --filter NavigationParserTest
- make -- test --filter BuildCommandTest
- make -- composer validate --no-check-publish --no-check-lock
- make -- psalm

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Build command now displays user-friendly error messages for invalid content configuration files, including suggested fixes, instead of technical stack traces.

* **Documentation**
  * Added guidance on build behavior when content configuration files are missing required values or contain invalid YAML syntax.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->