### PR TITLE
Fix root-relative URLs for subdirectory deployments

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -203,6 +203,8 @@ When enabled, YiiPress renames copied assets to include a content hash, for exam
 
 Built-in templates use the fingerprinted URLs automatically, and existing hardcoded `src` / `href`
 asset references in rendered HTML are rewritten during build so custom themes continue to work.
+Root-relative local asset references are treated as YiiPress site-root paths and emitted relative to
+the current output page, so they remain valid when `base_url` contains a deployment path.
 
 ### Editor
 

--- a/docs/content.md
+++ b/docs/content.md
@@ -117,7 +117,7 @@ extra:
 - **theme** — theme name for this entry; overrides the site-level default (see [Templates](templates.md))
 - **weight** — integer for custom sorting in non-blog collections (lower = first)
 - **language** — language code for multilingual content (e.g., `en`, `ru`)
-- **redirect_to** — URL to redirect to; generates a redirect HTML page (with `<meta http-equiv="refresh">`, JS `window.location.replace()`, and `<link rel="canonical">`) instead of rendering content. Redirect entries are excluded from feeds, sitemaps, listings, archives, and taxonomy pages
+- **redirect_to** — URL to redirect to; generates a redirect HTML page (with `<meta http-equiv="refresh">`, JS `window.location.replace()`, and `<link rel="canonical">`) instead of rendering content. Redirect entries are excluded from feeds, sitemaps, listings, archives, and taxonomy pages. Root-relative targets such as `/new-url/` are YiiPress site-root paths; when `base_url` includes a deployment path, YiiPress prefixes that path in the generated redirect target. Absolute URLs are emitted unchanged
 - **extra** — arbitrary key-value pairs accessible in templates
 
 ### Internal links
@@ -341,13 +341,16 @@ content/blog/assets/
 └── getting-started-screenshot.png
 ```
 
-Reference assets from markdown using absolute paths:
+Reference assets from markdown using site-root paths:
 
 ```markdown
 ![Banner](/blog/assets/hello-world-banner.svg)
 ```
 
 All `assets/` directories are copied to the build output preserving their path structure.
+When asset fingerprinting is enabled, these root-relative asset paths are rewritten relative to each
+generated page, which keeps them valid for deployments under a subdirectory such as GitHub Pages
+project sites.
 
 The project-level `assets/` directory (outside `content/`) is for build-time assets
 (CSS, JS) processed by the asset pipeline. Content assets are separate and copied as-is.

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -88,6 +88,8 @@ Enable GitHub Pages in your repository settings: go to **Settings → Pages** an
 
 > **Tip:** Replace `X.Y.Z` with a real YiiPress version tag for reproducible, stable builds. The action builds to `_site` by default for GitHub Pages. See [GitHub Actions](github-actions.md) for custom output directories and other inputs.
 
+For project sites such as `https://user.github.io/project/`, set `base_url` to the full deployed URL including the project path. YiiPress uses that path when rendering root-relative redirect targets, so `redirect_to: /blog/` points to `/project/blog/` in browser-facing redirect HTML. Root-relative local asset links in rendered HTML are emitted relative to each page so images and other copied assets stay valid under the same deployment path.
+
 > **Real-world example:** YiiPress documentation is built from the nightly binary image after the package workflow succeeds — see [`.github/workflows/build-docs.yml`](https://github.com/yiipress/engine/blob/master/.github/workflows/build-docs.yml) in this repository. Site repositories should use the release action above with a fixed version.
 
 ## Cloudflare Pages

--- a/roadmap.md
+++ b/roadmap.md
@@ -74,6 +74,7 @@
 
 - [x] Asset fingerprinting / cache busting
 - [x] Static file copying (fonts, downloads, PDFs from source to output)
+- [x] Root-relative asset URLs stay valid when deploying under a subdirectory
 
 ## Priority 6: SEO and web standards
 
@@ -81,6 +82,7 @@
 - [x] Canonical URL support
 - [x] Configurable `robots.txt` generation
 - [x] Redirect support (e.g., when changing permalinks, output redirect HTML or config)
+- [x] Root-relative redirects resolve against deployment paths from `base_url`
 - [x] 404 page in static build output for static hosting providers (Netlify, GitHub Pages, etc.)
 - [x] Deployment helpers/docs for common static hosts (GitHub Pages, Netlify, Vercel, Cloudflare Pages)
 

--- a/src/Build/AssetUrlRewriter.php
+++ b/src/Build/AssetUrlRewriter.php
@@ -100,7 +100,7 @@ final readonly class AssetUrlRewriter
     private function extractLogicalPath(string $path, string $rootPath): array
     {
         if (str_starts_with($path, '/')) {
-            return ['/', AssetFingerprintManifest::normalizePath($path)];
+            return ['', AssetFingerprintManifest::normalizePath($path)];
         }
 
         if ($rootPath !== '' && $rootPath !== '/' && str_starts_with($path, $rootPath)) {

--- a/src/Build/PublicUrlResolver.php
+++ b/src/Build/PublicUrlResolver.php
@@ -1,0 +1,150 @@
+<?php
+
+declare(strict_types=1);
+
+namespace YiiPress\Build;
+
+use YiiPress\Content\Model\SiteConfig;
+
+use function is_int;
+use function is_string;
+use function ltrim;
+use function parse_url;
+use function rtrim;
+use function str_contains;
+use function str_ends_with;
+use function str_starts_with;
+use function strtolower;
+use function substr;
+use function trim;
+
+final class PublicUrlResolver
+{
+    public static function browserUrl(SiteConfig $siteConfig, string $url): string
+    {
+        if (!self::isSiteRootPath($url)) {
+            return $url;
+        }
+
+        $basePath = self::basePath($siteConfig);
+        if ($basePath === '') {
+            return $url;
+        }
+
+        return self::joinPaths('/' . $basePath . '/', $url);
+    }
+
+    public static function absoluteUrl(SiteConfig $siteConfig, string $url): string
+    {
+        if ($url === '') {
+            return '';
+        }
+
+        if (self::isAbsoluteUrl($url)) {
+            return $url;
+        }
+
+        $baseOrigin = self::baseOrigin($siteConfig);
+        if ($baseOrigin === '') {
+            return self::browserUrl($siteConfig, $url);
+        }
+
+        if (self::isSiteRootPath($url)) {
+            return $baseOrigin . self::browserUrl($siteConfig, $url);
+        }
+
+        $basePath = self::basePath($siteConfig);
+        return $baseOrigin . self::joinPaths('/' . $basePath . '/', $url);
+    }
+
+    public static function isSamePublicUrl(SiteConfig $siteConfig, string $sourcePermalink, string $targetUrl): bool
+    {
+        $source = self::absoluteUrl($siteConfig, $sourcePermalink);
+        if ($source === '') {
+            $source = $sourcePermalink;
+        }
+
+        return self::normalizeForCompare($source) === self::normalizeForCompare(self::absoluteUrl($siteConfig, $targetUrl));
+    }
+
+    private static function isSiteRootPath(string $url): bool
+    {
+        return str_starts_with($url, '/') && !str_starts_with($url, '//');
+    }
+
+    private static function isAbsoluteUrl(string $url): bool
+    {
+        return str_contains($url, '://') || str_starts_with($url, '//');
+    }
+
+    private static function basePath(SiteConfig $siteConfig): string
+    {
+        if ($siteConfig->baseUrl === '') {
+            return '';
+        }
+
+        return trim(self::parseStringComponent($siteConfig->baseUrl, PHP_URL_PATH), '/');
+    }
+
+    private static function baseOrigin(SiteConfig $siteConfig): string
+    {
+        if ($siteConfig->baseUrl === '') {
+            return '';
+        }
+
+        $scheme = self::parseStringComponent($siteConfig->baseUrl, PHP_URL_SCHEME);
+        $host = self::parseStringComponent($siteConfig->baseUrl, PHP_URL_HOST);
+        if ($scheme === '' || $host === '') {
+            return '';
+        }
+
+        $port = parse_url($siteConfig->baseUrl, PHP_URL_PORT);
+        return $scheme . '://' . $host . (is_int($port) ? ':' . $port : '');
+    }
+
+    private static function parseStringComponent(string $url, int $component): string
+    {
+        $value = parse_url($url, $component);
+
+        return is_string($value) ? $value : '';
+    }
+
+    private static function joinPaths(string $basePath, string $path): string
+    {
+        $joined = '/' . trim($basePath, '/') . '/' . ltrim($path, '/');
+        if (str_ends_with($path, '/') && !str_ends_with($joined, '/')) {
+            $joined .= '/';
+        }
+
+        return $joined;
+    }
+
+    private static function normalizeForCompare(string $url): string
+    {
+        if ($url === '') {
+            return '';
+        }
+
+        $fragmentPosition = strpos($url, '#');
+        if ($fragmentPosition !== false) {
+            $url = substr($url, 0, $fragmentPosition);
+        }
+
+        $parts = parse_url($url);
+        if ($parts === false) {
+            return rtrim($url, '/') ?: '/';
+        }
+
+        $scheme = isset($parts['scheme']) ? strtolower($parts['scheme']) . '://' : '';
+        $host = isset($parts['host']) ? strtolower($parts['host']) : '';
+        $port = isset($parts['port']) ? ':' . $parts['port'] : '';
+        $path = $parts['path'] ?? '/';
+        if (str_ends_with($path, '/index.html')) {
+            $path = substr($path, 0, -10);
+        }
+        $path = rtrim($path, '/') ?: '/';
+        $query = isset($parts['query']) ? '?' . $parts['query'] : '';
+
+        return $scheme . $host . $port . $path . $query;
+    }
+}

--- a/src/Build/RedirectPageWriter.php
+++ b/src/Build/RedirectPageWriter.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace YiiPress\Build;
 
 use YiiPress\Content\Model\Entry;
+use YiiPress\Content\Model\SiteConfig;
 use YiiPress\I18n\UiText;
 use RuntimeException;
 
@@ -14,10 +15,27 @@ use function json_encode;
 
 final class RedirectPageWriter
 {
-    public function write(Entry $entry, string $filePath, string $language = 'en', ?UiText $ui = null, bool $noWrite = false): void
-    {
+    public function write(
+        Entry $entry,
+        string $filePath,
+        string $language = 'en',
+        ?UiText $ui = null,
+        bool $noWrite = false,
+        ?SiteConfig $siteConfig = null,
+        string $sourcePermalink = '',
+    ): void {
         $htmlLanguage = $language !== '' ? $language : 'en';
-        $target = $entry->redirectTo;
+        if ($siteConfig !== null && $sourcePermalink !== '' && PublicUrlResolver::isSamePublicUrl($siteConfig, $sourcePermalink, $entry->redirectTo)) {
+            throw new RuntimeException(sprintf(
+                'Redirect from "%s" to "%s" resolves to the same public URL.',
+                $sourcePermalink,
+                $entry->redirectTo,
+            ));
+        }
+
+        $target = $siteConfig !== null
+            ? PublicUrlResolver::browserUrl($siteConfig, $entry->redirectTo)
+            : $entry->redirectTo;
         $targetEscaped = htmlspecialchars($target, ENT_QUOTES | ENT_SUBSTITUTE, 'UTF-8');
         $targetJson = json_encode($target, JSON_THROW_ON_ERROR);
         $ui ??= UiText::for($htmlLanguage);

--- a/src/Console/BuildCommand.php
+++ b/src/Console/BuildCommand.php
@@ -429,7 +429,7 @@ final class BuildCommand extends Command
                 $filePath = $outputDir . $permalink . 'index.html';
 
                 if ($entry->redirectTo !== '') {
-                    $redirectTasks[] = ['entry' => $entry, 'filePath' => $filePath, 'sourcePath' => $sourcePath];
+                    $redirectTasks[] = ['entry' => $entry, 'filePath' => $filePath, 'permalink' => $permalink, 'sourcePath' => $sourcePath];
                     continue;
                 }
 
@@ -506,6 +506,8 @@ final class BuildCommand extends Command
                     $language,
                     UiText::forTheme($siteConfig->defaultLanguage, $this->templateResolver, $siteConfig->theme, $siteConfig->defaultLanguage),
                     $noWrite,
+                    $siteConfig,
+                    $task['permalink'],
                 );
             }
             $output->writeln('  Redirects ' . ($noWrite ? 'rendered' : 'written') . ': <comment>' . count($redirectTasks) . '</comment>');
@@ -549,7 +551,7 @@ final class BuildCommand extends Command
             }
 
             if ($page->redirectTo !== '') {
-                $standaloneRedirectTasks[] = ['entry' => $page, 'filePath' => $filePath, 'sourcePath' => $sourcePath];
+                $standaloneRedirectTasks[] = ['entry' => $page, 'filePath' => $filePath, 'permalink' => $permalink, 'sourcePath' => $sourcePath];
             } else {
                 $standaloneTask = [
                     'entry' => $page,
@@ -586,6 +588,8 @@ final class BuildCommand extends Command
                 $language,
                 UiText::forTheme($siteConfig->defaultLanguage, $this->templateResolver, $siteConfig->theme, $siteConfig->defaultLanguage),
                 $noWrite,
+                $siteConfig,
+                $task['permalink'],
             );
         }
         $standalonePagesWritten += count($standaloneRedirectTasks);

--- a/tests/Unit/Build/AssetFingerprintManifestTest.php
+++ b/tests/Unit/Build/AssetFingerprintManifestTest.php
@@ -57,7 +57,21 @@ final class AssetFingerprintManifestTest extends TestCase
         $absolute = $rewriter->rewrite('<link href="/assets/theme/style.css">', '../../');
 
         assertSame('<link href="../../' . $fingerprinted . '">', $relative);
-        assertSame('<link href="/' . $fingerprinted . '">', $absolute);
+        assertSame('<link href="../../' . $fingerprinted . '">', $absolute);
+    }
+
+    public function testRewriterRelativizesRootRelativeContentAssetUrls(): void
+    {
+        $source = $this->tempDir . '/photo.jpg';
+        file_put_contents($source, 'jpg');
+
+        $manifest = new AssetFingerprintManifest();
+        $fingerprinted = $manifest->register('blog/assets/photo.jpg', $source);
+        $rewriter = new AssetUrlRewriter($manifest);
+
+        $html = $rewriter->rewrite('<img src="/blog/assets/photo.jpg">', '../../');
+
+        assertSame('<img src="../../' . $fingerprinted . '">', $html);
     }
 
     public function testRewriterPrefixesUnqualifiedAssetUrlsWithRootPath(): void

--- a/tests/Unit/Build/PublicUrlResolverTest.php
+++ b/tests/Unit/Build/PublicUrlResolverTest.php
@@ -1,0 +1,62 @@
+<?php
+
+declare(strict_types=1);
+
+namespace YiiPress\Tests\Unit\Build;
+
+use YiiPress\Build\PublicUrlResolver;
+use YiiPress\Content\Model\SiteConfig;
+use PHPUnit\Framework\TestCase;
+
+use function PHPUnit\Framework\assertFalse;
+use function PHPUnit\Framework\assertSame;
+use function PHPUnit\Framework\assertTrue;
+
+final class PublicUrlResolverTest extends TestCase
+{
+    public function testPrefixesSiteRootUrlWithBasePath(): void
+    {
+        $siteConfig = $this->createSiteConfig('https://example.github.io/blog/');
+
+        assertSame('/blog/posts/', PublicUrlResolver::browserUrl($siteConfig, '/posts/'));
+    }
+
+    public function testLeavesSiteRootUrlAloneWhenBaseUrlHasNoPath(): void
+    {
+        $siteConfig = $this->createSiteConfig('https://example.com/');
+
+        assertSame('/posts/', PublicUrlResolver::browserUrl($siteConfig, '/posts/'));
+    }
+
+    public function testLeavesAbsoluteUrlAlone(): void
+    {
+        $siteConfig = $this->createSiteConfig('https://example.github.io/blog/');
+
+        assertSame('https://other.example/posts/', PublicUrlResolver::browserUrl($siteConfig, 'https://other.example/posts/'));
+    }
+
+    public function testDetectsSelfRedirectAfterBasePathResolution(): void
+    {
+        $siteConfig = $this->createSiteConfig('https://example.github.io/blog/');
+
+        assertTrue(PublicUrlResolver::isSamePublicUrl($siteConfig, '/', '/'));
+        assertFalse(PublicUrlResolver::isSamePublicUrl($siteConfig, '/', '/blog/'));
+    }
+
+    private function createSiteConfig(string $baseUrl): SiteConfig
+    {
+        return new SiteConfig(
+            title: 'Test Site',
+            description: '',
+            baseUrl: $baseUrl,
+            defaultLanguage: 'en',
+            charset: 'UTF-8',
+            defaultAuthor: '',
+            dateFormat: 'Y-m-d',
+            entriesPerPage: 10,
+            permalink: '/:collection/:slug/',
+            taxonomies: [],
+            params: [],
+        );
+    }
+}

--- a/tests/Unit/Build/RedirectPageWriterTest.php
+++ b/tests/Unit/Build/RedirectPageWriterTest.php
@@ -9,10 +9,12 @@ use YiiPress\Build\Theme;
 use YiiPress\Build\ThemeRegistry;
 use YiiPress\Build\RedirectPageWriter;
 use YiiPress\Content\Model\Entry;
+use YiiPress\Content\Model\SiteConfig;
 use YiiPress\I18n\UiText;
 use DateTimeImmutable;
 use FilesystemIterator;
 use PHPUnit\Framework\TestCase;
+use RuntimeException;
 
 use RecursiveDirectoryIterator;
 use RecursiveIteratorIterator;
@@ -122,6 +124,40 @@ final class RedirectPageWriterTest extends TestCase
         assertStringContainsString('Эта страница переехала.', $html);
     }
 
+    public function testPrefixesSiteRootRedirectWithBaseUrlPath(): void
+    {
+        $entry = $this->createEntry(redirectTo: '/blog/');
+        $filePath = $this->outputDir . '/index.html';
+
+        new RedirectPageWriter()->write(
+            $entry,
+            $filePath,
+            siteConfig: $this->createSiteConfig('https://samdark.github.io/blog/'),
+            sourcePermalink: '/',
+        );
+
+        $html = file_get_contents($filePath);
+        assertStringContainsString('href="/blog/blog/"', $html);
+        assertStringContainsString('url=/blog/blog/', $html);
+        assertStringContainsString('window.location.replace("\\/blog\\/blog\\/")', $html);
+    }
+
+    public function testRejectsSelfRedirectAfterBaseUrlPathResolution(): void
+    {
+        $entry = $this->createEntry(redirectTo: '/');
+        $filePath = $this->outputDir . '/index.html';
+
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessage('Redirect from "/" to "/" resolves to the same public URL.');
+
+        new RedirectPageWriter()->write(
+            $entry,
+            $filePath,
+            siteConfig: $this->createSiteConfig('https://samdark.github.io/blog/'),
+            sourcePermalink: '/',
+        );
+    }
+
     private function createEntry(string $redirectTo): Entry
     {
         $file = $this->outputDir . '/entry.md';
@@ -147,6 +183,23 @@ final class RedirectPageWriterTest extends TestCase
             extra: [],
             bodyOffset: 0,
             bodyLength: 0,
+        );
+    }
+
+    private function createSiteConfig(string $baseUrl): SiteConfig
+    {
+        return new SiteConfig(
+            title: 'Test Site',
+            description: '',
+            baseUrl: $baseUrl,
+            defaultLanguage: 'en',
+            charset: 'UTF-8',
+            defaultAuthor: '',
+            dateFormat: 'Y-m-d',
+            entriesPerPage: 10,
+            permalink: '/:collection/:slug/',
+            taxonomies: [],
+            params: [],
         );
     }
 

--- a/tests/Unit/Console/BuildCommandTest.php
+++ b/tests/Unit/Console/BuildCommandTest.php
@@ -1134,6 +1134,70 @@ PHP,
         assertStringNotContainsString('Old URL Post', $atom);
     }
 
+    public function testBuildPrefixesRedirectTargetWithBaseUrlPath(): void
+    {
+        $tempDir = sys_get_temp_dir() . '/yiipress-build-project-redirect-test-' . uniqid();
+        $contentDir = $tempDir . '/content';
+        $outputDir = $tempDir . '/output';
+        mkdir($contentDir, 0o755, true);
+        mkdir($contentDir . '/blog', 0o755, true);
+        $this->tempContentDirs[] = $tempDir;
+
+        file_put_contents($contentDir . '/config.yaml', "title: Project Site\nbase_url: https://samdark.github.io/blog/\nlanguages: [en]\n");
+        file_put_contents($contentDir . '/blog/_collection.yaml', "title: Blog\npermalink: /blog/:slug/\n");
+        file_put_contents($contentDir . '/index.md', "---\ntitle: Home\npermalink: /\nredirect_to: /blog/\n---\n");
+
+        $yii = dirname(__DIR__, 3) . '/yii';
+        exec(
+            $yii . ' build'
+            . ' --content-dir=' . escapeshellarg($contentDir)
+            . ' --output-dir=' . escapeshellarg($outputDir)
+            . ' --no-cache'
+            . ' 2>&1',
+            $output,
+            $exitCode,
+        );
+
+        assertSame(0, $exitCode, implode("\n", $output));
+
+        $html = file_get_contents($outputDir . '/index.html');
+        assertNotFalse($html);
+        assertStringContainsString('href="/blog/blog/"', $html);
+        assertStringContainsString('url=/blog/blog/', $html);
+    }
+
+    public function testBuildRewritesRootRelativeContentImageForSubdirectoryDeployment(): void
+    {
+        $tempDir = sys_get_temp_dir() . '/yiipress-build-project-image-test-' . uniqid();
+        $contentDir = $tempDir . '/content';
+        $outputDir = $tempDir . '/output';
+        mkdir($contentDir . '/blog/assets', 0o755, true);
+        $this->tempContentDirs[] = $tempDir;
+
+        file_put_contents($contentDir . '/config.yaml', "title: Project Site\nbase_url: https://samdark.github.io/blog/\nlanguages: [en]\n");
+        file_put_contents($contentDir . '/blog/_collection.yaml', "title: Blog\npermalink: /blog/:slug/\n");
+        file_put_contents($contentDir . '/blog/assets/photo.jpg', 'jpg');
+        file_put_contents($contentDir . '/blog/post.md', "---\ntitle: Post\nimage: /blog/assets/photo.jpg\n---\n\n![](/blog/assets/photo.jpg)\n");
+
+        $yii = dirname(__DIR__, 3) . '/yii';
+        exec(
+            $yii . ' build'
+            . ' --content-dir=' . escapeshellarg($contentDir)
+            . ' --output-dir=' . escapeshellarg($outputDir)
+            . ' --no-cache'
+            . ' 2>&1',
+            $output,
+            $exitCode,
+        );
+
+        assertSame(0, $exitCode, implode("\n", $output));
+
+        $html = file_get_contents($outputDir . '/blog/post/index.html');
+        assertNotFalse($html);
+        assertMatchesRegularExpression('~<img src="../../blog/assets/photo\.[a-f0-9]{12}\.jpg" alt="">~', $html);
+        assertStringContainsString('content="https://samdark.github.io/blog/blog/assets/photo.jpg"', $html);
+    }
+
     private function manifestPath(): string
     {
         return RuntimePaths::cachePath(dirname(__DIR__, 3)) . '/build-manifest-' . hash('xxh128', $this->outputDir) . '.json';


### PR DESCRIPTION
## Summary
- Resolve root-relative redirect targets against deployment paths from base_url and reject self-redirects after public URL resolution
- Rewrite root-relative fingerprinted asset URLs relative to the generated page so content images work under GitHub Pages project paths
- Document subdirectory deployment behavior for redirects and assets

## Tests
- make test
- make psalm
- make build-docs