### PR TITLE
Publish nightly binary for action builds

### DIFF
--- a/.github/actions/build/action.yml
+++ b/.github/actions/build/action.yml
@@ -3,7 +3,7 @@ description: Download the Linux YiiPress binary and build a static site.
 
 inputs:
   version:
-    description: YiiPress release tag to download, or "latest".
+    description: YiiPress release tag to download, "latest", or "nightly".
     required: false
     default: latest
   content-dir:

--- a/.github/workflows/package-static.yml
+++ b/.github/workflows/package-static.yml
@@ -22,7 +22,7 @@ jobs:
     name: Linux static binary, PHAR, and distroless image
     runs-on: ubuntu-latest
     permissions:
-      contents: read
+      contents: write
       packages: write
 
     steps:
@@ -88,6 +88,53 @@ jobs:
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
           platforms: linux/amd64
+
+      - name: Publish nightly Linux release
+        if: github.event_name != 'pull_request' && github.ref == 'refs/heads/master'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+
+          mkdir -p assets
+          tar -C dist/linux-amd64 -czf assets/yiipress-linux-amd64.tar.gz yiipress
+          sha256sum assets/yiipress-linux-amd64.tar.gz > assets/SHA256SUMS
+
+          {
+            printf '# Nightly\n\n'
+            printf 'Built from `%s` on `%s`.\n\n' "${GITHUB_SHA}" "${GITHUB_REF_NAME}"
+            printf '%s\n\n' 'This prerelease is updated after successful package builds on `master`.'
+            printf '%s\n' 'It is intended for testing unreleased YiiPress changes in site build workflows.'
+          } > nightly-release-notes.md
+
+          if gh api "repos/${GITHUB_REPOSITORY}/git/ref/tags/nightly" >/dev/null 2>&1; then
+            gh api \
+              --method PATCH \
+              "repos/${GITHUB_REPOSITORY}/git/refs/tags/nightly" \
+              -f sha="${GITHUB_SHA}" \
+              -F force=true >/dev/null
+          else
+            gh api \
+              --method POST \
+              "repos/${GITHUB_REPOSITORY}/git/refs" \
+              -f ref="refs/tags/nightly" \
+              -f sha="${GITHUB_SHA}" >/dev/null
+          fi
+
+          if gh release view nightly >/dev/null 2>&1; then
+            gh release upload nightly assets/* --clobber
+            gh release edit nightly \
+              --title "Nightly" \
+              --notes-file nightly-release-notes.md \
+              --prerelease
+          else
+            gh release create nightly assets/* \
+              --verify-tag \
+              --title "Nightly" \
+              --notes-file nightly-release-notes.md \
+              --prerelease \
+              --latest=false
+          fi
 
   windows:
     name: Windows static binary

--- a/docs/github-actions.md
+++ b/docs/github-actions.md
@@ -21,11 +21,15 @@ jobs:
           version: X.Y.Z
 ```
 
+For testing unreleased changes from the current `master` branch, use `version: nightly`.
+The nightly binary is mutable and intended for preview builds only; use a fixed release tag
+for production sites.
+
 The action accepts these inputs:
 
 | Input | Default | Description |
 |---|---|---|
-| `version` | `latest` | YiiPress release tag to download. Use a fixed tag such as `1.2.3` for stable builds. |
+| `version` | `latest` | YiiPress release tag to download. Use a fixed tag such as `1.2.3` for stable builds, or `nightly` to test the current master build. |
 | `content-dir` | `content` | Content directory passed to `yiipress build`. |
 | `output-dir` | `_site` | Output directory passed to `yiipress build`. Change it when the host expects a custom output directory. |
 | `working-directory` | `.` | Repository subdirectory where the build runs. |

--- a/roadmap.md
+++ b/roadmap.md
@@ -75,6 +75,7 @@
 - [x] Asset fingerprinting / cache busting
 - [x] Static file copying (fonts, downloads, PDFs from source to output)
 - [x] Root-relative asset URLs stay valid when deploying under a subdirectory
+- [x] Nightly Linux binary published for GitHub Actions preview builds
 
 ## Priority 6: SEO and web standards
 

--- a/tests/Unit/Content/Parser/CollectionConfigParserTest.php
+++ b/tests/Unit/Content/Parser/CollectionConfigParserTest.php
@@ -12,7 +12,6 @@ use function PHPUnit\Framework\assertFalse;
 use function PHPUnit\Framework\assertSame;
 use function PHPUnit\Framework\assertStringContainsString;
 use function PHPUnit\Framework\assertTrue;
-use function PHPUnit\Framework\fail;
 
 final class CollectionConfigParserTest extends TestCase
 {
@@ -79,7 +78,7 @@ final class CollectionConfigParserTest extends TestCase
 
         try {
             (new CollectionConfigParser())->parse($file, 'blog');
-            fail('Expected invalid content configuration exception.');
+            $this->fail('Expected invalid content configuration exception.');
         } catch (InvalidContentConfigException $e) {
             assertSame('Invalid content configuration', $e->getName());
             assertSame('The collection configuration file must contain YAML key-value pairs.', $e->getMessage());

--- a/tests/Unit/Content/Parser/NavigationParserTest.php
+++ b/tests/Unit/Content/Parser/NavigationParserTest.php
@@ -11,7 +11,6 @@ use PHPUnit\Framework\TestCase;
 use function PHPUnit\Framework\assertCount;
 use function PHPUnit\Framework\assertSame;
 use function PHPUnit\Framework\assertStringContainsString;
-use function PHPUnit\Framework\fail;
 use function file_put_contents;
 use function sys_get_temp_dir;
 use function tempnam;
@@ -88,7 +87,7 @@ YAML);
 
         try {
             (new NavigationParser())->parse($file);
-            fail('Expected invalid content configuration exception.');
+            $this->fail('Expected invalid content configuration exception.');
         } catch (InvalidContentConfigException $e) {
             assertSame('Invalid content configuration', $e->getName());
             assertSame('The navigation configuration file must contain YAML key-value pairs.', $e->getMessage());

--- a/tests/Unit/Content/Parser/SiteConfigParserTest.php
+++ b/tests/Unit/Content/Parser/SiteConfigParserTest.php
@@ -13,7 +13,6 @@ use function PHPUnit\Framework\assertFalse;
 use function PHPUnit\Framework\assertNotNull;
 use function PHPUnit\Framework\assertStringContainsString;
 use function PHPUnit\Framework\assertTrue;
-use function PHPUnit\Framework\fail;
 
 final class SiteConfigParserTest extends TestCase
 {
@@ -142,7 +141,7 @@ final class SiteConfigParserTest extends TestCase
 
         try {
             (new SiteConfigParser())->parse($filePath);
-            fail('Expected invalid content configuration exception.');
+            $this->fail('Expected invalid content configuration exception.');
         } catch (InvalidContentConfigException $e) {
             assertSame('Invalid content configuration', $e->getName());
             assertSame($filePath, $e->filePath());
@@ -163,7 +162,7 @@ final class SiteConfigParserTest extends TestCase
 
         try {
             (new SiteConfigParser())->parse($filePath);
-            fail('Expected invalid content configuration exception.');
+            $this->fail('Expected invalid content configuration exception.');
         } catch (InvalidContentConfigException $e) {
             assertSame('The site configuration file must contain YAML key-value pairs.', $e->getMessage());
             assertStringContainsString('title: My Site', (string) $e->getSolution());


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * GitHub Actions build action now supports `version: nightly` for testing unreleased builds
  * Nightly Linux binary is automatically published for preview use

* **Documentation**
  * Added guidance on using nightly builds in GitHub Actions with expected behavior noted

* **Chores**
  * Updated roadmap to reflect completed nightly Linux binary publishing task

<!-- end of auto-generated comment: release notes by coderabbit.ai -->