### PR TITLE
Fix dependency analyser failure in parser tests

### DIFF
--- a/tests/Unit/Content/Parser/CollectionConfigParserTest.php
+++ b/tests/Unit/Content/Parser/CollectionConfigParserTest.php
@@ -12,7 +12,6 @@ use function PHPUnit\Framework\assertFalse;
 use function PHPUnit\Framework\assertSame;
 use function PHPUnit\Framework\assertStringContainsString;
 use function PHPUnit\Framework\assertTrue;
-use function PHPUnit\Framework\fail;
 
 final class CollectionConfigParserTest extends TestCase
 {
@@ -79,7 +78,7 @@ final class CollectionConfigParserTest extends TestCase
 
         try {
             (new CollectionConfigParser())->parse($file, 'blog');
-            fail('Expected invalid content configuration exception.');
+            $this->fail('Expected invalid content configuration exception.');
         } catch (InvalidContentConfigException $e) {
             assertSame('Invalid content configuration', $e->getName());
             assertSame('The collection configuration file must contain YAML key-value pairs.', $e->getMessage());

--- a/tests/Unit/Content/Parser/NavigationParserTest.php
+++ b/tests/Unit/Content/Parser/NavigationParserTest.php
@@ -11,7 +11,6 @@ use PHPUnit\Framework\TestCase;
 use function PHPUnit\Framework\assertCount;
 use function PHPUnit\Framework\assertSame;
 use function PHPUnit\Framework\assertStringContainsString;
-use function PHPUnit\Framework\fail;
 use function file_put_contents;
 use function sys_get_temp_dir;
 use function tempnam;
@@ -88,7 +87,7 @@ YAML);
 
         try {
             (new NavigationParser())->parse($file);
-            fail('Expected invalid content configuration exception.');
+            $this->fail('Expected invalid content configuration exception.');
         } catch (InvalidContentConfigException $e) {
             assertSame('Invalid content configuration', $e->getName());
             assertSame('The navigation configuration file must contain YAML key-value pairs.', $e->getMessage());

--- a/tests/Unit/Content/Parser/SiteConfigParserTest.php
+++ b/tests/Unit/Content/Parser/SiteConfigParserTest.php
@@ -13,7 +13,6 @@ use function PHPUnit\Framework\assertFalse;
 use function PHPUnit\Framework\assertNotNull;
 use function PHPUnit\Framework\assertStringContainsString;
 use function PHPUnit\Framework\assertTrue;
-use function PHPUnit\Framework\fail;
 
 final class SiteConfigParserTest extends TestCase
 {
@@ -142,7 +141,7 @@ final class SiteConfigParserTest extends TestCase
 
         try {
             (new SiteConfigParser())->parse($filePath);
-            fail('Expected invalid content configuration exception.');
+            $this->fail('Expected invalid content configuration exception.');
         } catch (InvalidContentConfigException $e) {
             assertSame('Invalid content configuration', $e->getName());
             assertSame($filePath, $e->filePath());
@@ -163,7 +162,7 @@ final class SiteConfigParserTest extends TestCase
 
         try {
             (new SiteConfigParser())->parse($filePath);
-            fail('Expected invalid content configuration exception.');
+            $this->fail('Expected invalid content configuration exception.');
         } catch (InvalidContentConfigException $e) {
             assertSame('The site configuration file must contain YAML key-value pairs.', $e->getMessage());
             assertStringContainsString('title: My Site', (string) $e->getSolution());


### PR DESCRIPTION
## Summary
- replace imported PHPUnit fail() helper calls with TestCase fail assertions
- removes the unknown function reported by composer-dependency-analyser

## Tests
- make composer-dependency-analyser
- make psalm
- make test tests/Unit/Content/Parser/CollectionConfigParserTest.php tests/Unit/Content/Parser/NavigationParserTest.php tests/Unit/Content/Parser/SiteConfigParserTest.php