### PR TITLE
Fix build action manifest YAML

### DIFF
--- a/.github/actions/build/action.yml
+++ b/.github/actions/build/action.yml
@@ -93,26 +93,26 @@ runs:
 
             if version="$(
               python3 - "${nightly_releases}" <<'PY'
-import json
-import sys
+        import json
+        import sys
 
-with open(sys.argv[1], encoding="utf-8") as file:
-    releases = json.load(file)
+        with open(sys.argv[1], encoding="utf-8") as file:
+            releases = json.load(file)
 
-for release in releases:
-    tag = release.get("tag_name", "")
-    assets = {asset.get("name") for asset in release.get("assets", [])}
-    if (
-        not release.get("draft")
-        and release.get("prerelease")
-        and tag.startswith("nightly-")
-        and {"yiipress-linux-amd64.tar.gz", "SHA256SUMS"}.issubset(assets)
-    ):
-        print(tag)
-        sys.exit(0)
+        for release in releases:
+            tag = release.get("tag_name", "")
+            assets = {asset.get("name") for asset in release.get("assets", [])}
+            if (
+                not release.get("draft")
+                and release.get("prerelease")
+                and tag.startswith("nightly-")
+                and {"yiipress-linux-amd64.tar.gz", "SHA256SUMS"}.issubset(assets)
+            ):
+                print(tag)
+                sys.exit(0)
 
-sys.exit(1)
-PY
+        sys.exit(1)
+        PY
             )"; then
               break
             fi

--- a/tests/Unit/Packaging/ConfigurationPackagingTest.php
+++ b/tests/Unit/Packaging/ConfigurationPackagingTest.php
@@ -19,6 +19,7 @@ use function chdir;
 use function getcwd;
 use function mkdir;
 use function PHPUnit\Framework\assertSame;
+use function yaml_parse;
 
 final class ConfigurationPackagingTest extends TestCase
 {
@@ -303,6 +304,18 @@ final class ConfigurationPackagingTest extends TestCase
         self::assertStringContainsString('binary_path="${RUNNER_TEMP}/yiipress"', $action);
         self::assertStringContainsString('elif [[ "${BINARY_PATH}" = /* ]]; then', $action);
         self::assertStringContainsString('printf \'binary-path=%s\n\' "${binary_path}"', $action);
+    }
+
+    #[Test]
+    public function buildActionManifestIsValidYaml(): void
+    {
+        $action = file_get_contents(dirname(__DIR__, 3) . '/.github/actions/build/action.yml');
+        self::assertIsString($action);
+
+        $manifest = yaml_parse($action);
+
+        self::assertIsArray($manifest);
+        self::assertSame('composite', $manifest['runs']['using'] ?? null);
     }
 
     #[Test]


### PR DESCRIPTION
## Summary
- indent the Python heredoc in the composite action so the action manifest is valid YAML
- add a packaging test that parses the build action manifest with yaml_parse

## Cause
The blog workflow failed while loading `yiipress/engine@master/.github/actions/build/action.yml` because the heredoc added for nightly resolution started at physical column 1. GitHub parses the action file as YAML before running the shell script, so those lines broke the manifest.

## Tests
- `make test tests/Unit/Packaging/ConfigurationPackagingTest.php`
- `make psalm`
- `make composer-dependency-analyser`