### PR TITLE
Ignore nightly tags in release notes

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -266,7 +266,7 @@ jobs:
         run: |
           set -euo pipefail
           tag="${GITHUB_REF_NAME}"
-          previous_tag="$(git describe --tags --abbrev=0 --match '[0-9]*.[0-9]*.[0-9]*' "${tag}^" 2>/dev/null || true)"
+          previous_tag="$(git describe --tags --abbrev=0 --match '[0-9]*.[0-9]*.[0-9]*' --exclude '*[!0-9.]*' "${tag}^" 2>/dev/null || true)"
           range="${tag}"
           if [ -n "${previous_tag}" ]; then
             range="${previous_tag}..${tag}"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -266,7 +266,7 @@ jobs:
         run: |
           set -euo pipefail
           tag="${GITHUB_REF_NAME}"
-          previous_tag="$(git describe --tags --abbrev=0 "${tag}^" 2>/dev/null || true)"
+          previous_tag="$(git describe --tags --abbrev=0 --match '[0-9]*.[0-9]*.[0-9]*' "${tag}^" 2>/dev/null || true)"
           range="${tag}"
           if [ -n "${previous_tag}" ]; then
             range="${previous_tag}..${tag}"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -272,7 +272,44 @@ jobs:
             range="${previous_tag}..${tag}"
           fi
 
-          changes="$(git log --format='- %s (%an)' "${range}")"
+          release_author() {
+            local name="$1"
+            local email="$2"
+            local nickname=""
+
+            case "${email}" in
+              *+*@users.noreply.github.com)
+                nickname="${email#*+}"
+                nickname="${nickname%@users.noreply.github.com}"
+                ;;
+              *@users.noreply.github.com)
+                nickname="${email%@users.noreply.github.com}"
+                ;;
+              sam@rmcreative.ru)
+                nickname="samdark"
+                ;;
+              pamparam83@gmail.com)
+                nickname="pamparam83"
+                ;;
+              *)
+                if [[ "${name}" != *" "* ]]; then
+                  nickname="${name}"
+                else
+                  nickname="${email%@*}"
+                fi
+                ;;
+            esac
+
+            nickname="${nickname//[^[:alnum:]_.-]/-}"
+            printf '@%s' "${nickname:-unknown}"
+          }
+
+          changes_file="$(mktemp)"
+          while IFS=$'\t' read -r subject name email; do
+            author="$(release_author "${name}" "${email}")"
+            printf -- '- %s (%s)\n' "${subject}" "${author}" >> "${changes_file}"
+          done < <(git log --format='%s%x09%an%x09%ae' "${range}")
+
           image="${REGISTRY}/${IMAGE_NAME}:${tag}"
 
           {
@@ -288,7 +325,7 @@ jobs:
             if [ -n "${previous_tag}" ]; then
               printf 'Changes since %s:\n\n' "${previous_tag}"
             fi
-            printf '%s\n' "${changes}"
+            cat "${changes_file}"
           } > release-notes.md
 
       - name: Create draft release with assets

--- a/tests/Unit/Packaging/ConfigurationPackagingTest.php
+++ b/tests/Unit/Packaging/ConfigurationPackagingTest.php
@@ -357,6 +357,21 @@ final class ConfigurationPackagingTest extends TestCase
     }
 
     #[Test]
+    public function releaseWorkflowBuildsNotesFromPreviousStableReleaseTag(): void
+    {
+        $workflow = file_get_contents(dirname(__DIR__, 3) . '/.github/workflows/release.yml');
+        self::assertIsString($workflow);
+
+        self::assertStringContainsString("tags:\n      - '*.*.*'", $workflow);
+        self::assertStringContainsString(
+            "git describe --tags --abbrev=0 --match '[0-9]*.[0-9]*.[0-9]*' \"\${tag}^\"",
+            $workflow,
+        );
+        self::assertStringNotContainsString('git describe --tags --abbrev=0 "${tag}^"', $workflow);
+        self::assertStringContainsString('Changes since %s:', $workflow);
+    }
+
+    #[Test]
     public function cloudflareDeploymentVerifiesDownloadedBinaryChecksum(): void
     {
         $documentation = file_get_contents(dirname(__DIR__, 3) . '/docs/deployment.md');

--- a/tests/Unit/Packaging/ConfigurationPackagingTest.php
+++ b/tests/Unit/Packaging/ConfigurationPackagingTest.php
@@ -367,6 +367,15 @@ final class ConfigurationPackagingTest extends TestCase
             "git describe --tags --abbrev=0 --match '[0-9]*.[0-9]*.[0-9]*' \"\${tag}^\"",
             $workflow,
         );
+        self::assertStringContainsString('release_author() {', $workflow);
+        self::assertStringContainsString('*+*@users.noreply.github.com)', $workflow);
+        self::assertStringContainsString('sam@rmcreative.ru)', $workflow);
+        self::assertStringContainsString('nickname="samdark"', $workflow);
+        self::assertStringContainsString('pamparam83@gmail.com)', $workflow);
+        self::assertStringContainsString('nickname="pamparam83"', $workflow);
+        self::assertStringContainsString("git log --format='%s%x09%an%x09%ae'", $workflow);
+        self::assertStringNotContainsString('repos/${GITHUB_REPOSITORY}/commits/${commit}', $workflow);
+        self::assertStringNotContainsString("git log --format='- %s (%an)'", $workflow);
         self::assertStringNotContainsString('git describe --tags --abbrev=0 "${tag}^"', $workflow);
         self::assertStringContainsString('Changes since %s:', $workflow);
     }

--- a/tests/Unit/Packaging/ConfigurationPackagingTest.php
+++ b/tests/Unit/Packaging/ConfigurationPackagingTest.php
@@ -364,7 +364,7 @@ final class ConfigurationPackagingTest extends TestCase
 
         self::assertStringContainsString("tags:\n      - '*.*.*'", $workflow);
         self::assertStringContainsString(
-            "git describe --tags --abbrev=0 --match '[0-9]*.[0-9]*.[0-9]*' \"\${tag}^\"",
+            "git describe --tags --abbrev=0 --match '[0-9]*.[0-9]*.[0-9]*' --exclude '*[!0-9.]*' \"\${tag}^\"",
             $workflow,
         );
         self::assertStringContainsString('release_author() {', $workflow);


### PR DESCRIPTION
## Summary
- make release notes find the previous stable version tag only
- render changelog authors as @username-style handles instead of real names
- add packaging regression tests so nightly tags are not used as changelog boundaries and names do not come from %an

## Cause
After immutable nightly releases, `git describe --tags --abbrev=0 "${tag}^"` can return a `nightly-*` tag. That makes release notes show only changes since the latest nightly instead of the previous stable release. Existing notes also used real author names from `%an`; they should use handles.

## Existing releases
Updated the existing stable GitHub release descriptions for `0.1.0` and `0.1.1` to use the new format. Nightly prerelease descriptions were left unchanged.

## Tests
- `make test tests/Unit/Packaging/ConfigurationPackagingTest.php`
- `make psalm`
- `make composer-dependency-analyser`