### PR TITLE
Add configurable output minification

### DIFF
--- a/benchmarks/OutputMinifierBench.php
+++ b/benchmarks/OutputMinifierBench.php
@@ -1,0 +1,40 @@
+<?php
+
+declare(strict_types=1);
+
+namespace YiiPress\Benchmarks;
+
+use YiiPress\Build\OutputMinifier;
+use PhpBench\Attributes\Iterations;
+use PhpBench\Attributes\Revs;
+use PhpBench\Attributes\Warmup;
+
+final class OutputMinifierBench
+{
+    private string $html;
+
+    public function __construct()
+    {
+        $block = <<<'HTML'
+            <article>
+                <h2>Generated output</h2>
+                <p>YiiPress keeps generated pages compact while preserving code.</p>
+                <pre><code>Line 1
+                    Line 2</code></pre>
+                <script>
+                    const message = "  keep script spacing  ";
+                </script>
+            </article>
+            HTML;
+
+        $this->html = str_repeat($block, 100);
+    }
+
+    #[Revs(100)]
+    #[Iterations(3)]
+    #[Warmup(1)]
+    public function benchHtmlMinification(): void
+    {
+        OutputMinifier::html($this->html);
+    }
+}

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -44,6 +44,8 @@ params:
 assets:
   fingerprint: true
 
+minify: true
+
 last_updated: true
 edit_page: https://github.com/example/mysite/edit/main/content/{path}
 report_issue: https://github.com/example/mysite/issues/new?title=Docs:%20{title}&body={url}
@@ -72,6 +74,7 @@ editor: code
 - **toc** — generate a table of contents from headings (default: `true`); set to `false` to disable globally. When enabled, heading tags receive `id` attributes and a `$toc` variable is passed to templates
 - **search** — opt-in client-side search (see below)
 - **related** — opt-in related content suggestions (see below)
+- **minify** — minify generated HTML output (default: `true`); set to `false` to keep rendered template whitespace
 - **last_updated** — set to `true` to show each entry source file's last modification time below its content (default: `false`)
 - **edit_page** — URL template for an optional "Edit this page" link below entry content (see below)
 - **report_issue** — URL template for an optional "Report an issue" link below entry content (see below)
@@ -210,6 +213,17 @@ Built-in templates use the fingerprinted URLs automatically, and existing hardco
 asset references in rendered HTML are rewritten during build so custom themes continue to work.
 Root-relative local asset references are treated as YiiPress site-root paths and emitted relative to
 the current output page, so they remain valid when `base_url` contains a deployment path.
+
+### Output minification
+
+Generated HTML pages are minified by default:
+
+```yaml
+minify: true
+```
+
+Set `minify: false` to keep template indentation and line breaks in generated `*.html` files.
+Whitespace inside `pre`, `textarea`, `script`, and `style` elements is preserved either way.
 
 ### Editor
 

--- a/roadmap.md
+++ b/roadmap.md
@@ -76,6 +76,7 @@
 - [x] Static file copying (fonts, downloads, PDFs from source to output)
 - [x] Root-relative asset URLs stay valid when deploying under a subdirectory
 - [x] Nightly Linux binary published for GitHub Actions preview builds
+- [x] Configurable generated HTML output minification
 
 ## Priority 6: SEO and web standards
 

--- a/src/Build/AuthorPageWriter.php
+++ b/src/Build/AuthorPageWriter.php
@@ -40,7 +40,7 @@ final class AuthorPageWriter
             return 0;
         }
 
-        $renderer = new PageTemplateRenderer($this->templateResolver, $siteConfig->theme, $this->assetManifest);
+        $renderer = new PageTemplateRenderer($this->templateResolver, $siteConfig->theme, $this->assetManifest, $siteConfig->minify);
 
         $this->writeIndex($siteConfig, $authors, $outputDir, $navigation, $noWrite);
         $pageCount = 1;
@@ -65,7 +65,7 @@ final class AuthorPageWriter
         bool $noWrite = false,
     ): void {
         $this->writeIndexPage(
-            new PageTemplateRenderer($this->templateResolver, $siteConfig->theme, $this->assetManifest),
+            new PageTemplateRenderer($this->templateResolver, $siteConfig->theme, $this->assetManifest, $siteConfig->minify),
             $siteConfig,
             $authors,
             $outputDir,
@@ -89,7 +89,7 @@ final class AuthorPageWriter
         bool $noWrite = false,
     ): void {
         $this->writeAuthorPage(
-            $renderer ?? new PageTemplateRenderer($this->templateResolver, $siteConfig->theme, $this->assetManifest),
+            $renderer ?? new PageTemplateRenderer($this->templateResolver, $siteConfig->theme, $this->assetManifest, $siteConfig->minify),
             $siteConfig,
             $author,
             $entries,

--- a/src/Build/AuthorPageWriter.php
+++ b/src/Build/AuthorPageWriter.php
@@ -40,7 +40,7 @@ final class AuthorPageWriter
             return 0;
         }
 
-        $renderer = new PageTemplateRenderer($this->templateResolver, $siteConfig->theme, $this->assetManifest, $siteConfig->minify);
+        $renderer = $this->createPageTemplateRenderer($siteConfig);
 
         $this->writeIndex($siteConfig, $authors, $outputDir, $navigation, $noWrite);
         $pageCount = 1;
@@ -65,7 +65,7 @@ final class AuthorPageWriter
         bool $noWrite = false,
     ): void {
         $this->writeIndexPage(
-            new PageTemplateRenderer($this->templateResolver, $siteConfig->theme, $this->assetManifest, $siteConfig->minify),
+            $this->createPageTemplateRenderer($siteConfig),
             $siteConfig,
             $authors,
             $outputDir,
@@ -89,7 +89,7 @@ final class AuthorPageWriter
         bool $noWrite = false,
     ): void {
         $this->writeAuthorPage(
-            $renderer ?? new PageTemplateRenderer($this->templateResolver, $siteConfig->theme, $this->assetManifest, $siteConfig->minify),
+            $renderer ?? $this->createPageTemplateRenderer($siteConfig),
             $siteConfig,
             $author,
             $entries,
@@ -97,6 +97,16 @@ final class AuthorPageWriter
             $outputDir,
             $navigation,
             $noWrite,
+        );
+    }
+
+    private function createPageTemplateRenderer(SiteConfig $siteConfig): PageTemplateRenderer
+    {
+        return new PageTemplateRenderer(
+            $this->templateResolver,
+            $siteConfig->theme,
+            $this->assetManifest,
+            $siteConfig->minify,
         );
     }
 

--- a/src/Build/CollectionListingWriter.php
+++ b/src/Build/CollectionListingWriter.php
@@ -33,7 +33,7 @@ final readonly class CollectionListingWriter
         int $workerCount = 1,
         bool $noWrite = false,
     ): int {
-        $renderer = new PageTemplateRenderer($this->templateResolver, $siteConfig->theme, $this->assetManifest);
+        $renderer = new PageTemplateRenderer($this->templateResolver, $siteConfig->theme, $this->assetManifest, $siteConfig->minify);
         $perPage = $collection->entriesPerPage;
         if ($perPage <= 0) {
             $perPage = count($entries) ?: 1;

--- a/src/Build/DateArchiveWriter.php
+++ b/src/Build/DateArchiveWriter.php
@@ -30,7 +30,7 @@ final readonly class DateArchiveWriter
         int $workerCount = 1,
         bool $noWrite = false,
     ): int {
-        $renderer = new PageTemplateRenderer($this->templateResolver, $siteConfig->theme, $this->assetManifest);
+        $renderer = new PageTemplateRenderer($this->templateResolver, $siteConfig->theme, $this->assetManifest, $siteConfig->minify);
         $byYear = [];
         $byMonth = [];
 

--- a/src/Build/EntryRenderer.php
+++ b/src/Build/EntryRenderer.php
@@ -67,7 +67,9 @@ final class EntryRenderer
             $cacheContext = $this->cacheContext($siteConfig, $entry, $permalink, $navigation, $crossRefResolver, $navigationPager);
             $cached = $this->cache->get($entry->filePath, $cacheContext);
             if ($cached !== null) {
-                return $this->dispatchRenderFinished($siteConfig, $entry, $permalink, $cached);
+                $html = $this->dispatchRenderFinished($siteConfig, $entry, $permalink, $cached);
+
+                return $siteConfig->minify ? OutputMinifier::html($html) : $html;
             }
         }
 
@@ -91,7 +93,9 @@ final class EntryRenderer
             $this->cache->set($entry->filePath, $html, $cacheContext);
         }
 
-        return $this->dispatchRenderFinished($siteConfig, $entry, $permalink, $html);
+        $html = $this->dispatchRenderFinished($siteConfig, $entry, $permalink, $html);
+
+        return $siteConfig->minify ? OutputMinifier::html($html) : $html;
     }
 
     private function dispatchRenderFinished(SiteConfig $siteConfig, Entry $entry, string $permalink, string $html): string

--- a/src/Build/NotFoundPageWriter.php
+++ b/src/Build/NotFoundPageWriter.php
@@ -19,7 +19,7 @@ final readonly class NotFoundPageWriter
     {
         $rootPath = './';
         $uiViewData = UiViewData::forSite($siteConfig, $this->templateResolver, $siteConfig->theme);
-        $renderer = new PageTemplateRenderer($this->templateResolver, $siteConfig->theme, $this->assetManifest);
+        $renderer = new PageTemplateRenderer($this->templateResolver, $siteConfig->theme, $this->assetManifest, $siteConfig->minify);
         $html = $renderer->render('errors/404', [
             'siteTitle' => $siteConfig->title,
             'nav' => $navigation,

--- a/src/Build/OutputMinifier.php
+++ b/src/Build/OutputMinifier.php
@@ -6,12 +6,17 @@ namespace YiiPress\Build;
 
 use function preg_replace;
 use function preg_split;
-use function preg_match;
+use function preg_match_all;
+use function strlen;
 use function str_starts_with;
+use function substr;
 use function trim;
 
 final class OutputMinifier
 {
+    private const string PROTECTED_ELEMENT_PATTERN = '~<(?<tag>pre|textarea|script|style)\b(?:[^>"\']+|"[^"]*"|\'[^\']*\')*>.*?</\k<tag>>~is';
+    private const string TAG_PATTERN = '~(<(?:[^>"\']+|"[^"]*"|\'[^\']*\')*>)~';
+
     /**
      * Minifies generated HTML while preserving whitespace-sensitive element bodies.
      */
@@ -21,31 +26,26 @@ final class OutputMinifier
             return '';
         }
 
-        $protectedParts = preg_split(
-            '~(<(?:pre|textarea|script|style)\b[^>]*>.*?</(?:pre|textarea|script|style)>)~is',
-            $html,
-            -1,
-            PREG_SPLIT_DELIM_CAPTURE,
-        );
-        if ($protectedParts === false) {
+        $protectedParts = self::splitProtectedParts($html);
+        if ($protectedParts === null) {
             return $html;
         }
 
         $minified = '';
         $previousPartProtected = false;
         foreach ($protectedParts as $part) {
-            if ($part === '') {
+            if ($part['html'] === '') {
                 continue;
             }
 
-            if (preg_match('~^<(?:pre|textarea|script|style)\b~i', $part) === 1) {
+            if ($part['protected']) {
                 $minified = preg_replace('~(?<=>)\s+$~', '', $minified) ?? $minified;
-                $minified .= $part;
+                $minified .= $part['html'];
                 $previousPartProtected = true;
                 continue;
             }
 
-            $fragment = self::minifyHtmlFragment($part);
+            $fragment = self::minifyHtmlFragment($part['html']);
             if ($previousPartProtected) {
                 $fragment = preg_replace('~^\s+(?=<)~', '', $fragment) ?? $fragment;
             }
@@ -57,13 +57,54 @@ final class OutputMinifier
         return trim($minified);
     }
 
+    /**
+     * @return list<array{html: string, protected: bool}>|null
+     */
+    private static function splitProtectedParts(string $html): ?array
+    {
+        $matched = preg_match_all(self::PROTECTED_ELEMENT_PATTERN, $html, $matches, PREG_OFFSET_CAPTURE);
+        if ($matched === false) {
+            return null;
+        }
+
+        if ($matched === 0) {
+            return [['html' => $html, 'protected' => false]];
+        }
+
+        $parts = [];
+        $offset = 0;
+        foreach ($matches[0] as [$match, $position]) {
+            if ($position > $offset) {
+                $parts[] = [
+                    'html' => substr($html, $offset, $position - $offset),
+                    'protected' => false,
+                ];
+            }
+
+            $parts[] = [
+                'html' => $match,
+                'protected' => true,
+            ];
+            $offset = $position + strlen($match);
+        }
+
+        if ($offset < strlen($html)) {
+            $parts[] = [
+                'html' => substr($html, $offset),
+                'protected' => false,
+            ];
+        }
+
+        return $parts;
+    }
+
     private static function minifyHtmlFragment(string $html): string
     {
         if (trim($html) === '') {
             return '';
         }
 
-        $tokens = preg_split('~(<[^>]+>)~', $html, -1, PREG_SPLIT_DELIM_CAPTURE);
+        $tokens = preg_split(self::TAG_PATTERN, $html, -1, PREG_SPLIT_DELIM_CAPTURE);
         if ($tokens === false) {
             return $html;
         }

--- a/src/Build/OutputMinifier.php
+++ b/src/Build/OutputMinifier.php
@@ -1,0 +1,87 @@
+<?php
+
+declare(strict_types=1);
+
+namespace YiiPress\Build;
+
+use function preg_replace;
+use function preg_split;
+use function preg_match;
+use function str_starts_with;
+use function trim;
+
+final class OutputMinifier
+{
+    /**
+     * Minifies generated HTML while preserving whitespace-sensitive element bodies.
+     */
+    public static function html(string $html): string
+    {
+        if ($html === '') {
+            return '';
+        }
+
+        $protectedParts = preg_split(
+            '~(<(?:pre|textarea|script|style)\b[^>]*>.*?</(?:pre|textarea|script|style)>)~is',
+            $html,
+            -1,
+            PREG_SPLIT_DELIM_CAPTURE,
+        );
+        if ($protectedParts === false) {
+            return $html;
+        }
+
+        $minified = '';
+        $previousPartProtected = false;
+        foreach ($protectedParts as $part) {
+            if ($part === '') {
+                continue;
+            }
+
+            if (preg_match('~^<(?:pre|textarea|script|style)\b~i', $part) === 1) {
+                $minified = preg_replace('~(?<=>)\s+$~', '', $minified) ?? $minified;
+                $minified .= $part;
+                $previousPartProtected = true;
+                continue;
+            }
+
+            $fragment = self::minifyHtmlFragment($part);
+            if ($previousPartProtected) {
+                $fragment = preg_replace('~^\s+(?=<)~', '', $fragment) ?? $fragment;
+            }
+
+            $minified .= $fragment;
+            $previousPartProtected = false;
+        }
+
+        return trim($minified);
+    }
+
+    private static function minifyHtmlFragment(string $html): string
+    {
+        if (trim($html) === '') {
+            return '';
+        }
+
+        $tokens = preg_split('~(<[^>]+>)~', $html, -1, PREG_SPLIT_DELIM_CAPTURE);
+        if ($tokens === false) {
+            return $html;
+        }
+
+        $minified = '';
+        foreach ($tokens as $token) {
+            if ($token === '') {
+                continue;
+            }
+
+            if (str_starts_with($token, '<')) {
+                $minified .= $token;
+                continue;
+            }
+
+            $minified .= preg_replace('~[ \t\r\n\f]+~', ' ', $token) ?? $token;
+        }
+
+        return preg_replace('~>\s+<~', '><', $minified) ?? $minified;
+    }
+}

--- a/src/Build/PageTemplateRenderer.php
+++ b/src/Build/PageTemplateRenderer.php
@@ -21,6 +21,7 @@ final class PageTemplateRenderer
         private readonly TemplateResolver $templateResolver,
         private readonly string $themeName,
         private readonly ?AssetFingerprintManifest $assetManifest = null,
+        private readonly bool $minify = true,
     ) {}
 
     /**
@@ -54,6 +55,8 @@ final class PageTemplateRenderer
 
         $html = ($this->templateClosures[$templatePath])($variables);
 
-        return $this->templateContexts[$this->themeName]->rewriteHtml($html, $rootPath);
+        $html = $this->templateContexts[$this->themeName]->rewriteHtml($html, $rootPath);
+
+        return $this->minify ? OutputMinifier::html($html) : $html;
     }
 }

--- a/src/Build/RedirectPageWriter.php
+++ b/src/Build/RedirectPageWriter.php
@@ -58,6 +58,10 @@ final class RedirectPageWriter
             </html>
             HTML;
 
+        if ($siteConfig?->minify ?? true) {
+            $html = OutputMinifier::html($html);
+        }
+
         if ($noWrite) {
             return;
         }

--- a/src/Build/TaxonomyPageWriter.php
+++ b/src/Build/TaxonomyPageWriter.php
@@ -30,7 +30,7 @@ final readonly class TaxonomyPageWriter
         ?Navigation $navigation = null,
         bool $noWrite = false,
     ): int {
-        $renderer = new PageTemplateRenderer($this->templateResolver, $siteConfig->theme, $this->assetManifest);
+        $renderer = new PageTemplateRenderer($this->templateResolver, $siteConfig->theme, $this->assetManifest, $siteConfig->minify);
         $pageCount = 0;
 
         foreach ($taxonomyData as $taxonomyName => $terms) {

--- a/src/Content/Model/SiteConfig.php
+++ b/src/Content/Model/SiteConfig.php
@@ -37,5 +37,6 @@ final readonly class SiteConfig
         public ?string $editPageUrl = null,
         public ?string $reportIssueUrl = null,
         public bool $authorPages = false,
+        public bool $minify = true,
     ) {}
 }

--- a/src/Content/Parser/SiteConfigParser.php
+++ b/src/Content/Parser/SiteConfigParser.php
@@ -88,6 +88,7 @@ final class SiteConfigParser
             editPageUrl: self::parseOptionalString($data['edit_page'] ?? null),
             reportIssueUrl: self::parseOptionalString($data['report_issue'] ?? null),
             authorPages: (bool) ($data['author_pages'] ?? false),
+            minify: (bool) ($data['minify'] ?? true),
         );
     }
 

--- a/tests/Unit/Build/EntryRendererTest.php
+++ b/tests/Unit/Build/EntryRendererTest.php
@@ -552,6 +552,7 @@ PHP);
         ?string $editPageUrl = null,
         ?string $reportIssueUrl = null,
         bool $authorPages = false,
+        bool $minify = true,
     ): SiteConfig
     {
         return new SiteConfig(
@@ -573,6 +574,7 @@ PHP);
             editPageUrl: $editPageUrl,
             reportIssueUrl: $reportIssueUrl,
             authorPages: $authorPages,
+            minify: $minify,
         );
     }
 

--- a/tests/Unit/Build/OutputMinifierTest.php
+++ b/tests/Unit/Build/OutputMinifierTest.php
@@ -1,0 +1,65 @@
+<?php
+
+declare(strict_types=1);
+
+namespace YiiPress\Tests\Unit\Build;
+
+use YiiPress\Build\OutputMinifier;
+use PHPUnit\Framework\TestCase;
+
+use function PHPUnit\Framework\assertSame;
+
+final class OutputMinifierTest extends TestCase
+{
+    public function testMinifiesInterTagAndTextWhitespace(): void
+    {
+        $html = <<<'HTML'
+            <!DOCTYPE html>
+            <html>
+                <body>
+                    <h1>
+                        Hello
+                    </h1>
+                    <p>One
+                        two</p>
+                </body>
+            </html>
+            HTML;
+
+        assertSame('<!DOCTYPE html><html><body><h1> Hello </h1><p>One two</p></body></html>', OutputMinifier::html($html));
+    }
+
+    public function testPreservesWhitespaceSensitiveElementBodies(): void
+    {
+        $html = <<<'HTML'
+            <html>
+            <body>
+            <pre>Line 1
+                Line 2</pre>
+            <script>
+                const value = "  kept  ";
+            </script>
+            <style>
+                body {
+                    white-space: pre;
+                }
+            </style>
+            </body>
+            </html>
+            HTML;
+
+        assertSame(
+            <<<'HTML'
+            <html><body><pre>Line 1
+                Line 2</pre><script>
+                const value = "  kept  ";
+            </script><style>
+                body {
+                    white-space: pre;
+                }
+            </style></body></html>
+            HTML,
+            OutputMinifier::html($html),
+        );
+    }
+}

--- a/tests/Unit/Build/OutputMinifierTest.php
+++ b/tests/Unit/Build/OutputMinifierTest.php
@@ -34,10 +34,10 @@ final class OutputMinifierTest extends TestCase
         $html = <<<'HTML'
             <html>
             <body>
-            <pre>Line 1
+            <pre title="1 > 0">Line 1
                 Line 2</pre>
             <script>
-                const value = "  kept  ";
+                const value = "</pre>  kept  ";
             </script>
             <style>
                 body {
@@ -50,9 +50,9 @@ final class OutputMinifierTest extends TestCase
 
         assertSame(
             <<<'HTML'
-            <html><body><pre>Line 1
+            <html><body><pre title="1 > 0">Line 1
                 Line 2</pre><script>
-                const value = "  kept  ";
+                const value = "</pre>  kept  ";
             </script><style>
                 body {
                     white-space: pre;
@@ -61,5 +61,36 @@ final class OutputMinifierTest extends TestCase
             HTML,
             OutputMinifier::html($html),
         );
+    }
+
+    public function testPreservesTextareaWhitespace(): void
+    {
+        $html = <<<'HTML'
+            <div>
+                <textarea data-value="1 > 0">  spaced
+                    content  </textarea>
+            </div>
+            HTML;
+
+        assertSame(
+            <<<'HTML'
+            <div><textarea data-value="1 > 0">  spaced
+                    content  </textarea></div>
+            HTML,
+            OutputMinifier::html($html),
+        );
+    }
+
+    public function testKeepsTagsWithGreaterThanSignInQuotedAttributesIntact(): void
+    {
+        $html = <<<'HTML'
+            <div>
+                <a title="1 > 0" data-test='x > y'>
+                    Link
+                </a>
+            </div>
+            HTML;
+
+        assertSame('<div><a title="1 > 0" data-test=\'x > y\'> Link </a></div>', OutputMinifier::html($html));
     }
 }

--- a/tests/Unit/Build/PageTemplateRendererTest.php
+++ b/tests/Unit/Build/PageTemplateRendererTest.php
@@ -16,6 +16,7 @@ use RecursiveIteratorIterator;
 use SplFileInfo;
 
 use function PHPUnit\Framework\assertStringContainsString;
+use function PHPUnit\Framework\assertSame;
 
 final class PageTemplateRendererTest extends TestCase
 {
@@ -82,5 +83,35 @@ PHP,
 
         assertStringContainsString('<h1>Поиск</h1>', $html);
         assertStringContainsString('<p>Далее</p>', $html);
+    }
+
+    public function testMinifiesRenderedHtmlByDefault(): void
+    {
+        $registry = new ThemeRegistry();
+        $registry->register(new Theme('test', $this->tempDir));
+        $registry->register(new Theme('minimal', dirname(__DIR__, 3) . '/themes/minimal'));
+        $resolver = new TemplateResolver($registry);
+        $renderer = new PageTemplateRenderer($resolver, 'test');
+
+        $html = $renderer->render('example', [
+            'ui' => UiText::forTheme('en', $resolver, 'minimal'),
+        ], './');
+
+        assertSame('<h1>Search</h1><p>Next</p>', $html);
+    }
+
+    public function testCanKeepRenderedHtmlUnminified(): void
+    {
+        $registry = new ThemeRegistry();
+        $registry->register(new Theme('test', $this->tempDir));
+        $registry->register(new Theme('minimal', dirname(__DIR__, 3) . '/themes/minimal'));
+        $resolver = new TemplateResolver($registry);
+        $renderer = new PageTemplateRenderer($resolver, 'test', minify: false);
+
+        $html = $renderer->render('example', [
+            'ui' => UiText::forTheme('en', $resolver, 'minimal'),
+        ], './');
+
+        assertStringContainsString("<h1>Search</h1>\n<p>Next</p>", $html);
     }
 }

--- a/tests/Unit/Content/Parser/SiteConfigParserTest.php
+++ b/tests/Unit/Content/Parser/SiteConfigParserTest.php
@@ -38,6 +38,20 @@ final class SiteConfigParserTest extends TestCase
         assertSame('local', $config->theme);
         assertSame('Solarized (dark)', $config->highlightTheme);
         assertTrue($config->assets->fingerprint);
+        assertTrue($config->minify);
+    }
+
+    public function testParseMinifyConfigCanDisableOutputMinification(): void
+    {
+        $filePath = sys_get_temp_dir() . '/yiipress-site-config-' . uniqid() . '.yaml';
+        file_put_contents($filePath, "title: Test\nlanguages: [en]\nminify: false\n");
+
+        $parser = new SiteConfigParser();
+        $config = $parser->parse($filePath);
+
+        assertFalse($config->minify);
+
+        unlink($filePath);
     }
 
     public function testParseAssetConfigCanDisableFingerprinting(): void


### PR DESCRIPTION
## Summary
- add a `minify` site config option, enabled by default
- minify generated HTML pages while preserving `pre`, `textarea`, `script`, and `style` contents
- document the option, update the roadmap, and add PHPUnit coverage plus a phpbench benchmark

## Tests
- make test
- make psalm
- BENCH_FILTER=OutputMinifierBench make bench

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Generated HTML pages are now minified by default, reducing file sizes by removing unnecessary whitespace.
  * Whitespace is preserved in `<pre>`, `<textarea>`, `<script>`, and `<style>` elements.
  * New `minify` configuration option allows disabling minification when needed.

* **Documentation**
  * Configuration documentation updated with the new `minify` setting and behavior details.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->