### PR TITLE
Harden build error handling and bugfixes

### DIFF
--- a/.github/workflows/package-static.yml
+++ b/.github/workflows/package-static.yml
@@ -120,7 +120,7 @@ jobs:
   windows:
     name: Windows static binary
     if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
-    runs-on: windows-latest
+    runs-on: windows-2022
     permissions:
       contents: read
 
@@ -177,7 +177,7 @@ jobs:
   macos:
     name: macOS static binary
     if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
-    runs-on: macos-latest
+    runs-on: macos-14
     permissions:
       contents: read
 

--- a/.github/workflows/package-static.yml
+++ b/.github/workflows/package-static.yml
@@ -131,7 +131,7 @@ jobs:
           persist-credentials: false
 
       - name: Set up PHP
-        uses: shivammathur/setup-php@7c071dfe9dc99bdf297fa79cb49ea005b9fcadbc
+        uses: shivammathur/setup-php@f3e473d116dcccaddc5834248c87452386958240
         with:
           php-version: '8.5'
           coverage: none
@@ -188,7 +188,7 @@ jobs:
           persist-credentials: false
 
       - name: Set up PHP
-        uses: shivammathur/setup-php@7c071dfe9dc99bdf297fa79cb49ea005b9fcadbc
+        uses: shivammathur/setup-php@f3e473d116dcccaddc5834248c87452386958240
         with:
           php-version: '8.5'
           coverage: none

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -61,7 +61,7 @@ jobs:
 
   windows:
     name: Windows static binary
-    runs-on: windows-latest
+    runs-on: windows-2022
     permissions:
       contents: read
 
@@ -117,7 +117,7 @@ jobs:
 
   macos:
     name: macOS static binary
-    runs-on: macos-latest
+    runs-on: macos-14
     permissions:
       contents: read
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -72,7 +72,7 @@ jobs:
           persist-credentials: false
 
       - name: Set up PHP
-        uses: shivammathur/setup-php@7c071dfe9dc99bdf297fa79cb49ea005b9fcadbc
+        uses: shivammathur/setup-php@f3e473d116dcccaddc5834248c87452386958240
         with:
           php-version: '8.5'
           coverage: none
@@ -128,7 +128,7 @@ jobs:
           persist-credentials: false
 
       - name: Set up PHP
-        uses: shivammathur/setup-php@7c071dfe9dc99bdf297fa79cb49ea005b9fcadbc
+        uses: shivammathur/setup-php@f3e473d116dcccaddc5834248c87452386958240
         with:
           php-version: '8.5'
           coverage: none

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -15,7 +15,7 @@ Generates static HTML content from source files.
 - `--content-dir`, `-c` — path to the content directory (default: `content`). Absolute or relative to project root.
 - `--output-dir`, `-o` — path to the output directory (default: `output`). Absolute or relative to project root.
 - `--workers`, `-w` — number of parallel workers or `auto` (default: `auto`). Auto mode detects available CPU capacity inside the container, caps it at `4`, and still falls back to sequential work for small task sets.
-- `--no-cache` — disable build cache and incremental builds. Forces a full rebuild, clearing the output directory. By default, rendered HTML is cached and a build manifest tracks source file hashes for incremental builds.
+- `--no-cache` — disable build cache and incremental builds. Forces a full rebuild. Fresh or empty output directories are written directly. Existing non-empty output directories are replaced only if they contain the `.yiipress-build` marker written by previous builds; in that case the rebuild is written to a temporary sibling directory and swapped in after generation succeeds.
 - `--drafts` — include draft entries in the build. By default, entries with `draft: true` in front matter are excluded from HTML output, feeds, and sitemap.
 - `--future` — include future-dated entries in the build. By default, entries with a date in the future are excluded from HTML output, feeds, and sitemap.
 - `--dry-run` — list all files that would be generated without writing anything. The output directory is not created or modified.
@@ -47,7 +47,7 @@ The command:
 
 1. Parses site config, navigation, collections, authors, and entries from the content directory.
 2. Runs build diagnostics and prints warnings.
-3. Cleans the output directory (or skips unchanged entries on incremental builds).
+3. Prepares output writing. Incremental builds skip unchanged entries; full non-incremental builds write directly to fresh or empty output directories, and use a temporary output directory only when replacing existing marked build output.
 4. Renders collection entries — converts markdown to HTML via MD4C, applies the entry template, writes each entry as `index.html` at its resolved permalink path. Drafts and future-dated entries are excluded by default.
 5. Renders standalone pages — markdown files in the content root directory (e.g., `contact.md` → `/contact/`).
 6. Copies content assets (images, SVGs, etc.) to the output directory.

--- a/docs/content.md
+++ b/docs/content.md
@@ -114,7 +114,7 @@ extra:
 - **authors** — list of author slugs (referencing files in `content/authors/`)
 - **image** — featured image URL (absolute, or root-relative path resolved against `base_url`); used as `og:image` for social sharing. Falls back to the site-level `image` in `config.yaml`
 - **summary** — manual excerpt; if omitted, auto-generated from content
-- **permalink** — per-entry URL override; takes precedence over collection pattern. Permalinks must be root-relative paths with a trailing slash, must not contain `.` or `..` path segments, and must be unique across generated entries and standalone pages.
+- **permalink** — per-entry URL override; takes precedence over collection pattern. Permalinks must be root-relative paths with a trailing slash, must not contain repeated `/`, `.` or `..` path segments, and must be unique across generated entries and standalone pages.
 - **layout** — template layout name (default: collection-specific or `entry`)
 - **theme** — theme name for this entry; overrides the site-level default (see [Templates](templates.md))
 - **weight** — integer for custom sorting in non-blog collections (lower = first)

--- a/docs/content.md
+++ b/docs/content.md
@@ -114,7 +114,7 @@ extra:
 - **authors** — list of author slugs (referencing files in `content/authors/`)
 - **image** — featured image URL (absolute, or root-relative path resolved against `base_url`); used as `og:image` for social sharing. Falls back to the site-level `image` in `config.yaml`
 - **summary** — manual excerpt; if omitted, auto-generated from content
-- **permalink** — per-entry URL override; takes precedence over collection pattern. Permalinks must be root-relative paths, must not contain `.` or `..` path segments, and must be unique across generated entries and standalone pages.
+- **permalink** — per-entry URL override; takes precedence over collection pattern. Permalinks must be root-relative paths with a trailing slash, must not contain `.` or `..` path segments, and must be unique across generated entries and standalone pages.
 - **layout** — template layout name (default: collection-specific or `entry`)
 - **theme** — theme name for this entry; overrides the site-level default (see [Templates](templates.md))
 - **weight** — integer for custom sorting in non-blog collections (lower = first)

--- a/docs/content.md
+++ b/docs/content.md
@@ -106,7 +106,7 @@ extra:
 ```
 
 - **title** — entry title; if omitted, inferred from the first `# Heading` in the markdown body. Files with no title (neither in front matter nor as H1) are skipped with a console warning
-- **date** — publication date (`YYYY-MM-DD` or `YYYY-MM-DDTHH:MM:SS+00:00`); entries with a future date are excluded from build by default (scheduling)
+- **date** — publication date (`YYYY-MM-DD` or `YYYY-MM-DDTHH:MM:SS+00:00`); entries with a future date are excluded from build by default (scheduling). Invalid dates fail the build with the source file path.
 - **slug** — URL slug; overrides filename-derived slug
 - **draft** — `true` to exclude from build (default: `false`)
 - **tags** — list of tag slugs
@@ -114,13 +114,15 @@ extra:
 - **authors** — list of author slugs (referencing files in `content/authors/`)
 - **image** — featured image URL (absolute, or root-relative path resolved against `base_url`); used as `og:image` for social sharing. Falls back to the site-level `image` in `config.yaml`
 - **summary** — manual excerpt; if omitted, auto-generated from content
-- **permalink** — per-entry URL override; takes precedence over collection pattern
+- **permalink** — per-entry URL override; takes precedence over collection pattern. Permalinks must be root-relative paths, must not contain `.` or `..` path segments, and must be unique across generated entries and standalone pages.
 - **layout** — template layout name (default: collection-specific or `entry`)
 - **theme** — theme name for this entry; overrides the site-level default (see [Templates](templates.md))
 - **weight** — integer for custom sorting in non-blog collections (lower = first)
 - **language** — language code for multilingual content (e.g., `en`, `ru`)
 - **redirect_to** — URL to redirect to; generates a redirect HTML page (with `<meta http-equiv="refresh">`, JS `window.location.replace()`, and `<link rel="canonical">`) instead of rendering content. Redirect entries are excluded from feeds, sitemaps, listings, archives, and taxonomy pages. Root-relative targets such as `/new-url/` are YiiPress site-root paths; when `base_url` includes a deployment path, YiiPress prefixes that path in the generated redirect target. Absolute URLs are emitted unchanged
 - **extra** — arbitrary key-value pairs accessible in templates
+
+Front matter must be valid YAML key-value pairs. Syntax errors fail the build with the affected file path instead of being ignored.
 
 ### Internal links
 

--- a/docs/importing-content.md
+++ b/docs/importing-content.md
@@ -29,6 +29,7 @@ new ImporterOption(
     description: 'Path to the export directory',
     required: true,
     default: null,
+    path: true,
 )
 ```
 
@@ -36,6 +37,7 @@ new ImporterOption(
 - **`description`** — help text shown in `yii import --help`.
 - **`required`** — whether the option must be provided. The command validates this before calling `import()`.
 - **`default`** — default value when the option is not provided (only for optional options).
+- **`path`** — whether the option value is a filesystem path. Path options are resolved relative to the project root; non-path options such as comma-separated IDs are passed through unchanged.
 
 ### ImportResult
 

--- a/docs/preview.md
+++ b/docs/preview.md
@@ -27,5 +27,5 @@ How it works:
 1. `DevHtmlInjector` injects a small JavaScript snippet before `</body>` in every served HTML response.
 2. The snippet opens an SSE (Server-Sent Events) connection to `/_live-reload`.
 3. The ReactPHP server handles this endpoint directly and attaches all EventSource clients in the same worker to a shared inotify read stream.
-4. When a change is detected, `SiteBuildRunner` triggers a normal build, so live reload benefits from the same incremental build pipeline as manual builds.
-5. After the build completes, the server sends a `reload` event and the browser refreshes.
+4. When a change is detected, `SiteBuildRunner` triggers a normal build, so live reload benefits from the same incremental build pipeline as manual builds. Rebuilds are serialized with a lock so multiple preview workers do not write the same output concurrently.
+5. After a successful build, the server sends a `reload` event and the browser refreshes. If the build fails, the page is not reloaded and the build output is sent to the browser console as a `build-error` event.

--- a/src/Build/AuthorPageWriter.php
+++ b/src/Build/AuthorPageWriter.php
@@ -150,7 +150,7 @@ final class AuthorPageWriter
                 throw new RuntimeException(sprintf('Directory "%s" was not created', $dir));
             }
 
-            file_put_contents($dir . '/index.html', $html);
+            FileWriter::write($dir . '/index.html', $html);
         }
     }
 
@@ -218,7 +218,7 @@ final class AuthorPageWriter
                 throw new RuntimeException(sprintf('Directory "%s" was not created', $dir));
             }
 
-            file_put_contents($dir . '/index.html', $html);
+            FileWriter::write($dir . '/index.html', $html);
         }
     }
 }

--- a/src/Build/BuildCache.php
+++ b/src/Build/BuildCache.php
@@ -52,7 +52,7 @@ final class BuildCache
     public function set(string $sourceFilePath, string $html, string $context = ''): void
     {
         $key = $this->buildKey($sourceFilePath, $context);
-        file_put_contents($this->cacheDir . '/' . $key, $html);
+        FileWriter::write($this->cacheDir . '/' . $key, $html);
     }
 
     public function clear(): void

--- a/src/Build/BuildManifest.php
+++ b/src/Build/BuildManifest.php
@@ -27,28 +27,24 @@ final class BuildManifest
     public function load(): void
     {
         if (!is_file($this->manifestPath)) {
-            $this->entries = [];
+            $this->clear();
             return;
         }
 
         $json = file_get_contents($this->manifestPath);
         if ($json === false) {
-            $this->entries = [];
+            $this->clear();
             return;
         }
 
         try {
             $data = json_decode($json, true, 512, JSON_THROW_ON_ERROR);
         } catch (\JsonException) {
-            $this->entries = [];
-            $this->configFiles = [];
-            $this->trackedDirectories = [];
+            $this->clear();
             return;
         }
         if (!is_array($data)) {
-            $this->entries = [];
-            $this->configFiles = [];
-            $this->trackedDirectories = [];
+            $this->clear();
             return;
         }
 
@@ -60,6 +56,13 @@ final class BuildManifest
         }
 
         $this->entries = $data;
+        $this->configFiles = [];
+        $this->trackedDirectories = [];
+    }
+
+    private function clear(): void
+    {
+        $this->entries = [];
         $this->configFiles = [];
         $this->trackedDirectories = [];
     }

--- a/src/Build/BuildManifest.php
+++ b/src/Build/BuildManifest.php
@@ -37,7 +37,14 @@ final class BuildManifest
             return;
         }
 
-        $data = json_decode($json, true, 512, JSON_THROW_ON_ERROR);
+        try {
+            $data = json_decode($json, true, 512, JSON_THROW_ON_ERROR);
+        } catch (\JsonException) {
+            $this->entries = [];
+            $this->configFiles = [];
+            $this->trackedDirectories = [];
+            return;
+        }
         if (!is_array($data)) {
             $this->entries = [];
             return;
@@ -62,7 +69,7 @@ final class BuildManifest
             throw new RuntimeException(sprintf('Directory "%s" was not created', $dir));
         }
 
-        file_put_contents(
+        FileWriter::writeAtomic(
             $this->manifestPath,
             json_encode([
                 'entries' => $this->entries,

--- a/src/Build/BuildManifest.php
+++ b/src/Build/BuildManifest.php
@@ -47,6 +47,8 @@ final class BuildManifest
         }
         if (!is_array($data)) {
             $this->entries = [];
+            $this->configFiles = [];
+            $this->trackedDirectories = [];
             return;
         }
 

--- a/src/Build/CollectionListingWriter.php
+++ b/src/Build/CollectionListingWriter.php
@@ -90,7 +90,7 @@ final readonly class CollectionListingWriter
                     throw new RuntimeException(sprintf('Directory "%s" was not created', $task['dir']));
                 }
 
-                file_put_contents($task['dir'] . '/index.html', $html);
+                FileWriter::write($task['dir'] . '/index.html', $html);
             }
 
             return 1;

--- a/src/Build/DateArchiveWriter.php
+++ b/src/Build/DateArchiveWriter.php
@@ -160,7 +160,7 @@ final readonly class DateArchiveWriter
                 throw new RuntimeException(sprintf('Directory "%s" was not created', $dir));
             }
 
-            file_put_contents($dir . '/index.html', $html);
+            FileWriter::write($dir . '/index.html', $html);
         }
     }
 
@@ -216,7 +216,7 @@ final readonly class DateArchiveWriter
                 throw new RuntimeException(sprintf('Directory "%s" was not created', $dir));
             }
 
-            file_put_contents($dir . '/index.html', $html);
+            FileWriter::write($dir . '/index.html', $html);
         }
     }
 
@@ -271,7 +271,7 @@ final readonly class DateArchiveWriter
                 throw new RuntimeException(sprintf('Directory "%s" was not created', $dir));
             }
 
-            file_put_contents($dir . '/index.html', $html);
+            FileWriter::write($dir . '/index.html', $html);
         }
     }
 }

--- a/src/Build/FeedGenerator.php
+++ b/src/Build/FeedGenerator.php
@@ -62,9 +62,7 @@ final class FeedGenerator
         Collection $collection,
         array $entries,
     ): void {
-        $xml = $this->createFileWriter($path);
-        $this->writeAtomDocument($xml, $siteConfig, $collection, $this->limitEntries($collection, $entries));
-        $xml->flush();
+        FileWriter::write($path, $this->generateAtom($siteConfig, $collection, $entries));
     }
 
     /**
@@ -76,9 +74,7 @@ final class FeedGenerator
         Collection $collection,
         array $entries,
     ): void {
-        $xml = $this->createFileWriter($path);
-        $this->writeRssDocument($xml, $siteConfig, $collection, $this->limitEntries($collection, $entries));
-        $xml->flush();
+        FileWriter::write($path, $this->generateRss($siteConfig, $collection, $entries));
     }
 
     /**
@@ -289,16 +285,6 @@ final class FeedGenerator
     {
         $xml = new XMLWriter();
         $xml->openMemory();
-        $xml->setIndent(true);
-        $xml->setIndentString('  ');
-
-        return $xml;
-    }
-
-    private function createFileWriter(string $path): XMLWriter
-    {
-        $xml = new XMLWriter();
-        $xml->openUri($path);
         $xml->setIndent(true);
         $xml->setIndentString('  ');
 

--- a/src/Build/FileWriter.php
+++ b/src/Build/FileWriter.php
@@ -1,0 +1,47 @@
+<?php
+
+declare(strict_types=1);
+
+namespace YiiPress\Build;
+
+use RuntimeException;
+
+use function basename;
+use function dirname;
+use function file_put_contents;
+use function getmypid;
+use function is_file;
+use function rename;
+use function sprintf;
+use function strlen;
+use function uniqid;
+use function unlink;
+
+final class FileWriter
+{
+    public static function write(string $path, string $contents): void
+    {
+        $bytes = file_put_contents($path, $contents);
+        if ($bytes === false || $bytes !== strlen($contents)) {
+            throw new RuntimeException(sprintf('Unable to write file "%s".', $path));
+        }
+    }
+
+    public static function writeAtomic(string $path, string $contents): void
+    {
+        $pid = getmypid();
+        $tempPath = dirname($path) . '/.' . basename($path) . '.' . ($pid === false ? 0 : $pid) . '.' . uniqid('', true) . '.tmp';
+
+        try {
+            self::write($tempPath, $contents);
+
+            if (!rename($tempPath, $path)) {
+                throw new RuntimeException(sprintf('Unable to replace file "%s".', $path));
+            }
+        } finally {
+            if (is_file($tempPath)) {
+                unlink($tempPath);
+            }
+        }
+    }
+}

--- a/src/Build/NotFoundPageWriter.php
+++ b/src/Build/NotFoundPageWriter.php
@@ -37,6 +37,6 @@ final readonly class NotFoundPageWriter
             throw new RuntimeException(sprintf('Directory "%s" was not created', $outputDir));
         }
 
-        file_put_contents($outputDir . '/404.html', $html);
+        FileWriter::write($outputDir . '/404.html', $html);
     }
 }

--- a/src/Build/ParallelEntryWriter.php
+++ b/src/Build/ParallelEntryWriter.php
@@ -22,6 +22,7 @@ use function function_exists;
 use function min;
 use function pcntl_fork;
 use function pcntl_wexitstatus;
+use function pcntl_wifexited;
 use function pcntl_waitpid;
 
 final readonly class ParallelEntryWriter
@@ -89,7 +90,7 @@ final readonly class ParallelEntryWriter
         foreach ($tasks as $task) {
             $html = $renderer->render($siteConfig, $task['entry'], $task['permalink'], $navigation, $crossRefResolver, $task['navigationPager'] ?? null);
             if (!$noWrite) {
-                file_put_contents($task['filePath'], $html);
+                FileWriter::write($task['filePath'], $html);
             }
         }
     }
@@ -115,7 +116,7 @@ final readonly class ParallelEntryWriter
                 foreach ($chunk as $task) {
                     $html = $renderer->render($siteConfig, $task['entry'], $task['permalink'], $navigation, $crossRefResolver, $task['navigationPager'] ?? null);
                     if (!$noWrite) {
-                        file_put_contents($task['filePath'], $html);
+                        FileWriter::write($task['filePath'], $html);
                     }
                 }
 
@@ -128,7 +129,7 @@ final readonly class ParallelEntryWriter
         $failed = false;
         foreach ($pids as $pid) {
             pcntl_waitpid($pid, $status);
-            if (pcntl_wexitstatus($status) !== 0) {
+            if (!pcntl_wifexited($status) || pcntl_wexitstatus($status) !== 0) {
                 $failed = true;
             }
         }

--- a/src/Build/ParallelTaskRunner.php
+++ b/src/Build/ParallelTaskRunner.php
@@ -10,13 +10,13 @@ use function array_slice;
 use function ceil;
 use function count;
 use function file_get_contents;
-use function file_put_contents;
 use function function_exists;
 use function is_dir;
 use function mkdir;
 use function min;
 use function pcntl_fork;
 use function pcntl_wexitstatus;
+use function pcntl_wifexited;
 use function pcntl_waitpid;
 use function rmdir;
 use function sys_get_temp_dir;
@@ -62,7 +62,7 @@ final class ParallelTaskRunner
 
                 if ($pid === 0) {
                     $count = $this->runSequential($chunk, $taskRunner);
-                    file_put_contents($resultFile, (string) $count);
+                    FileWriter::write($resultFile, (string) $count);
                     exit(0);
                 }
 
@@ -72,7 +72,7 @@ final class ParallelTaskRunner
 
             foreach ($pids as $pid) {
                 pcntl_waitpid($pid, $status);
-                if (pcntl_wexitstatus($status) !== 0) {
+                if (!pcntl_wifexited($status) || pcntl_wexitstatus($status) !== 0) {
                     throw new RuntimeException('One or more worker processes failed');
                 }
             }

--- a/src/Build/RedirectPageWriter.php
+++ b/src/Build/RedirectPageWriter.php
@@ -71,6 +71,6 @@ final class RedirectPageWriter
             throw new RuntimeException(sprintf('Directory "%s" was not created', $dirPath));
         }
 
-        file_put_contents($filePath, $html);
+        FileWriter::write($filePath, $html);
     }
 }

--- a/src/Build/SearchIndexGenerator.php
+++ b/src/Build/SearchIndexGenerator.php
@@ -64,7 +64,7 @@ final class SearchIndexGenerator
 
         $json = json_encode($items, JSON_THROW_ON_ERROR | JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES);
         if (!$noWrite) {
-            file_put_contents($outputDir . '/search-index.json', $json);
+            FileWriter::write($outputDir . '/search-index.json', $json);
         }
     }
 }

--- a/src/Build/TaxonomyPageWriter.php
+++ b/src/Build/TaxonomyPageWriter.php
@@ -85,7 +85,7 @@ final readonly class TaxonomyPageWriter
                 throw new RuntimeException(sprintf('Directory "%s" was not created', $dir));
             }
 
-            file_put_contents($dir . '/index.html', $html);
+            FileWriter::write($dir . '/index.html', $html);
         }
     }
 
@@ -143,7 +143,7 @@ final readonly class TaxonomyPageWriter
                 throw new RuntimeException(sprintf('Directory "%s" was not created', $dir));
             }
 
-            file_put_contents($dir . '/index.html', $html);
+            FileWriter::write($dir . '/index.html', $html);
         }
     }
 }

--- a/src/Console/BuildCommand.php
+++ b/src/Console/BuildCommand.php
@@ -1401,11 +1401,11 @@ final class BuildCommand extends Command
             );
         }
 
-        if (str_contains($permalink, "\0") || str_contains($permalink, '\\')) {
+        if (str_contains($permalink, "\0") || str_contains($permalink, '\\') || str_contains($permalink, '//')) {
             throw new InvalidContentConfigException(
                 sprintf('Invalid permalink "%s" in %s.', $permalink, $sourcePath),
                 $sourcePath,
-                'Permalinks must use URL path separators and must not contain control characters.',
+                'Permalinks must use single URL path separators and must not contain control characters.',
             );
         }
 

--- a/src/Console/BuildCommand.php
+++ b/src/Console/BuildCommand.php
@@ -21,6 +21,7 @@ use YiiPress\Build\SearchIndexGenerator;
 use YiiPress\Build\ThemeAssetCopier;
 use YiiPress\Build\FeedGenerator;
 use YiiPress\Build\FileCopy;
+use YiiPress\Build\FileWriter;
 use YiiPress\Build\ParallelEntryWriter;
 use YiiPress\Build\ParallelTaskRunner;
 use YiiPress\Build\SitemapGenerator;
@@ -104,6 +105,7 @@ use function yaml_parse;
 final class BuildCommand extends Command
 {
     private const int MAX_AUTO_WORKERS = 4;
+    private const string OUTPUT_MARKER_FILE = '.yiipress-build';
 
     public function __construct(
         private readonly string $rootPath,
@@ -190,6 +192,8 @@ final class BuildCommand extends Command
         /** @var string $outputDirOption */
         $outputDirOption = $input->getOption('output-dir');
         $outputDir = $this->resolvePath($outputDirOption, $rootPath);
+        $finalOutputDir = $outputDir;
+        $atomicOutputDir = null;
 
         /** @var string $workersOption */
         $workersOption = $input->getOption('workers');
@@ -277,9 +281,7 @@ final class BuildCommand extends Command
             $staleOutputs = $manifest->removedOutputs($allSourceFiles);
 
             foreach ($staleOutputs as $staleFile) {
-                if (is_file($staleFile)) {
-                    unlink($staleFile);
-                }
+                $this->removeOutputFile($staleFile, $outputDir);
             }
 
             if ($changedSourceFiles === [] && $staleOutputs === []) {
@@ -313,7 +315,10 @@ final class BuildCommand extends Command
             );
 
             if (!$noWrite) {
-                $this->prepareOutputDir($outputDir);
+                $atomicOutputDir = $this->prepareOutputDir($outputDir);
+                if ($atomicOutputDir !== null) {
+                    $outputDir = $atomicOutputDir;
+                }
             }
         }
 
@@ -358,7 +363,14 @@ final class BuildCommand extends Command
         $output->writeln('  Menus: <comment>' . count($navigation->menuNames()) . '</comment>');
 
         if ($dryRun) {
-            $exitCode = $this->dryRun($output, $parser, $siteConfig, $collections, $authors, $contentDir, $outputDir, $includeDrafts, $includeFuture);
+            try {
+                $exitCode = $this->dryRun($output, $parser, $siteConfig, $collections, $authors, $contentDir, $outputDir, $includeDrafts, $includeFuture);
+            } catch (FriendlyExceptionInterface $e) {
+                $this->writeFriendlyException($output, $e);
+                $this->writeProfile($output, $profile);
+
+                return ExitCode::DATAERR;
+            }
             $this->writeProfile($output, $profile);
             return $exitCode;
         }
@@ -368,33 +380,45 @@ final class BuildCommand extends Command
         /** @var array<string, list<Entry>> $rawEntriesByCollection */
         $rawEntriesByCollection = [];
         $fileToPermalink = [];
+        $permalinkSources = [];
 
-        foreach ($collections as $collectionName => $collection) {
-            $collectionEntries = [];
-            foreach ($parser->parseEntries($contentDir, $collectionName) as $entry) {
-                $sourcePath = $entry->filePath;
-                if ($entry->title === '') {
+        try {
+            foreach ($collections as $collectionName => $collection) {
+                $collectionEntries = [];
+                foreach ($parser->parseEntries($contentDir, $collectionName) as $entry) {
+                    $sourcePath = $entry->filePath;
+                    if ($entry->title === '') {
+                        $output->writeln('<error>  Skipping ' . $sourcePath . ': no title found</error>');
+                        continue;
+                    }
+                    $collectionEntries[] = $entry;
+                    $relativePath = substr($sourcePath, strlen($contentDir) + 1);
+                    $permalink = PermalinkResolver::resolve($entry, $collection, $siteConfig->i18n);
+                    $this->registerPermalink($permalinkSources, $permalink, $sourcePath);
+                    $fileToPermalink[$relativePath] = $permalink;
+                }
+                $rawEntriesByCollection[$collectionName] = $collectionEntries;
+            }
+
+            $standalonePages = [];
+            foreach ($parser->parseStandalonePages($contentDir) as $page) {
+                $sourcePath = $page->filePath;
+                if ($page->title === '') {
                     $output->writeln('<error>  Skipping ' . $sourcePath . ': no title found</error>');
                     continue;
                 }
-                $collectionEntries[] = $entry;
+                $standalonePages[] = $page;
                 $relativePath = substr($sourcePath, strlen($contentDir) + 1);
-                $fileToPermalink[$relativePath] = PermalinkResolver::resolve($entry, $collection, $siteConfig->i18n);
+                $basePermalink = $page->permalink !== '' ? $page->permalink : '/' . $page->slug . '/';
+                $permalink = PermalinkResolver::applyLanguagePrefix($basePermalink, $page->language, $siteConfig->i18n);
+                $this->registerPermalink($permalinkSources, $permalink, $sourcePath);
+                $fileToPermalink[$relativePath] = $permalink;
             }
-            $rawEntriesByCollection[$collectionName] = $collectionEntries;
-        }
+        } catch (FriendlyExceptionInterface $e) {
+            $this->writeFriendlyException($output, $e);
+            $this->writeProfile($output, $profile);
 
-        $standalonePages = [];
-        foreach ($parser->parseStandalonePages($contentDir) as $page) {
-            $sourcePath = $page->filePath;
-            if ($page->title === '') {
-                $output->writeln('<error>  Skipping ' . $sourcePath . ': no title found</error>');
-                continue;
-            }
-            $standalonePages[] = $page;
-            $relativePath = substr($sourcePath, strlen($contentDir) + 1);
-            $basePermalink = $page->permalink !== '' ? $page->permalink : '/' . $page->slug . '/';
-            $fileToPermalink[$relativePath] = PermalinkResolver::applyLanguagePrefix($basePermalink, $page->language, $siteConfig->i18n);
+            return ExitCode::DATAERR;
         }
 
         $crossRefResolver = new CrossReferenceResolver($fileToPermalink);
@@ -530,16 +554,16 @@ final class BuildCommand extends Command
 
         if ($manifest !== null) {
             foreach ($allTasks as $task) {
-                $this->removeStaleOutputs($manifest->replace($task['sourcePath'], [$task['filePath']]));
+                $this->removeStaleOutputs($manifest->replace($task['sourcePath'], [$task['filePath']]), $outputDir);
             }
             foreach ($redirectTasks as $task) {
-                $this->removeStaleOutputs($manifest->replace($task['sourcePath'], [$task['filePath']]));
+                $this->removeStaleOutputs($manifest->replace($task['sourcePath'], [$task['filePath']]), $outputDir);
             }
             foreach ($rawEntriesByCollection as $entries) {
                 foreach ($entries as $entry) {
                     $sourcePath = $entry->filePath;
                     if (!isset($manifest->entries()[$sourcePath])) {
-                        $this->removeStaleOutputs($manifest->replace($sourcePath, []));
+                        $this->removeStaleOutputs($manifest->replace($sourcePath, []), $outputDir);
                     }
                 }
             }
@@ -611,10 +635,10 @@ final class BuildCommand extends Command
 
         if ($manifest !== null) {
             foreach ($standaloneTasks as $task) {
-                $this->removeStaleOutputs($manifest->replace($task['sourcePath'], [$task['filePath']]));
+                $this->removeStaleOutputs($manifest->replace($task['sourcePath'], [$task['filePath']]), $outputDir);
             }
             foreach ($standaloneRedirectTasks as $task) {
-                $this->removeStaleOutputs($manifest->replace($task['sourcePath'], [$task['filePath']]));
+                $this->removeStaleOutputs($manifest->replace($task['sourcePath'], [$task['filePath']]), $outputDir);
             }
         }
 
@@ -645,7 +669,7 @@ final class BuildCommand extends Command
         if ($manifest !== null) {
             foreach ($allAssetMappings as $sourcePath => $logicalPath) {
                 $resolvedTarget = $assetManifest?->resolve($logicalPath) ?? $logicalPath;
-                $this->removeStaleOutputs($manifest->replace($sourcePath, [$outputDir . '/' . $resolvedTarget]));
+                $this->removeStaleOutputs($manifest->replace($sourcePath, [$outputDir . '/' . $resolvedTarget]), $outputDir);
             }
         }
 
@@ -775,7 +799,7 @@ final class BuildCommand extends Command
         $robots = $robotsGenerator->generate($siteConfig);
         if ($robots !== '') {
             if (!$noWrite) {
-                file_put_contents($outputDir . '/robots.txt', $robots);
+                FileWriter::write($outputDir . '/robots.txt', $robots);
             }
             $output->writeln('  robots.txt generated.');
         }
@@ -818,9 +842,19 @@ final class BuildCommand extends Command
             $manifest->setConfigFiles($configFiles);
             $manifest->setTrackedDirectories($trackedDirectories);
             foreach ($configFiles as $configFile) {
-                $this->removeStaleOutputs($manifest->replace($configFile, []));
+                $this->removeStaleOutputs($manifest->replace($configFile, []), $outputDir);
             }
             $manifest->save();
+        }
+
+        if (!$noWrite) {
+            $this->writeOutputMarker($outputDir);
+        }
+
+        if ($atomicOutputDir !== null) {
+            $this->replaceOutputDir($atomicOutputDir, $finalOutputDir);
+            $outputDir = $finalOutputDir;
+            $atomicOutputDir = null;
         }
 
         $this->eventDispatcher?->dispatch(new BuildFinishedEvent($buildContext, $siteConfig));
@@ -1206,13 +1240,168 @@ final class BuildCommand extends Command
         return ExitCode::OK;
     }
 
-    private function prepareOutputDir(string $outputDir): void
+    private function prepareOutputDir(string $outputDir): ?string
     {
-        if (is_dir($outputDir)) {
-            exec('rm -rf ' . escapeshellarg($outputDir));
+        $this->assertReplaceableOutputDir($outputDir);
+
+        if (!file_exists($outputDir)) {
+            if (!mkdir($outputDir, 0o755, true) && !is_dir($outputDir)) {
+                throw new RuntimeException(sprintf('Directory "%s" was not created', $outputDir));
+            }
+
+            return null;
         }
-        if (!mkdir($outputDir, 0o755, true) && !is_dir($outputDir)) {
-            throw new RuntimeException(sprintf('Directory "%s" was not created', $outputDir));
+
+        if ($this->isEmptyDirectory($outputDir)) {
+            return null;
+        }
+
+        $parentDir = dirname($outputDir);
+        if (!is_dir($parentDir) && !mkdir($parentDir, 0o755, true) && !is_dir($parentDir)) {
+            throw new RuntimeException(sprintf('Directory "%s" was not created', $parentDir));
+        }
+
+        $tempDir = $parentDir . '/.' . basename($outputDir) . '.tmp-' . bin2hex(random_bytes(6));
+        if (!mkdir($tempDir, 0o755, true) && !is_dir($tempDir)) {
+            throw new RuntimeException(sprintf('Directory "%s" was not created', $tempDir));
+        }
+
+        return $tempDir;
+    }
+
+    private function assertReplaceableOutputDir(string $outputDir): void
+    {
+        if (!file_exists($outputDir)) {
+            return;
+        }
+
+        if (!is_dir($outputDir)) {
+            throw new RuntimeException(sprintf('Output path exists and is not a directory: "%s".', $outputDir));
+        }
+
+        if ($this->isEmptyDirectory($outputDir) || is_file($outputDir . '/' . self::OUTPUT_MARKER_FILE)) {
+            return;
+        }
+
+        throw new RuntimeException(sprintf(
+            'Refusing to replace output directory "%s" because it does not contain a %s marker.',
+            $outputDir,
+            self::OUTPUT_MARKER_FILE,
+        ));
+    }
+
+    private function replaceOutputDir(string $sourceDir, string $targetDir): void
+    {
+        if (!is_dir($sourceDir)) {
+            throw new RuntimeException(sprintf('Output directory "%s" was not built.', $sourceDir));
+        }
+
+        if (!file_exists($targetDir)) {
+            if (!rename($sourceDir, $targetDir)) {
+                throw new RuntimeException(sprintf('Unable to move "%s" to "%s".', $sourceDir, $targetDir));
+            }
+            return;
+        }
+
+        $backupDir = dirname($targetDir) . '/.' . basename($targetDir) . '.old-' . bin2hex(random_bytes(6));
+        if (!rename($targetDir, $backupDir)) {
+            throw new RuntimeException(sprintf('Unable to move existing output directory "%s".', $targetDir));
+        }
+
+        if (!rename($sourceDir, $targetDir)) {
+            rename($backupDir, $targetDir);
+            throw new RuntimeException(sprintf('Unable to move "%s" to "%s".', $sourceDir, $targetDir));
+        }
+
+        $this->removeDirectory($backupDir);
+    }
+
+    private function writeOutputMarker(string $outputDir): void
+    {
+        FileWriter::write($outputDir . '/' . self::OUTPUT_MARKER_FILE, "YiiPress build output\n");
+    }
+
+    private function isEmptyDirectory(string $directory): bool
+    {
+        $iterator = new FilesystemIterator($directory, FilesystemIterator::SKIP_DOTS);
+
+        return !$iterator->valid();
+    }
+
+    private function removeDirectory(string $directory): void
+    {
+        if (!is_dir($directory)) {
+            return;
+        }
+
+        $iterator = new RecursiveIteratorIterator(
+            new RecursiveDirectoryIterator($directory, FilesystemIterator::SKIP_DOTS),
+            RecursiveIteratorIterator::CHILD_FIRST,
+        );
+
+        foreach ($iterator as $item) {
+            /** @var SplFileInfo $item */
+            if ($item->isDir() && !$item->isLink()) {
+                rmdir($item->getPathname());
+                continue;
+            }
+
+            unlink($item->getPathname());
+        }
+
+        rmdir($directory);
+    }
+
+    /**
+     * @param array<string, string> $permalinkSources
+     */
+    private function registerPermalink(array &$permalinkSources, string $permalink, string $sourcePath): void
+    {
+        $this->validatePermalink($permalink, $sourcePath);
+
+        $normalized = $permalink === '/' ? '/' : rtrim($permalink, '/');
+        if (isset($permalinkSources[$normalized])) {
+            throw new InvalidContentConfigException(
+                sprintf(
+                    'Duplicate permalink "%s" in %s and %s.',
+                    $permalink,
+                    $permalinkSources[$normalized],
+                    $sourcePath,
+                ),
+                $sourcePath,
+                'Change one of the permalink values so each generated page has a unique output path.',
+            );
+        }
+
+        $permalinkSources[$normalized] = $sourcePath;
+    }
+
+    private function validatePermalink(string $permalink, string $sourcePath): void
+    {
+        if ($permalink === '' || !str_starts_with($permalink, '/')) {
+            throw new InvalidContentConfigException(
+                sprintf('Invalid permalink "%s" in %s.', $permalink, $sourcePath),
+                $sourcePath,
+                'Permalinks must be root-relative paths, for example: permalink: /blog/my-post/',
+            );
+        }
+
+        if (str_contains($permalink, "\0") || str_contains($permalink, '\\')) {
+            throw new InvalidContentConfigException(
+                sprintf('Invalid permalink "%s" in %s.', $permalink, $sourcePath),
+                $sourcePath,
+                'Permalinks must use URL path separators and must not contain control characters.',
+            );
+        }
+
+        foreach (explode('/', trim($permalink, '/')) as $segment) {
+            if ($segment === '.' || $segment === '..') {
+                throw new InvalidContentConfigException(
+                    sprintf('Invalid permalink "%s" in %s.', $permalink, $sourcePath),
+                    $sourcePath,
+                    'Permalinks must stay inside the output directory and cannot contain "." or ".." path segments.',
+                );
+            }
         }
     }
 
@@ -1228,12 +1417,22 @@ final class BuildCommand extends Command
     /**
      * @param list<string> $outputFiles
      */
-    private function removeStaleOutputs(array $outputFiles): void
+    private function removeStaleOutputs(array $outputFiles, string $outputDir): void
     {
         foreach ($outputFiles as $outputFile) {
-            if (is_file($outputFile)) {
-                unlink($outputFile);
-            }
+            $this->removeOutputFile($outputFile, $outputDir);
+        }
+    }
+
+    private function removeOutputFile(string $outputFile, string $outputDir): void
+    {
+        $outputRoot = rtrim($outputDir, '/');
+        if ($outputFile !== $outputRoot && !str_starts_with($outputFile, $outputRoot . '/')) {
+            return;
+        }
+
+        if (is_file($outputFile)) {
+            unlink($outputFile);
         }
     }
 

--- a/src/Console/BuildCommand.php
+++ b/src/Console/BuildCommand.php
@@ -91,6 +91,7 @@ use function shell_exec;
 use function round;
 use function sort;
 use function sprintf;
+use function str_ends_with;
 use function str_starts_with;
 use function strtolower;
 use function substr;
@@ -322,6 +323,7 @@ final class BuildCommand extends Command
             }
         }
 
+        try {
         if ($manifest !== null && $allSourceFiles === []) {
             $sourceInventory = $this->collectSourceInventory($contentDir, array_keys($allAssetMappings));
             $configFiles = $sourceInventory['configFiles'];
@@ -870,6 +872,11 @@ final class BuildCommand extends Command
         );
 
         return ExitCode::OK;
+        } finally {
+            if ($atomicOutputDir !== null) {
+                $this->removeDirectory($atomicOutputDir);
+            }
+        }
     }
 
     private function formatElapsedTime(float $seconds): string
@@ -1383,6 +1390,14 @@ final class BuildCommand extends Command
                 sprintf('Invalid permalink "%s" in %s.', $permalink, $sourcePath),
                 $sourcePath,
                 'Permalinks must be root-relative paths, for example: permalink: /blog/my-post/',
+            );
+        }
+
+        if ($permalink !== '/' && !str_ends_with($permalink, '/')) {
+            throw new InvalidContentConfigException(
+                sprintf('Invalid permalink "%s" in %s.', $permalink, $sourcePath),
+                $sourcePath,
+                'Permalinks must end with a trailing slash so YiiPress can write an index.html page.',
             );
         }
 

--- a/src/Console/ImportCommand.php
+++ b/src/Console/ImportCommand.php
@@ -146,7 +146,7 @@ final class ImportCommand extends Command
         foreach ($importer->options() as $option) {
             $value = $rawOptions[$option->name] ?? $option->default;
 
-            if ($value !== null && $value !== '') {
+            if ($option->path && $value !== null && $value !== '') {
                 $value = $this->resolvePath($value, $this->rootPath);
             }
 

--- a/src/Console/InitCommand.php
+++ b/src/Console/InitCommand.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace YiiPress\Console;
 
-use RuntimeException;
+use YiiPress\Build\FileWriter;
 use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
@@ -16,8 +16,6 @@ use Yiisoft\Yii\Console\ExitCode;
 use function array_keys;
 use function dirname;
 use function file_exists;
-use function file_put_contents;
-use function sprintf;
 use function str_starts_with;
 
 #[AsCommand(
@@ -65,10 +63,7 @@ final class InitCommand extends Command
 
         foreach ($files as $filePath => $contents) {
             FileHelper::ensureDirectory(dirname($filePath), 0o755);
-
-            if (file_put_contents($filePath, $contents) === false) {
-                throw new RuntimeException(sprintf('File "%s" was not written', $filePath));
-            }
+            FileWriter::write($filePath, $contents);
 
             $output->writeln("Created: <info>$filePath</info>");
         }

--- a/src/Console/NewCommand.php
+++ b/src/Console/NewCommand.php
@@ -7,6 +7,7 @@ namespace YiiPress\Console;
 use YiiPress\Content\Parser\CollectionConfigParser;
 use YiiPress\Content\Parser\SiteConfigParser;
 use YiiPress\Content\Slugifier;
+use YiiPress\Build\FileWriter;
 use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputArgument;
@@ -130,7 +131,7 @@ final class NewCommand extends Command
 
         FileHelper::ensureDirectory(dirname($filePath), 0o755);
 
-        file_put_contents($filePath, $frontMatter);
+        FileWriter::write($filePath, $frontMatter);
 
         $output->writeln("Created: <info>$filePath</info>");
         return ExitCode::OK;
@@ -156,7 +157,7 @@ final class NewCommand extends Command
         }
         $frontMatter .= "---\n\n";
 
-        file_put_contents($filePath, $frontMatter);
+        FileWriter::write($filePath, $frontMatter);
 
         $output->writeln("Created: <info>$filePath</info>");
         return ExitCode::OK;

--- a/src/Console/ServeCommand.php
+++ b/src/Console/ServeCommand.php
@@ -412,8 +412,9 @@ final class ServeCommand extends Command
                 return;
             }
 
-            $this->buildLiveReloadSite();
-            $this->broadcastLiveReloadEvent('reload', 'changed', true);
+            if ($this->buildLiveReloadSite()) {
+                $this->broadcastLiveReloadEvent('reload', 'changed', true);
+            }
         });
     }
 
@@ -429,7 +430,7 @@ final class ServeCommand extends Command
                 $this->finishLiveReloadResponse($client, $event, $data);
                 unset($this->liveReloadClients[$clientId]);
             } else {
-                $client->write("event: {$event}\ndata: {$data}\n\n");
+                $client->write($this->formatServerSentEvent($event, $data));
             }
         }
     }
@@ -461,20 +462,38 @@ final class ServeCommand extends Command
         $this->liveReloadClients = [];
     }
 
-    private function buildLiveReloadSite(): void
+    private function buildLiveReloadSite(): bool
     {
         $now = microtime(true);
         if ($now - $this->lastLiveReloadBuildTime < 1.0) {
-            return;
+            return false;
         }
 
         $this->lastLiveReloadBuildTime = $now;
-        $this->createLiveReloadBuildRunner()->build();
+        $runner = $this->createLiveReloadBuildRunner();
+        if ($runner->build()) {
+            return true;
+        }
+
+        $message = trim($runner->lastOutput());
+        $this->broadcastLiveReloadEvent('build-error', $message !== '' ? $message : 'Build failed.', false);
+
+        return false;
     }
 
     private function finishLiveReloadResponse(ConnectionInterface $connection, string $event, string $data): void
     {
-        $connection->end("event: {$event}\ndata: {$data}\n\n");
+        $connection->end($this->formatServerSentEvent($event, $data));
+    }
+
+    private function formatServerSentEvent(string $event, string $data): string
+    {
+        $message = "event: {$event}\n";
+        foreach (explode("\n", str_replace("\r\n", "\n", $data)) as $line) {
+            $message .= "data: {$line}\n";
+        }
+
+        return $message . "\n";
     }
 
     private function createLiveReloadBuildRunner(): SiteBuildRunner

--- a/src/Content/Parser/EntryParser.php
+++ b/src/Content/Parser/EntryParser.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace YiiPress\Content\Parser;
 
 use YiiPress\Content\Model\Entry;
+use DateMalformedStringException;
 use DateTimeImmutable;
 
 use function is_array;
@@ -51,9 +52,17 @@ final readonly class EntryParser
 
         $filenameParsed = $this->filenameParser->parse($filePath);
 
-        $date = isset($fields['date'])
-            ? new DateTimeImmutable((string) $fields['date'])
-            : $filenameParsed['date'];
+        try {
+            $date = isset($fields['date'])
+                ? new DateTimeImmutable((string) $fields['date'])
+                : $filenameParsed['date'];
+        } catch (DateMalformedStringException) {
+            throw new InvalidContentConfigException(
+                "Invalid date in front matter: $filePath",
+                $filePath,
+                'Use a date value accepted by PHP DateTimeImmutable, for example: date: 2024-03-15',
+            );
+        }
 
         $slug = (string) ($fields['slug'] ?? $filenameParsed['slug']);
 

--- a/src/Content/Parser/FrontMatterParser.php
+++ b/src/Content/Parser/FrontMatterParser.php
@@ -6,6 +6,7 @@ namespace YiiPress\Content\Parser;
 
 use RuntimeException;
 
+use function array_is_list;
 use function fclose;
 use function fgets;
 use function fopen;
@@ -36,7 +37,7 @@ final class FrontMatterParser
         }
 
         try {
-            return $this->extract($handle, $fileSize);
+            return $this->extract($handle, $fileSize, $filePath);
         } finally {
             fclose($handle);
         }
@@ -46,7 +47,7 @@ final class FrontMatterParser
      * @param resource $handle
      * @return array{frontMatter: array<string, mixed>, bodyOffset: int, bodyLength: int}
      */
-    private function extract($handle, int $fileSize): array
+    private function extract($handle, int $fileSize, string $filePath): array
     {
         $firstLine = fgets($handle);
         if ($firstLine === false || !str_starts_with(trim($firstLine), '---')) {
@@ -68,9 +69,29 @@ final class FrontMatterParser
                 }
 
                 $yaml = implode('', $yamlLines);
-                $parsed = yaml_parse($yaml);
+                $parsed = trim($yaml) === '' ? null : @yaml_parse($yaml);
                 if ($parsed === false) {
+                    throw new InvalidContentConfigException(
+                        "Invalid YAML in front matter: $filePath",
+                        $filePath,
+                        "Fix the YAML front matter between the opening and closing --- markers in $filePath.",
+                    );
+                }
+
+                if ($parsed === null) {
                     $parsed = [];
+                }
+
+                if (!is_array($parsed) || ($parsed !== [] && array_is_list($parsed))) {
+                    throw new InvalidContentConfigException(
+                        "Front matter must contain YAML key-value pairs: $filePath",
+                        $filePath,
+                        implode("\n", [
+                            'Use mappings such as:',
+                            'title: My Post',
+                            'tags: [php, yii]',
+                        ]),
+                    );
                 }
 
                 $result = [

--- a/src/Import/ImporterOption.php
+++ b/src/Import/ImporterOption.php
@@ -17,5 +17,6 @@ final readonly class ImporterOption
         public string $description,
         public bool $required = false,
         public ?string $default = null,
+        public bool $path = false,
     ) {}
 }

--- a/src/Import/Telegram/TelegramContentImporter.php
+++ b/src/Import/Telegram/TelegramContentImporter.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace YiiPress\Import\Telegram;
 
+use YiiPress\Build\FileWriter;
 use YiiPress\Import\ContentImporterInterface;
 use YiiPress\Import\ImporterOption;
 use YiiPress\Import\ImportResult;
@@ -21,6 +22,7 @@ final class TelegramContentImporter implements ContentImporterInterface
                 name: 'directory',
                 description: 'Path to the Telegram export directory containing result.json',
                 required: true,
+                path: true,
             ),
             new ImporterOption(
                 name: 'ignore_message_ids',
@@ -150,7 +152,7 @@ final class TelegramContentImporter implements ContentImporterInterface
             }
 
             $content = $this->buildMarkdownFile($message, $mediaPath, $collection);
-            file_put_contents($filePath, $content);
+            FileWriter::write($filePath, $content);
             $importedFiles[] = $filePath;
         }
 
@@ -250,7 +252,7 @@ final class TelegramContentImporter implements ContentImporterInterface
         $config .= "entries_per_page: 10\n";
         $config .= "feed: true\n";
 
-        file_put_contents($configPath, $config);
+        FileWriter::write($configPath, $config);
     }
 
     private function parseIgnoredIds(string $ignoreMessageIds): array

--- a/src/Web/DevServer/assets/live-reload.js
+++ b/src/Web/DevServer/assets/live-reload.js
@@ -19,6 +19,7 @@
         }
         es = new EventSource("/_live-reload");
         es.addEventListener("reload", function() { es.close(); location.reload(); });
+        es.addEventListener("build-error", function(event) { if (event.data) { console.error(event.data); } });
         es.addEventListener("ping", function() {});
         es.onerror = function() {
             es.close();

--- a/src/Web/LiveReload/SiteBuildRunner.php
+++ b/src/Web/LiveReload/SiteBuildRunner.php
@@ -46,10 +46,8 @@ final class SiteBuildRunner
 
             return $exitCode === 0;
         } finally {
-            if ($lock !== false) {
-                flock($lock, LOCK_UN);
-                fclose($lock);
-            }
+            flock($lock, LOCK_UN);
+            fclose($lock);
         }
     }
 

--- a/src/Web/LiveReload/SiteBuildRunner.php
+++ b/src/Web/LiveReload/SiteBuildRunner.php
@@ -4,24 +4,46 @@ declare(strict_types=1);
 
 namespace YiiPress\Web\LiveReload;
 
-final readonly class SiteBuildRunner
+final class SiteBuildRunner
 {
+    private string $lastOutput;
+
     public function __construct(
         private string $yiiBinary,
         private string $contentDir,
         private string $outputDir,
-    ) {}
+    ) {
+        $this->lastOutput = '';
+    }
 
     public function build(): bool
     {
+        $lock = fopen(sys_get_temp_dir() . '/yiipress-build-' . hash('xxh128', $this->outputDir) . '.lock', 'c');
+        if ($lock !== false) {
+            flock($lock, LOCK_EX);
+        }
+
         $command = escapeshellarg($this->yiiBinary)
             . ' build'
             . ' --content-dir=' . escapeshellarg($this->contentDir)
             . ' --output-dir=' . escapeshellarg($this->outputDir)
             . ' 2>&1';
 
-        exec($command, $output, $exitCode);
+        try {
+            exec($command, $output, $exitCode);
+            $this->lastOutput = implode("\n", $output);
 
-        return $exitCode === 0;
+            return $exitCode === 0;
+        } finally {
+            if ($lock !== false) {
+                flock($lock, LOCK_UN);
+                fclose($lock);
+            }
+        }
+    }
+
+    public function lastOutput(): string
+    {
+        return $this->lastOutput;
     }
 }

--- a/src/Web/LiveReload/SiteBuildRunner.php
+++ b/src/Web/LiveReload/SiteBuildRunner.php
@@ -18,9 +18,20 @@ final class SiteBuildRunner
 
     public function build(): bool
     {
-        $lock = fopen(sys_get_temp_dir() . '/yiipress-build-' . hash('xxh128', $this->outputDir) . '.lock', 'c');
-        if ($lock !== false) {
-            flock($lock, LOCK_EX);
+        $lockId = hash('xxh128', $this->outputDir);
+        $lockPath = sys_get_temp_dir() . '/yiipress-build-' . $lockId . '.lock';
+        $lock = fopen($lockPath, 'c');
+        if ($lock === false) {
+            $this->lastOutput = sprintf('Unable to open build lock "%s" (%s).', $lockPath, $lockId);
+
+            return false;
+        }
+
+        if (!flock($lock, LOCK_EX)) {
+            fclose($lock);
+            $this->lastOutput = sprintf('Unable to acquire build lock "%s" (%s).', $lockPath, $lockId);
+
+            return false;
         }
 
         $command = escapeshellarg($this->yiiBinary)

--- a/tests/Unit/Build/BuildManifestTest.php
+++ b/tests/Unit/Build/BuildManifestTest.php
@@ -145,6 +145,30 @@ final class BuildManifestTest extends TestCase
         assertSame([], $manifest->sourceFiles());
     }
 
+    public function testInvalidManifestPayloadClearsPreviouslyLoadedMetadata(): void
+    {
+        $sourceFile = $this->tempDir . '/entry.md';
+        $contentDir = $this->tempDir . '/content';
+        $manifestPath = $this->tempDir . '/manifest.json';
+        file_put_contents($sourceFile, '# Hello');
+        mkdir($contentDir, 0o755, true);
+
+        $manifest = new BuildManifest($manifestPath);
+        $manifest->record($sourceFile, ['/out/entry/index.html']);
+        $manifest->setConfigFiles([$contentDir . '/config.yaml']);
+        $manifest->setTrackedDirectories([$contentDir => (int) filemtime($contentDir)]);
+        $manifest->save();
+        $manifest->load();
+
+        file_put_contents($manifestPath, '"invalid"');
+        $manifest->load();
+
+        assertSame([], $manifest->entries());
+        assertSame([], $manifest->configFiles());
+        assertSame([], $manifest->sourceFiles());
+        assertFalse($manifest->hasTrackedDirectories());
+    }
+
     public function testReplaceReturnsOutputsThatAreNoLongerReferenced(): void
     {
         $sourceFile = $this->tempDir . '/asset.css';

--- a/tests/Unit/Build/BuildManifestTest.php
+++ b/tests/Unit/Build/BuildManifestTest.php
@@ -132,6 +132,19 @@ final class BuildManifestTest extends TestCase
         assertSame([], $manifest->removedOutputs([$sourceFile]));
     }
 
+    public function testCorruptedManifestLoadsAsEmptyManifest(): void
+    {
+        $manifestPath = $this->tempDir . '/manifest.json';
+        file_put_contents($manifestPath, '{"entries":');
+
+        $manifest = new BuildManifest($manifestPath);
+        $manifest->load();
+
+        assertSame([], $manifest->entries());
+        assertSame([], $manifest->configFiles());
+        assertSame([], $manifest->sourceFiles());
+    }
+
     public function testReplaceReturnsOutputsThatAreNoLongerReferenced(): void
     {
         $sourceFile = $this->tempDir . '/asset.css';

--- a/tests/Unit/Build/BuildManifestTest.php
+++ b/tests/Unit/Build/BuildManifestTest.php
@@ -169,6 +169,30 @@ final class BuildManifestTest extends TestCase
         assertFalse($manifest->hasTrackedDirectories());
     }
 
+    public function testMissingManifestClearsPreviouslyLoadedMetadata(): void
+    {
+        $sourceFile = $this->tempDir . '/entry.md';
+        $contentDir = $this->tempDir . '/content';
+        $manifestPath = $this->tempDir . '/manifest.json';
+        file_put_contents($sourceFile, '# Hello');
+        mkdir($contentDir, 0o755, true);
+
+        $manifest = new BuildManifest($manifestPath);
+        $manifest->record($sourceFile, ['/out/entry/index.html']);
+        $manifest->setConfigFiles([$contentDir . '/config.yaml']);
+        $manifest->setTrackedDirectories([$contentDir => (int) filemtime($contentDir)]);
+        $manifest->save();
+        $manifest->load();
+
+        unlink($manifestPath);
+        $manifest->load();
+
+        assertSame([], $manifest->entries());
+        assertSame([], $manifest->configFiles());
+        assertSame([], $manifest->sourceFiles());
+        assertFalse($manifest->hasTrackedDirectories());
+    }
+
     public function testReplaceReturnsOutputsThatAreNoLongerReferenced(): void
     {
         $sourceFile = $this->tempDir . '/asset.css';

--- a/tests/Unit/Build/ParallelTaskRunnerTest.php
+++ b/tests/Unit/Build/ParallelTaskRunnerTest.php
@@ -6,6 +6,7 @@ namespace YiiPress\Tests\Unit\Build;
 
 use YiiPress\Build\ParallelTaskRunner;
 use PHPUnit\Framework\TestCase;
+use RuntimeException;
 
 use function array_unique;
 use function count;
@@ -66,5 +67,24 @@ final class ParallelTaskRunnerTest extends TestCase
                 unlink($pidFile);
             }
         }
+    }
+
+    public function testRunTreatsSignaledWorkerAsFailure(): void
+    {
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessage('One or more worker processes failed');
+
+        (new ParallelTaskRunner())->run(
+            [1, 2],
+            2,
+            static function (int $task): int {
+                if ($task === 1) {
+                    posix_kill(getmypid(), SIGKILL);
+                }
+
+                return 1;
+            },
+            minTasksPerWorker: 1,
+        );
     }
 }

--- a/tests/Unit/Build/ParallelTaskRunnerTest.php
+++ b/tests/Unit/Build/ParallelTaskRunnerTest.php
@@ -14,11 +14,14 @@ use function file;
 use function file_put_contents;
 use function getmypid;
 use function is_file;
+use function posix_kill;
 use function PHPUnit\Framework\assertNotFalse;
 use function PHPUnit\Framework\assertSame;
 use function sys_get_temp_dir;
 use function uniqid;
 use function unlink;
+
+use const SIGKILL;
 
 final class ParallelTaskRunnerTest extends TestCase
 {

--- a/tests/Unit/Console/BuildCommandTest.php
+++ b/tests/Unit/Console/BuildCommandTest.php
@@ -1181,6 +1181,19 @@ PHP,
         assertFalse(is_file($this->outputDir . '/aboutindex.html'));
     }
 
+    public function testBuildRejectsPermalinkWithRepeatedSlashes(): void
+    {
+        $contentDir = $this->createMinimalContent([
+            'index.md' => "---\ntitle: Home\npermalink: /about//team/\n---\n\nHello.\n",
+        ]);
+
+        $result = $this->runBuildResult($contentDir);
+
+        assertSame(65, $result['exitCode'], $result['output']);
+        assertStringContainsString('Invalid permalink "/about//team/"', $result['output']);
+        assertFalse(is_file($this->outputDir . '/about/team/index.html'));
+    }
+
     public function testFailedNoCacheBuildRemovesTemporaryOutputDirectory(): void
     {
         $contentDir = $this->createMinimalContent([

--- a/tests/Unit/Console/BuildCommandTest.php
+++ b/tests/Unit/Console/BuildCommandTest.php
@@ -1168,6 +1168,40 @@ PHP,
         assertFalse(is_file(dirname($this->outputDir) . '/outside/index.html'));
     }
 
+    public function testBuildRejectsPermalinkWithoutTrailingSlash(): void
+    {
+        $contentDir = $this->createMinimalContent([
+            'index.md' => "---\ntitle: Home\npermalink: /about\n---\n\nHello.\n",
+        ]);
+
+        $result = $this->runBuildResult($contentDir);
+
+        assertSame(65, $result['exitCode'], $result['output']);
+        assertStringContainsString('Invalid permalink "/about"', $result['output']);
+        assertFalse(is_file($this->outputDir . '/aboutindex.html'));
+    }
+
+    public function testFailedNoCacheBuildRemovesTemporaryOutputDirectory(): void
+    {
+        $contentDir = $this->createMinimalContent([
+            'index.md' => "---\ntitle: Home\npermalink: /broken\n---\n\nHello.\n",
+        ]);
+        mkdir($this->outputDir, 0o755, true);
+        file_put_contents($this->outputDir . '/.yiipress-build', "YiiPress build output\n");
+        file_put_contents($this->outputDir . '/existing.txt', 'keep');
+        $tempPattern = dirname($this->outputDir) . '/.' . basename($this->outputDir) . '.tmp-*';
+
+        foreach (glob($tempPattern) ?: [] as $tempDir) {
+            $this->removeDir($tempDir);
+        }
+
+        $result = $this->runBuildResult($contentDir, '--no-cache');
+
+        assertSame(65, $result['exitCode'], $result['output']);
+        assertSame([], glob($tempPattern) ?: []);
+        assertStringContainsString('keep', (string) file_get_contents($this->outputDir . '/existing.txt'));
+    }
+
     public function testNoCacheBuildRefusesToReplaceUnmarkedOutputDirectory(): void
     {
         $contentDir = $this->createMinimalContent([

--- a/tests/Unit/Console/BuildCommandTest.php
+++ b/tests/Unit/Console/BuildCommandTest.php
@@ -1127,6 +1127,62 @@ PHP,
         assertStringContainsString('https://test.example.com/ru/blog/test-post/', $sitemap);
     }
 
+    public function testBuildReportsInvalidEntryDateWithFilePath(): void
+    {
+        $contentDir = $this->createMinimalContent([
+            'index.md' => "---\ntitle: Home\ndate: not-a-real-date\n---\n\nHello.\n",
+        ]);
+
+        $result = $this->runBuildResult($contentDir);
+
+        assertSame(65, $result['exitCode'], $result['output']);
+        assertStringContainsString('Invalid content configuration', $result['output']);
+        assertStringContainsString('File:', $result['output']);
+        assertStringContainsString($contentDir . '/index.md', $result['output']);
+        assertStringContainsString('Invalid date in front matter', $result['output']);
+    }
+
+    public function testBuildRejectsDuplicatePermalinks(): void
+    {
+        $contentDir = $this->createMinimalContent([
+            'index.md' => "---\ntitle: Home\npermalink: /same/\n---\n\nHello.\n",
+            'about.md' => "---\ntitle: About\npermalink: /same/\n---\n\nAbout.\n",
+        ]);
+
+        $result = $this->runBuildResult($contentDir);
+
+        assertSame(65, $result['exitCode'], $result['output']);
+        assertStringContainsString('Duplicate permalink "/same/"', $result['output']);
+    }
+
+    public function testBuildRejectsTraversingPermalink(): void
+    {
+        $contentDir = $this->createMinimalContent([
+            'index.md' => "---\ntitle: Home\npermalink: /../../outside/\n---\n\nHello.\n",
+        ]);
+
+        $result = $this->runBuildResult($contentDir);
+
+        assertSame(65, $result['exitCode'], $result['output']);
+        assertStringContainsString('Invalid permalink "/../../outside/"', $result['output']);
+        assertFalse(is_file(dirname($this->outputDir) . '/outside/index.html'));
+    }
+
+    public function testNoCacheBuildRefusesToReplaceUnmarkedOutputDirectory(): void
+    {
+        $contentDir = $this->createMinimalContent([
+            'index.md' => "---\ntitle: Home\n---\n\nHello.\n",
+        ]);
+        mkdir($this->outputDir, 0o755, true);
+        file_put_contents($this->outputDir . '/existing.txt', 'keep');
+
+        $result = $this->runBuildResult($contentDir, '--no-cache');
+
+        assertSame(1, $result['exitCode'], $result['output']);
+        assertStringContainsString('Refusing to replace output directory', $result['output']);
+        assertStringContainsString('keep', (string) file_get_contents($this->outputDir . '/existing.txt'));
+    }
+
     public function testBuildUsesCustomLayoutFromFrontMatter(): void
     {
         $yii = dirname(__DIR__, 3) . '/yii';
@@ -1364,6 +1420,16 @@ PHP,
 
     private function runBuild(string $contentDir, string $extraOptions = ''): void
     {
+        $result = $this->runBuildResult($contentDir, $extraOptions);
+
+        assertSame(0, $result['exitCode'], 'Build failed: ' . $result['output']);
+    }
+
+    /**
+     * @return array{exitCode: int, output: string}
+     */
+    private function runBuildResult(string $contentDir, string $extraOptions = ''): array
+    {
         $yii = dirname(__DIR__, 3) . '/yii';
         exec(
             $yii . ' build'
@@ -1375,7 +1441,31 @@ PHP,
             $exitCode,
         );
 
-        assertSame(0, $exitCode, 'Build failed: ' . implode("\n", $output));
+        return [
+            'exitCode' => $exitCode,
+            'output' => implode("\n", $output),
+        ];
+    }
+
+    /**
+     * @param array<string, string> $files
+     */
+    private function createMinimalContent(array $files): string
+    {
+        $contentDir = sys_get_temp_dir() . '/yiipress-minimal-content-' . uniqid();
+        mkdir($contentDir, 0o755, true);
+        file_put_contents($contentDir . '/config.yaml', "title: Test Site\nbase_url: https://example.com\nlanguages: [en]\n");
+        foreach ($files as $relativePath => $contents) {
+            $filePath = $contentDir . '/' . $relativePath;
+            $dir = dirname($filePath);
+            if (!is_dir($dir)) {
+                mkdir($dir, 0o755, true);
+            }
+            file_put_contents($filePath, $contents);
+        }
+        $this->tempContentDirs[] = $contentDir;
+
+        return $contentDir;
     }
 
     private function copyContentFixture(): string

--- a/tests/Unit/Console/ImportCommandTest.php
+++ b/tests/Unit/Console/ImportCommandTest.php
@@ -103,6 +103,46 @@ final class ImportCommandTest extends TestCase
         assertStringContainsString('Imported: 1', $result['output']);
     }
 
+    public function testIgnoreMessageIdsOptionIsNotResolvedAsPath(): void
+    {
+        file_put_contents(
+            $this->sourceDir . '/result.json',
+            json_encode([
+                'type' => 'public_channel',
+                'messages' => [
+                    [
+                        'id' => 1,
+                        'type' => 'message',
+                        'date' => '2024-03-15T10:30:00',
+                        'text' => 'Imported post',
+                        'text_entities' => [
+                            ['type' => 'plain', 'text' => 'Imported post'],
+                        ],
+                    ],
+                    [
+                        'id' => 2,
+                        'type' => 'message',
+                        'date' => '2024-03-16T10:30:00',
+                        'text' => 'Ignored post',
+                        'text_entities' => [
+                            ['type' => 'plain', 'text' => 'Ignored post'],
+                        ],
+                    ],
+                ],
+            ], JSON_THROW_ON_ERROR),
+        );
+
+        $result = $this->runImport('telegram', [
+            '--directory' => $this->sourceDir,
+            '--ignore_message_ids' => '2',
+        ]);
+
+        assertSame(0, $result['exitCode'], $result['output']);
+        assertStringContainsString('ignore_message_ids: 2', $result['output']);
+        assertStringContainsString('Imported: 1', $result['output']);
+    }
+
+
     public function testShowsAvailableImportersOnError(): void
     {
         $result = $this->runImport('wordpress', ['--directory' => $this->sourceDir]);

--- a/tests/Unit/Content/Parser/EntryParserTest.php
+++ b/tests/Unit/Content/Parser/EntryParserTest.php
@@ -7,6 +7,7 @@ namespace YiiPress\Tests\Unit\Content\Parser;
 use YiiPress\Content\Parser\EntryParser;
 use YiiPress\Content\Parser\FilenameParser;
 use YiiPress\Content\Parser\FrontMatterParser;
+use YiiPress\Content\Parser\InvalidContentConfigException;
 use PHPUnit\Framework\TestCase;
 
 use function file_put_contents;
@@ -129,6 +130,24 @@ final class EntryParserTest extends TestCase
             assertSame([], $entry->tags);
             assertSame([], $entry->categories);
             assertSame([], $entry->authors);
+        } finally {
+            unlink($filePath);
+        }
+    }
+
+    public function testInvalidFrontMatterDateThrowsFriendlyExceptionWithFilePath(): void
+    {
+        $filePath = tempnam(sys_get_temp_dir(), 'yiipress-entry-');
+        self::assertNotFalse($filePath);
+
+        file_put_contents($filePath, "---\ntitle: Bad Date\ndate: not-a-real-date\n---\n\nBody.\n");
+
+        try {
+            $this->parser->parse($filePath, 'blog');
+            self::fail('Expected invalid date to throw.');
+        } catch (InvalidContentConfigException $e) {
+            assertStringContainsString('Invalid date in front matter', $e->getMessage());
+            assertSame($filePath, $e->filePath());
         } finally {
             unlink($filePath);
         }

--- a/tests/Unit/Content/Parser/FrontMatterParserTest.php
+++ b/tests/Unit/Content/Parser/FrontMatterParserTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace YiiPress\Tests\Unit\Content\Parser;
 
 use YiiPress\Content\Parser\FrontMatterParser;
+use YiiPress\Content\Parser\InvalidContentConfigException;
 use PHPUnit\Framework\TestCase;
 
 use function PHPUnit\Framework\assertArrayHasKey;
@@ -133,6 +134,19 @@ final class FrontMatterParserTest extends TestCase
         $result = new FrontMatterParser()->parse($tmpFile);
 
         assertSame('Explicit Title', $result['frontMatter']['title']);
+    }
+
+    public function testMalformedFrontMatterThrowsFriendlyExceptionWithFilePath(): void
+    {
+        $tmpFile = $this->createTempFile("---\ntitle: [unterminated\n---\n\nBody.");
+
+        try {
+            new FrontMatterParser()->parse($tmpFile);
+            self::fail('Expected invalid front matter to throw.');
+        } catch (InvalidContentConfigException $e) {
+            assertStringContainsString('Invalid YAML in front matter', $e->getMessage());
+            assertSame($tmpFile, $e->filePath());
+        }
     }
 
     private function createTempFile(string $content): string

--- a/tests/Unit/Packaging/ConfigurationPackagingTest.php
+++ b/tests/Unit/Packaging/ConfigurationPackagingTest.php
@@ -274,10 +274,11 @@ final class ConfigurationPackagingTest extends TestCase
         );
         self::assertStringContainsString('Cache Windows package dependencies', $workflow);
         self::assertStringContainsString('runtime\package-windows\yiipress-highlighter', $workflow);
+        self::assertStringContainsString('runs-on: windows-2022', $workflow);
         self::assertStringContainsString('Smoke test Windows binary', $workflow);
         self::assertStringContainsString('./dist/windows-amd64/yiipress.exe --help', $workflow);
         self::assertStringContainsString('path: dist/windows-amd64/yiipress.exe', $workflow);
-        self::assertStringContainsString('runs-on: macos-latest', $workflow);
+        self::assertStringContainsString('runs-on: macos-14', $workflow);
         self::assertStringContainsString('targets: aarch64-apple-darwin', $workflow);
         self::assertStringContainsString('Cache macOS package dependencies', $workflow);
         self::assertStringContainsString('runtime/package-macos/yiipress-highlighter', $workflow);

--- a/tests/Unit/Web/LiveReload/SiteBuildRunnerTest.php
+++ b/tests/Unit/Web/LiveReload/SiteBuildRunnerTest.php
@@ -67,12 +67,13 @@ final class SiteBuildRunnerTest extends TestCase
     public function testBuildReturnsFalseWhenCommandFails(): void
     {
         $script = $this->tempDir . '/fail-yii';
-        file_put_contents($script, "#!/bin/sh\nexit 1\n");
+        file_put_contents($script, "#!/bin/sh\necho 'broken build'\nexit 1\n");
         chmod($script, 0o755);
 
         $runner = new SiteBuildRunner($script, $this->tempDir . '/content', $this->tempDir . '/output');
 
         assertFalse($runner->build());
+        assertStringContainsString('broken build', $runner->lastOutput());
     }
 
     private function removeDir(string $path): void


### PR DESCRIPTION
## Summary
- add safe file writes and marker-based output directory replacement for no-cache builds
- report invalid content configuration with friendlier build errors and source context
- validate permalinks to prevent duplicates and output traversal
- document the hardened build/import/preview behavior

## Tests
- make test

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Safer builds with atomic output-directory replacement and marker-based swaps
  * Live-reload now serializes rebuilds and emits build-error events to the browser console

* **Bug Fixes**
  * Invalid entry dates and malformed front matter now report the originating file path
  * Duplicate, traversal, repeated-slash, and missing-trailing-slash permalinks are rejected

* **Documentation**
  * Clarified --no-cache behavior, permalink rules, and importer path option handling
<!-- end of auto-generated comment: release notes by coderabbit.ai -->