### PR TITLE
Harden build manifest persistence

### DIFF
--- a/docs/engine.md
+++ b/docs/engine.md
@@ -176,6 +176,8 @@ The cache stores:
 - rendered Markdown HTML keyed by content hash;
 - incremental build manifests keyed by source and output paths.
 
+Build manifests are treated as disposable cache metadata: missing, unreadable, corrupt, or structurally invalid manifests reset incremental state and trigger normal rebuild work instead of failing the build. Manifest saves write a uniquely named temporary file in the target directory and replace the manifest atomically after the full JSON payload is written.
+
 `yiipress clean` removes both configured output and the relevant build cache.
 
 ## Serve Mode

--- a/src/Build/FileWriter.php
+++ b/src/Build/FileWriter.php
@@ -19,9 +19,9 @@ use function unlink;
 
 final class FileWriter
 {
-    public static function write(string $path, string $contents): void
+    public static function write(string $path, string $contents, int $flags = 0): void
     {
-        $bytes = file_put_contents($path, $contents);
+        $bytes = @file_put_contents($path, $contents, $flags);
         if ($bytes === false || $bytes !== strlen($contents)) {
             throw new RuntimeException(sprintf('Unable to write file "%s".', $path));
         }
@@ -33,9 +33,9 @@ final class FileWriter
         $tempPath = dirname($path) . '/.' . basename($path) . '.' . ($pid === false ? 0 : $pid) . '.' . uniqid('', true) . '.tmp';
 
         try {
-            self::write($tempPath, $contents);
+            self::write($tempPath, $contents, LOCK_EX);
 
-            if (!rename($tempPath, $path)) {
+            if (!@rename($tempPath, $path)) {
                 throw new RuntimeException(sprintf('Unable to replace file "%s".', $path));
             }
         } finally {

--- a/tests/Unit/Build/BuildManifestTest.php
+++ b/tests/Unit/Build/BuildManifestTest.php
@@ -10,6 +10,7 @@ use PHPUnit\Framework\TestCase;
 
 use RecursiveDirectoryIterator;
 use RecursiveIteratorIterator;
+use RuntimeException;
 use SplFileInfo;
 
 use function PHPUnit\Framework\assertFalse;
@@ -193,6 +194,60 @@ final class BuildManifestTest extends TestCase
         assertFalse($manifest->hasTrackedDirectories());
     }
 
+    public function testSaveDoesNotLeaveTemporaryManifestFile(): void
+    {
+        $sourceFile = $this->tempDir . '/entry.md';
+        file_put_contents($sourceFile, '# Hello');
+        $manifestPath = $this->tempDir . '/manifest.json';
+
+        $manifest = new BuildManifest($manifestPath);
+        $manifest->record($sourceFile, ['/out/entry/index.html']);
+        $manifest->save();
+
+        assertTrue(is_file($manifestPath));
+        assertSame([], $this->manifestTemporaryFiles());
+    }
+
+    public function testSaveCleansTemporaryManifestFileWhenWriteFails(): void
+    {
+        $sourceFile = $this->tempDir . '/entry.md';
+        file_put_contents($sourceFile, '# Hello');
+        $manifestPath = $this->tempDir . '/' . str_repeat('a', 240) . '.json';
+
+        $manifest = new BuildManifest($manifestPath);
+        $manifest->record($sourceFile, ['/out/entry/index.html']);
+
+        try {
+            $manifest->save();
+            self::fail('Expected manifest save to fail.');
+        } catch (RuntimeException $exception) {
+            assertTrue(str_starts_with($exception->getMessage(), 'Unable to write file "'));
+        }
+
+        assertSame([], $this->manifestTemporaryFiles());
+    }
+
+    public function testSaveCleansTemporaryManifestFileWhenRenameFails(): void
+    {
+        $sourceFile = $this->tempDir . '/entry.md';
+        file_put_contents($sourceFile, '# Hello');
+        $manifestPath = $this->tempDir . '/manifest.json';
+        mkdir($manifestPath, 0o755);
+
+        $manifest = new BuildManifest($manifestPath);
+        $manifest->record($sourceFile, ['/out/entry/index.html']);
+
+        try {
+            $manifest->save();
+            self::fail('Expected manifest save to fail.');
+        } catch (RuntimeException $exception) {
+            assertSame(sprintf('Unable to replace file "%s".', $manifestPath), $exception->getMessage());
+        }
+
+        assertTrue(is_dir($manifestPath));
+        assertSame([], $this->manifestTemporaryFiles());
+    }
+
     public function testReplaceReturnsOutputsThatAreNoLongerReferenced(): void
     {
         $sourceFile = $this->tempDir . '/asset.css';
@@ -308,5 +363,15 @@ final class BuildManifestTest extends TestCase
         }
 
         rmdir($path);
+    }
+
+    /**
+     * @return list<string>
+     */
+    private function manifestTemporaryFiles(): array
+    {
+        $files = glob($this->tempDir . '/.*.tmp');
+
+        return $files === false ? [] : array_values($files);
     }
 }


### PR DESCRIPTION
## Summary
- treat corrupt build manifests as cache misses instead of crashing future builds
- save manifests through a same-directory temporary file and rename into place
- throw when manifest writes or replacement fail

## Tests
- make test -- --filter BuildManifestTest
- make psalm
- make test

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Build system now automatically recovers from corrupted, missing, or unreadable manifest files by resetting incremental state and performing a full rebuild instead of failing.

* **Documentation**
  * Updated caching documentation to clarify incremental build manifest behavior and atomic write operations for better reliability.

* **Tests**
  * Added comprehensive tests for manifest file cleanup and error handling during save operations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->