### PR TITLE
Harden no-cache output cleanup

### DIFF
--- a/src/Console/BuildCommand.php
+++ b/src/Console/BuildCommand.php
@@ -58,6 +58,7 @@ use RecursiveDirectoryIterator;
 use RecursiveIteratorIterator;
 use RuntimeException;
 use SplFileInfo;
+use UnexpectedValueException;
 use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Formatter\OutputFormatter;
@@ -206,17 +207,6 @@ final class BuildCommand extends Command
         $includeFuture = $input->getOption('future') !== false ? (bool) $input->getOption('future') : Environment::isDev();
         $dryRun = (bool) $input->getOption('dry-run');
         $noWrite = (bool) $input->getOption('no-write');
-        $buildContext = new BuildContext(
-            rootPath: $rootPath,
-            contentDir: $contentDir,
-            outputDir: $outputDir,
-            workerCount: $workerCount,
-            noCache: $noCache,
-            includeDrafts: $includeDrafts,
-            includeFuture: $includeFuture,
-            dryRun: $dryRun,
-            noWrite: $noWrite,
-        );
         $profile = new BuildProfile((bool) $input->getOption('profile'));
         $profile->start('prepare');
 
@@ -290,6 +280,14 @@ final class BuildCommand extends Command
 
             if ($changedSourceFiles === [] && $staleOutputs === []) {
                 $output->writeln('<info>No changes detected, nothing to build.</info>');
+                try {
+                    $this->writeOutputMarker($outputDir);
+                } catch (RuntimeException $e) {
+                    $output->writeln('<error>' . OutputFormatter::escape($e->getMessage()) . '</error>');
+                    $this->writeProfile($output, $profile);
+
+                    return ExitCode::DATAERR;
+                }
                 $this->writeProfile($output, $profile);
                 return ExitCode::OK;
             }
@@ -317,13 +315,6 @@ final class BuildCommand extends Command
                 ? '<info>Rendering without writing output' . $this->workerMessageSuffix($workerCount, false) . '...</info>'
                 : '<info>Rendering and writing output' . $this->workerMessageSuffix($workerCount, false) . '...</info>',
             );
-
-            if (!$noWrite) {
-                $atomicOutputDir = $this->prepareOutputDir($outputDir);
-                if ($atomicOutputDir !== null) {
-                    $outputDir = $atomicOutputDir;
-                }
-            }
         }
 
         try {
@@ -379,6 +370,31 @@ final class BuildCommand extends Command
             $this->writeProfile($output, $profile);
             return $exitCode;
         }
+
+        if (!$noWrite && $noCache) {
+            try {
+                $atomicOutputDir = $this->prepareOutputDir($outputDir);
+                if ($atomicOutputDir !== null) {
+                    $outputDir = $atomicOutputDir;
+                }
+            } catch (RuntimeException $e) {
+                $output->writeln('<error>' . OutputFormatter::escape($e->getMessage()) . '</error>');
+                $this->writeProfile($output, $profile);
+                return ExitCode::DATAERR;
+            }
+        }
+
+        $buildContext = new BuildContext(
+            rootPath: $rootPath,
+            contentDir: $contentDir,
+            outputDir: $outputDir,
+            workerCount: $workerCount,
+            noCache: $noCache,
+            includeDrafts: $includeDrafts,
+            includeFuture: $includeFuture,
+            dryRun: $dryRun,
+            noWrite: $noWrite,
+        );
 
         $this->eventDispatcher?->dispatch(new BuildStartedEvent($buildContext, $siteConfig, $navigation, $collections, $authors));
 
@@ -860,13 +876,20 @@ final class BuildCommand extends Command
         }
 
         if (!$noWrite) {
-            $this->writeOutputMarker($outputDir);
-        }
+            try {
+                $this->writeOutputMarker($outputDir);
 
-        if ($atomicOutputDir !== null) {
-            $this->replaceOutputDir($atomicOutputDir, $finalOutputDir);
-            $outputDir = $finalOutputDir;
-            $atomicOutputDir = null;
+                if ($atomicOutputDir !== null) {
+                    $this->replaceOutputDir($atomicOutputDir, $finalOutputDir);
+                    $outputDir = $finalOutputDir;
+                    $atomicOutputDir = null;
+                }
+            } catch (RuntimeException $e) {
+                $output->writeln('<error>' . OutputFormatter::escape($e->getMessage()) . '</error>');
+                $this->writeProfile($output, $profile);
+
+                return ExitCode::DATAERR;
+            }
         }
 
         $this->eventDispatcher?->dispatch(new BuildFinishedEvent($buildContext, $siteConfig));
@@ -1341,7 +1364,11 @@ final class BuildCommand extends Command
 
     private function isEmptyDirectory(string $directory): bool
     {
-        $iterator = new FilesystemIterator($directory, FilesystemIterator::SKIP_DOTS);
+        try {
+            $iterator = new FilesystemIterator($directory, FilesystemIterator::SKIP_DOTS);
+        } catch (UnexpectedValueException $e) {
+            throw new RuntimeException(sprintf('Unable to inspect output directory "%s".', $directory), 0, $e);
+        }
 
         return !$iterator->valid();
     }

--- a/tests/Unit/Console/BuildCommandTest.php
+++ b/tests/Unit/Console/BuildCommandTest.php
@@ -94,6 +94,7 @@ final class BuildCommandTest extends TestCase
         assertSame(0, $exitCode, "Build failed: $outputText");
         assertMatchesRegularExpression('/Build complete in \d+(?:\.\d+)?(?:ms|s)\. Peak memory: \d+(?:\.\d+)? MiB\./', $outputText);
         assertDirectoryExists($this->outputDir);
+        assertFileExists($this->outputDir . '/.yiipress-build');
     }
 
     public function testBuildHooksAreDispatched(): void
@@ -198,10 +199,12 @@ PHP,
         $contentDir = $tempDir . '/content';
         $outputDir = $tempDir . '/output';
         mkdir($contentDir, 0o755, true);
+        mkdir($outputDir, 0o755, true);
         $this->tempContentDirs[] = $tempDir;
 
         file_put_contents($contentDir . '/config.yaml', "title: Broken Site\n");
         file_put_contents($contentDir . '/index.md', "---\ntitle: Home\n---\n\nHello.\n");
+        file_put_contents($outputDir . '/existing.html', 'existing output');
 
         $yii = dirname(__DIR__, 3) . '/yii';
         exec(
@@ -224,6 +227,38 @@ PHP,
         assertStringNotContainsString('Stack trace:', $outputText);
         assertStringNotContainsString('RuntimeException:', $outputText);
         assertStringNotContainsString('#0 ', $outputText);
+        assertFileExists($outputDir . '/existing.html');
+    }
+
+    public function testNoCacheBuildRefusesToClearUnmarkedNonEmptyOutputDirectory(): void
+    {
+        $tempDir = sys_get_temp_dir() . '/yiipress-build-output-safety-test-' . uniqid();
+        $contentDir = $tempDir . '/content';
+        $outputDir = $tempDir . '/public_html';
+        mkdir($contentDir, 0o755, true);
+        mkdir($outputDir, 0o755, true);
+        $this->tempContentDirs[] = $tempDir;
+
+        file_put_contents($contentDir . '/config.yaml', "title: Safe Site\nlanguages: [en]\n");
+        file_put_contents($contentDir . '/index.md', "---\ntitle: Home\n---\n\nHello.\n");
+        file_put_contents($outputDir . '/do-not-delete.html', 'important');
+
+        $yii = dirname(__DIR__, 3) . '/yii';
+        exec(
+            $yii . ' build'
+            . ' --content-dir=' . escapeshellarg($contentDir)
+            . ' --output-dir=' . escapeshellarg($outputDir)
+            . ' --no-cache'
+            . ' 2>&1',
+            $output,
+            $exitCode,
+        );
+
+        $outputText = implode("\n", $output);
+
+        assertSame(ExitCode::DATAERR, $exitCode, $outputText);
+        assertStringContainsString('Refusing to replace output directory', $outputText);
+        assertFileExists($outputDir . '/do-not-delete.html');
     }
 
     public function testBuildOutputContainsRenderedHtml(): void
@@ -935,6 +970,7 @@ PHP,
         $firstOutputText = implode("\n", $firstOutput);
         assertSame(0, $firstExitCode, "First build failed: $firstOutputText");
         assertStringContainsString('Build complete', $firstOutputText);
+        unlink($this->outputDir . '/.yiipress-build');
 
         $secondOutput = [];
         exec(
@@ -949,6 +985,7 @@ PHP,
         $secondOutputText = implode("\n", $secondOutput);
         assertSame(0, $secondExitCode, "Second build failed: $secondOutputText");
         assertStringContainsString('No changes detected', $secondOutputText);
+        assertFileExists($this->outputDir . '/.yiipress-build');
 
         if (is_file($manifestPath)) {
             unlink($manifestPath);
@@ -1282,7 +1319,7 @@ PHP,
 
         $result = $this->runBuildResult($contentDir, '--no-cache');
 
-        assertSame(1, $result['exitCode'], $result['output']);
+        assertSame(65, $result['exitCode'], $result['output']);
         assertStringContainsString('Refusing to replace output directory', $result['output']);
         assertStringContainsString('keep', (string) file_get_contents($this->outputDir . '/existing.txt'));
     }


### PR DESCRIPTION
## Summary
- replace shell-based output cleanup with Yii file helper cleanup
- write a YiiPress build marker after successful builds
- refuse --no-cache cleanup for non-empty output directories without that marker
- delay destructive cleanup until after content configuration parses successfully

## Tests
- make test -- --filter BuildCommandTest
- make psalm
- make test