### PR TITLE
Validate build output permalinks

### DIFF
--- a/src/Console/BuildCommand.php
+++ b/src/Console/BuildCommand.php
@@ -405,6 +405,7 @@ final class BuildCommand extends Command
         $permalinkSources = [];
         $aliasRedirectTasks = [];
         $aliasOutputsBySource = [];
+        $now = new DateTimeImmutable();
 
         try {
             foreach ($collections as $collectionName => $collection) {
@@ -418,9 +419,12 @@ final class BuildCommand extends Command
                     $collectionEntries[] = $entry;
                     $relativePath = substr($sourcePath, strlen($contentDir) + 1);
                     $permalink = PermalinkResolver::resolve($entry, $collection, $siteConfig->i18n);
-                    $this->registerPermalink($permalinkSources, $permalink, $sourcePath);
-                    foreach ($entry->aliases as $alias) {
-                        $this->registerAliasPermalink($permalinkSources, $this->normalizeAliasPermalink($alias), $sourcePath);
+                    $this->validatePermalink($permalink, $sourcePath);
+                    if ($this->shouldGenerateEntry($entry, $includeDrafts, $includeFuture, $now)) {
+                        $this->registerPermalink($permalinkSources, $permalink, $sourcePath);
+                        foreach ($entry->aliases as $alias) {
+                            $this->registerAliasPermalink($permalinkSources, $this->normalizeAliasPermalink($alias), $sourcePath);
+                        }
                     }
                     $fileToPermalink[$relativePath] = $permalink;
                 }
@@ -438,9 +442,12 @@ final class BuildCommand extends Command
                 $relativePath = substr($sourcePath, strlen($contentDir) + 1);
                 $basePermalink = $page->permalink !== '' ? $page->permalink : '/' . $page->slug . '/';
                 $permalink = PermalinkResolver::applyLanguagePrefix($basePermalink, $page->language, $siteConfig->i18n);
-                $this->registerPermalink($permalinkSources, $permalink, $sourcePath);
-                foreach ($page->aliases as $alias) {
-                    $this->registerAliasPermalink($permalinkSources, $this->normalizeAliasPermalink($alias), $sourcePath);
+                $this->validatePermalink($permalink, $sourcePath);
+                if ($this->shouldGenerateEntry($page, $includeDrafts, $includeFuture, $now)) {
+                    $this->registerPermalink($permalinkSources, $permalink, $sourcePath);
+                    foreach ($page->aliases as $alias) {
+                        $this->registerAliasPermalink($permalinkSources, $this->normalizeAliasPermalink($alias), $sourcePath);
+                    }
                 }
                 $fileToPermalink[$relativePath] = $permalink;
             }
@@ -476,8 +483,6 @@ final class BuildCommand extends Command
             $output->writeln("<comment>  ⚠ $warning</comment>");
         }
 
-        $now = new DateTimeImmutable();
-
         $profile->switchTo('prepare entry tasks');
         $allTasks = [];
         $redirectTasks = [];
@@ -495,7 +500,13 @@ final class BuildCommand extends Command
                 $sourcePath = $entry->filePath;
                 $relativePath = substr($sourcePath, strlen($contentDir) + 1);
                 $permalink = $fileToPermalink[$relativePath];
-                $filePath = $outputDir . $permalink . 'index.html';
+                try {
+                    $filePath = $this->outputFilePath($outputDir, $permalink);
+                } catch (RuntimeException $e) {
+                    $output->writeln('<error>' . OutputFormatter::escape($e->getMessage()) . '</error>');
+                    $this->writeProfile($output, $profile);
+                    return ExitCode::DATAERR;
+                }
 
                 if ($entry->redirectTo !== '') {
                     $redirectTasks[] = ['entry' => $entry, 'filePath' => $filePath, 'permalink' => $permalink, 'sourcePath' => $sourcePath];
@@ -659,7 +670,13 @@ final class BuildCommand extends Command
             $sourcePath = $page->filePath;
             $basePermalink = $page->permalink !== '' ? $page->permalink : '/' . $page->slug . '/';
             $permalink = PermalinkResolver::applyLanguagePrefix($basePermalink, $page->language, $siteConfig->i18n);
-            $filePath = $outputDir . $permalink . 'index.html';
+            try {
+                $filePath = $this->outputFilePath($outputDir, $permalink);
+            } catch (RuntimeException $e) {
+                $output->writeln('<error>' . OutputFormatter::escape($e->getMessage()) . '</error>');
+                $this->writeProfile($output, $profile);
+                return ExitCode::DATAERR;
+            }
 
             if ($changedSet !== null && !isset($changedSet[$sourcePath])) {
                 $outputs = [$filePath];
@@ -1505,8 +1522,6 @@ final class BuildCommand extends Command
      */
     private function registerPermalink(array &$permalinkSources, string $permalink, string $sourcePath): void
     {
-        $this->validatePermalink($permalink, $sourcePath);
-
         $normalized = $permalink === '/' ? '/' : rtrim($permalink, '/');
         if (isset($permalinkSources[$normalized])) {
             throw new InvalidContentConfigException(
@@ -1581,6 +1596,44 @@ final class BuildCommand extends Command
                 );
             }
         }
+    }
+
+    private function outputFilePath(string $outputDir, string $permalink): string
+    {
+        return $outputDir . '/' . $this->permalinkOutputPath($permalink) . 'index.html';
+    }
+
+    private function shouldGenerateEntry(Entry $entry, bool $includeDrafts, bool $includeFuture, DateTimeImmutable $now): bool
+    {
+        if (!$includeDrafts && $entry->draft) {
+            return false;
+        }
+
+        return $includeFuture || $entry->date === null || $entry->date <= $now;
+    }
+
+    private function permalinkOutputPath(string $permalink): string
+    {
+        if (!str_starts_with($permalink, '/')) {
+            throw new RuntimeException(sprintf('Permalink "%s" must start with "/".', $permalink));
+        }
+
+        if (str_contains($permalink, "\0") || str_contains($permalink, '\\')) {
+            throw new RuntimeException(sprintf('Permalink "%s" contains an unsafe path segment.', $permalink));
+        }
+
+        if ($permalink === '/') {
+            return '';
+        }
+
+        $segments = explode('/', trim($permalink, '/'));
+        foreach ($segments as $segment) {
+            if ($segment === '' || $segment === '.' || $segment === '..') {
+                throw new RuntimeException(sprintf('Permalink "%s" contains an unsafe path segment.', $permalink));
+            }
+        }
+
+        return implode('/', $segments) . '/';
     }
 
     private function resolvePath(string $path, string $rootPath): string

--- a/tests/Unit/Console/BuildCommandTest.php
+++ b/tests/Unit/Console/BuildCommandTest.php
@@ -261,6 +261,67 @@ PHP,
         assertFileExists($outputDir . '/do-not-delete.html');
     }
 
+    public function testBuildFailsForDuplicatePermalinks(): void
+    {
+        $tempDir = sys_get_temp_dir() . '/yiipress-build-duplicate-permalink-test-' . uniqid();
+        $contentDir = $tempDir . '/content';
+        $outputDir = $tempDir . '/output';
+        mkdir($contentDir . '/blog', 0o755, true);
+        $this->tempContentDirs[] = $tempDir;
+
+        file_put_contents($contentDir . '/config.yaml', "title: Duplicate Site\nlanguages: [en]\n");
+        file_put_contents($contentDir . '/blog/_collection.yaml', "title: Blog\npermalink: /blog/:slug/\n");
+        file_put_contents($contentDir . '/blog/first.md', "---\ntitle: First\npermalink: /same/\n---\n\nFirst.\n");
+        file_put_contents($contentDir . '/blog/second.md', "---\ntitle: Second\npermalink: /same/\n---\n\nSecond.\n");
+
+        $yii = dirname(__DIR__, 3) . '/yii';
+        exec(
+            $yii . ' build'
+            . ' --content-dir=' . escapeshellarg($contentDir)
+            . ' --output-dir=' . escapeshellarg($outputDir)
+            . ' --no-cache'
+            . ' 2>&1',
+            $output,
+            $exitCode,
+        );
+
+        $outputText = implode("\n", $output);
+
+        assertSame(ExitCode::DATAERR, $exitCode, $outputText);
+        assertStringContainsString('Duplicate permalink "/same/"', $outputText);
+        assertFalse(is_file($outputDir . '/same/index.html'));
+    }
+
+    public function testBuildFailsForUnsafePermalinkPathSegments(): void
+    {
+        $tempDir = sys_get_temp_dir() . '/yiipress-build-unsafe-permalink-test-' . uniqid();
+        $contentDir = $tempDir . '/content';
+        $outputDir = $tempDir . '/output';
+        mkdir($contentDir . '/blog', 0o755, true);
+        $this->tempContentDirs[] = $tempDir;
+
+        file_put_contents($contentDir . '/config.yaml', "title: Unsafe Site\nlanguages: [en]\n");
+        file_put_contents($contentDir . '/blog/_collection.yaml', "title: Blog\npermalink: /blog/:slug/\n");
+        file_put_contents($contentDir . '/blog/post.md', "---\ntitle: Escape\npermalink: /../../outside/\n---\n\nEscape.\n");
+
+        $yii = dirname(__DIR__, 3) . '/yii';
+        exec(
+            $yii . ' build'
+            . ' --content-dir=' . escapeshellarg($contentDir)
+            . ' --output-dir=' . escapeshellarg($outputDir)
+            . ' --no-cache'
+            . ' 2>&1',
+            $output,
+            $exitCode,
+        );
+
+        $outputText = implode("\n", $output);
+
+        assertSame(ExitCode::DATAERR, $exitCode, $outputText);
+        assertStringContainsString('Invalid permalink "/../../outside/"', $outputText);
+        assertFalse(is_file($tempDir . '/outside/index.html'));
+    }
+
     public function testBuildOutputContainsRenderedHtml(): void
     {
         $yii = dirname(__DIR__, 3) . '/yii';
@@ -1326,6 +1387,35 @@ PHP,
         assertStringContainsString('Duplicate permalink "/same/"', $result['output']);
     }
 
+    public function testBuildIgnoresDuplicateDraftPermalinksWhenDraftsAreExcluded(): void
+    {
+        $contentDir = $this->createMinimalContent([
+            'index.md' => "---\ntitle: Home\npermalink: /\n---\n\nHello.\n",
+            'draft-one.md' => "---\ntitle: Draft One\ndraft: true\npermalink: /draft/\n---\n\nDraft.\n",
+            'draft-two.md' => "---\ntitle: Draft Two\ndraft: true\npermalink: /draft/\n---\n\nDraft.\n",
+        ]);
+
+        $result = $this->runBuildResult($contentDir);
+
+        assertSame(0, $result['exitCode'], $result['output']);
+        assertFileExists($this->outputDir . '/index.html');
+        assertFalse(is_file($this->outputDir . '/draft/index.html'));
+    }
+
+    public function testBuildRejectsDuplicateDraftPermalinksWhenDraftsAreIncluded(): void
+    {
+        $contentDir = $this->createMinimalContent([
+            'index.md' => "---\ntitle: Home\npermalink: /\n---\n\nHello.\n",
+            'draft-one.md' => "---\ntitle: Draft One\ndraft: true\npermalink: /draft/\n---\n\nDraft.\n",
+            'draft-two.md' => "---\ntitle: Draft Two\ndraft: true\npermalink: /draft/\n---\n\nDraft.\n",
+        ]);
+
+        $result = $this->runBuildResult($contentDir, '--drafts');
+
+        assertSame(65, $result['exitCode'], $result['output']);
+        assertStringContainsString('Duplicate permalink "/draft/"', $result['output']);
+    }
+
     public function testBuildRejectsAliasThatDuplicatesPermalink(): void
     {
         $contentDir = $this->createMinimalContent([
@@ -1336,7 +1426,7 @@ PHP,
         $result = $this->runBuildResult($contentDir);
 
         assertSame(65, $result['exitCode'], $result['output']);
-        assertStringContainsString('Duplicate permalink "/about/"', $result['output']);
+        assertStringContainsString('Duplicate alias "/about/"', $result['output']);
     }
 
     public function testBuildRejectsDuplicateAliases(): void
@@ -1389,6 +1479,19 @@ PHP,
         assertSame(65, $result['exitCode'], $result['output']);
         assertStringContainsString('Invalid permalink "/about//team/"', $result['output']);
         assertFalse(is_file($this->outputDir . '/about/team/index.html'));
+    }
+
+    public function testBuildRejectsPermalinkWithBackslash(): void
+    {
+        $contentDir = $this->createMinimalContent([
+            'index.md' => "---\ntitle: Home\npermalink: /..\\outside/\n---\n\nHello.\n",
+        ]);
+
+        $result = $this->runBuildResult($contentDir);
+
+        assertSame(65, $result['exitCode'], $result['output']);
+        assertStringContainsString('Invalid permalink "/..\\outside/"', $result['output']);
+        assertFalse(is_file(dirname($this->outputDir) . '/outside/index.html'));
     }
 
     public function testFailedNoCacheBuildRemovesTemporaryOutputDirectory(): void


### PR DESCRIPTION
## Summary
- reject unsafe permalink path segments before writing output files
- fail builds that define duplicate permalinks before parallel workers can overwrite each other
- document front matter permalink path constraints

## Tests
- make test -- --filter BuildCommandTest
- make psalm
- make test

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Build now validates and rejects duplicate permalinks with clear error reporting.
  * Build now rejects permalinks containing unsafe path segments and path traversal attempts (e.g., `../../`).

* **Tests**
  * Added comprehensive test coverage for permalink validation, duplicate detection, and safe path segment enforcement.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->