### PR TITLE
Report live reload build failures

### DIFF
--- a/docs/preview.md
+++ b/docs/preview.md
@@ -28,4 +28,4 @@ How it works:
 2. The snippet opens an SSE (Server-Sent Events) connection to `/_live-reload`.
 3. The ReactPHP server handles this endpoint directly and attaches all EventSource clients in the same worker to a shared inotify read stream.
 4. When a change is detected, `SiteBuildRunner` triggers a normal build, so live reload benefits from the same incremental build pipeline as manual builds. Rebuilds are serialized with a lock so multiple preview workers do not write the same output concurrently.
-5. After a successful build, the server sends a `reload` event and the browser refreshes. If the build fails, the page is not reloaded and the build output is sent to the browser console as a `build-error` event.
+5. After a successful build, the server sends a `reload` event and the browser refreshes. If the build fails, the page is not reloaded and the build output is shown in a fixed on-page error panel.

--- a/src/Console/ServeCommand.php
+++ b/src/Console/ServeCommand.php
@@ -425,10 +425,20 @@ final class ServeCommand extends Command
 
             $this->broadcastLiveReloadEvent(
                 'build-error',
-                json_encode(['output' => $result->output], JSON_THROW_ON_ERROR),
+                $this->liveReloadBuildErrorData($result),
                 true,
             );
         });
+    }
+
+    private function liveReloadBuildErrorData(SiteBuildResult $result): string
+    {
+        $payload = json_encode(['output' => $result->output], JSON_INVALID_UTF8_SUBSTITUTE);
+        if ($payload === false) {
+            return '{"output":"Build failed, but output could not be encoded."}';
+        }
+
+        return $payload;
     }
 
     private function broadcastLiveReloadEvent(string $event, string $data, bool $close): void

--- a/src/Console/ServeCommand.php
+++ b/src/Console/ServeCommand.php
@@ -7,6 +7,7 @@ namespace YiiPress\Console;
 use YiiPress\Environment;
 use YiiPress\RuntimePaths;
 use YiiPress\Web\DevServer\DevHtmlInjector;
+use YiiPress\Web\LiveReload\SiteBuildResult;
 use YiiPress\Web\LiveReload\SiteBuildRunner;
 use FilesystemIterator;
 use HttpSoft\Message\ServerRequest;
@@ -412,9 +413,21 @@ final class ServeCommand extends Command
                 return;
             }
 
-            if ($this->buildLiveReloadSite()) {
-                $this->broadcastLiveReloadEvent('reload', 'changed', true);
+            $result = $this->buildLiveReloadSite();
+            if ($result === null) {
+                return;
             }
+
+            if ($result->succeeded()) {
+                $this->broadcastLiveReloadEvent('reload', 'changed', true);
+                return;
+            }
+
+            $this->broadcastLiveReloadEvent(
+                'build-error',
+                json_encode(['output' => $result->output], JSON_THROW_ON_ERROR),
+                true,
+            );
         });
     }
 
@@ -462,23 +475,15 @@ final class ServeCommand extends Command
         $this->liveReloadClients = [];
     }
 
-    private function buildLiveReloadSite(): bool
+    private function buildLiveReloadSite(): ?SiteBuildResult
     {
         $now = microtime(true);
         if ($now - $this->lastLiveReloadBuildTime < 1.0) {
-            return false;
+            return null;
         }
 
         $this->lastLiveReloadBuildTime = $now;
-        $runner = $this->createLiveReloadBuildRunner();
-        if ($runner->build()) {
-            return true;
-        }
-
-        $message = trim($runner->lastOutput());
-        $this->broadcastLiveReloadEvent('build-error', $message !== '' ? $message : 'Build failed.', false);
-
-        return false;
+        return $this->createLiveReloadBuildRunner()->build();
     }
 
     private function finishLiveReloadResponse(ConnectionInterface $connection, string $event, string $data): void

--- a/src/Web/DevServer/assets/live-reload.js
+++ b/src/Web/DevServer/assets/live-reload.js
@@ -19,7 +19,17 @@
         }
         es = new EventSource("/_live-reload");
         es.addEventListener("reload", function() { es.close(); location.reload(); });
-        es.addEventListener("build-error", function(event) { if (event.data) { console.error(event.data); } });
+        es.addEventListener("build-error", function(event) {
+            es.close();
+            try {
+                var payload = JSON.parse(event.data);
+                if (payload.output) {
+                    console.error(payload.output);
+                }
+            } catch (error) {
+                console.error(event.data);
+            }
+        });
         es.addEventListener("ping", function() {});
         es.onerror = function() {
             es.close();

--- a/src/Web/DevServer/assets/live-reload.js
+++ b/src/Web/DevServer/assets/live-reload.js
@@ -2,6 +2,49 @@
     var leaving = false;
     var reconnectTimer = 0;
     var es = null;
+    var errorPanel = null;
+    var errorOutput = null;
+
+    function hideBuildError() {
+        if (errorPanel) {
+            errorPanel.remove();
+            errorPanel = null;
+            errorOutput = null;
+        }
+    }
+
+    function showBuildError(output) {
+        if (!errorPanel) {
+            errorPanel = document.createElement("section");
+            errorPanel.id = "yiipress-build-error";
+            errorPanel.setAttribute("role", "status");
+            errorPanel.style.cssText = "position:fixed;top:16px;right:16px;z-index:2147483647;box-sizing:border-box;width:min(720px,calc(100vw - 32px));max-height:min(520px,calc(100vh - 32px));overflow:hidden;border:1px solid rgba(185,28,28,.38);border-radius:8px;background:#1f1515;color:#fff;box-shadow:0 18px 48px rgba(0,0,0,.32);font:13px/1.45 ui-monospace,SFMono-Regular,Menlo,Consolas,Liberation Mono,monospace";
+
+            var header = document.createElement("div");
+            header.style.cssText = "display:flex;align-items:center;gap:12px;padding:10px 12px;border-bottom:1px solid rgba(255,255,255,.12);background:#3f1717";
+
+            var title = document.createElement("strong");
+            title.textContent = "Build failed";
+            title.style.cssText = "flex:1;font:600 13px/1.3 system-ui,-apple-system,BlinkMacSystemFont,Segoe UI,sans-serif";
+
+            var closeButton = document.createElement("button");
+            closeButton.type = "button";
+            closeButton.textContent = "Close";
+            closeButton.style.cssText = "border:1px solid rgba(255,255,255,.2);border-radius:6px;background:rgba(255,255,255,.08);color:#fff;padding:4px 8px;font:12px system-ui,-apple-system,BlinkMacSystemFont,Segoe UI,sans-serif;cursor:pointer";
+            closeButton.addEventListener("click", hideBuildError);
+
+            errorOutput = document.createElement("pre");
+            errorOutput.style.cssText = "box-sizing:border-box;max-height:min(454px,calc(100vh - 98px));margin:0;padding:12px;overflow:auto;white-space:pre-wrap;word-break:break-word";
+
+            header.appendChild(title);
+            header.appendChild(closeButton);
+            errorPanel.appendChild(header);
+            errorPanel.appendChild(errorOutput);
+            document.body.appendChild(errorPanel);
+        }
+
+        errorOutput.textContent = output || "Build failed.";
+    }
 
     function close() {
         leaving = true;
@@ -18,16 +61,16 @@
             return;
         }
         es = new EventSource("/_live-reload");
-        es.addEventListener("reload", function() { es.close(); location.reload(); });
+        es.addEventListener("reload", function() { hideBuildError(); es.close(); location.reload(); });
         es.addEventListener("build-error", function(event) {
+            var output = event.data;
             try {
                 var payload = JSON.parse(event.data);
                 if (payload.output) {
-                    console.error(payload.output);
+                    output = payload.output;
                 }
-            } catch (error) {
-                console.error(event.data);
-            }
+            } catch (error) {}
+            showBuildError(output);
         });
         es.addEventListener("ping", function() {});
         es.onerror = function() {

--- a/src/Web/DevServer/assets/live-reload.js
+++ b/src/Web/DevServer/assets/live-reload.js
@@ -20,7 +20,6 @@
         es = new EventSource("/_live-reload");
         es.addEventListener("reload", function() { es.close(); location.reload(); });
         es.addEventListener("build-error", function(event) {
-            es.close();
             try {
                 var payload = JSON.parse(event.data);
                 if (payload.output) {

--- a/src/Web/LiveReload/SiteBuildResult.php
+++ b/src/Web/LiveReload/SiteBuildResult.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+namespace YiiPress\Web\LiveReload;
+
+final readonly class SiteBuildResult
+{
+    public function __construct(
+        public int $exitCode,
+        public string $output,
+    ) {}
+
+    public function succeeded(): bool
+    {
+        return $this->exitCode === 0;
+    }
+}

--- a/src/Web/LiveReload/SiteBuildRunner.php
+++ b/src/Web/LiveReload/SiteBuildRunner.php
@@ -16,7 +16,7 @@ final class SiteBuildRunner
         $this->lastOutput = '';
     }
 
-    public function build(): bool
+    public function build(): SiteBuildResult
     {
         $lockId = hash('xxh128', $this->outputDir);
         $lockPath = sys_get_temp_dir() . '/yiipress-build-' . $lockId . '.lock';
@@ -24,14 +24,14 @@ final class SiteBuildRunner
         if ($lock === false) {
             $this->lastOutput = sprintf('Unable to open build lock "%s" (%s).', $lockPath, $lockId);
 
-            return false;
+            return new SiteBuildResult(1, $this->lastOutput);
         }
 
         if (!flock($lock, LOCK_EX)) {
             fclose($lock);
             $this->lastOutput = sprintf('Unable to acquire build lock "%s" (%s).', $lockPath, $lockId);
 
-            return false;
+            return new SiteBuildResult(1, $this->lastOutput);
         }
 
         $command = escapeshellarg($this->yiiBinary)
@@ -44,7 +44,7 @@ final class SiteBuildRunner
             exec($command, $output, $exitCode);
             $this->lastOutput = implode("\n", $output);
 
-            return $exitCode === 0;
+            return new SiteBuildResult($exitCode, $this->lastOutput);
         } finally {
             flock($lock, LOCK_UN);
             fclose($lock);

--- a/tests/Unit/Console/ServeCommandTest.php
+++ b/tests/Unit/Console/ServeCommandTest.php
@@ -6,6 +6,7 @@ namespace YiiPress\Tests\Unit\Console;
 
 use YiiPress\Console\ServeCommand;
 use YiiPress\RuntimePaths;
+use YiiPress\Web\LiveReload\SiteBuildResult;
 use Evenement\EventEmitter;
 use FilesystemIterator;
 use PHPUnit\Framework\Attributes\Test;
@@ -412,6 +413,17 @@ final class ServeCommandTest extends TestCase
         } finally {
             $closeMethod->invoke($command);
         }
+    }
+
+    #[Test]
+    public function serveEncodesLiveReloadBuildErrorWithInvalidUtf8Output(): void
+    {
+        $command = new ServeCommand();
+        $method = new ReflectionMethod($command, 'liveReloadBuildErrorData');
+
+        $data = $method->invoke($command, new SiteBuildResult(1, "failed \xB1 build"));
+
+        self::assertSame('{"output":"failed \ufffd build"}', $data);
     }
 
     #[Test]

--- a/tests/Unit/Web/DevServer/DevHtmlInjectorTest.php
+++ b/tests/Unit/Web/DevServer/DevHtmlInjectorTest.php
@@ -34,6 +34,17 @@ final class DevHtmlInjectorTest extends TestCase
         self::assertStringNotContainsString('es.addEventListener("ping", function() { es.close(); connect(); });', $body);
     }
 
+    public function testLiveReloadShowsBuildErrorsOnPage(): void
+    {
+        $body = LiveReloadHtmlInjector::inject('<html><body><p>Hello</p></body></html>');
+
+        self::assertStringContainsString('errorPanel.id = "yiipress-build-error";', $body);
+        self::assertStringContainsString('title.textContent = "Build failed";', $body);
+        self::assertStringContainsString('showBuildError(output);', $body);
+        self::assertStringContainsString('hideBuildError(); es.close(); location.reload();', $body);
+        self::assertStringNotContainsString('console.error', $body);
+    }
+
     public function testLiveReloadClosesEventSourceWhenPageIsLeaving(): void
     {
         $body = LiveReloadHtmlInjector::inject('<html><body><p>Hello</p></body></html>');

--- a/tests/Unit/Web/LiveReload/SiteBuildRunnerTest.php
+++ b/tests/Unit/Web/LiveReload/SiteBuildRunnerTest.php
@@ -52,7 +52,7 @@ final class SiteBuildRunnerTest extends TestCase
 
         $runner = new SiteBuildRunner($script, $this->tempDir . '/content', $this->tempDir . '/output');
 
-        self::assertTrue($runner->build());
+        self::assertTrue($runner->build()->succeeded());
 
         $commandLine = file_get_contents($recordFile);
         assertSame(
@@ -64,16 +64,18 @@ final class SiteBuildRunnerTest extends TestCase
         assertStringNotContainsString('--no-cache', $commandLine);
     }
 
-    public function testBuildReturnsFalseWhenCommandFails(): void
+    public function testBuildReturnsFailureResultWhenCommandFails(): void
     {
         $script = $this->tempDir . '/fail-yii';
-        file_put_contents($script, "#!/bin/sh\necho 'broken build'\nexit 1\n");
+        file_put_contents($script, "#!/bin/sh\nprintf 'failed build\n'\nexit 1\n");
         chmod($script, 0o755);
 
         $runner = new SiteBuildRunner($script, $this->tempDir . '/content', $this->tempDir . '/output');
+        $result = $runner->build();
 
-        assertFalse($runner->build());
-        assertStringContainsString('broken build', $runner->lastOutput());
+        assertFalse($result->succeeded());
+        assertSame(1, $result->exitCode);
+        assertStringContainsString('failed build', $result->output);
     }
 
     private function removeDir(string $path): void


### PR DESCRIPTION
## Summary
- return build exit code and captured output from live reload rebuilds
- send reload only after successful rebuilds
- send build-error SSE events with command output instead of reloading stale pages after failures

## Tests
- make test -- --filter SiteBuildRunnerTest
- make test -- --filter DevHtmlInjectorTest
- make test -- --filter DevHtmlMiddlewareTest
- make psalm
- make test

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved internal build result handling in the development server to provide structured error information.

* **Bug Fixes**
  * Enhanced error reporting during live reload, displaying detailed build failure messages directly in the browser console.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->