### PR TITLE
Add entry alias redirects

### DIFF
--- a/docs/content.md
+++ b/docs/content.md
@@ -115,6 +115,9 @@ authors:
 image: /blog/assets/hero.jpg
 summary: A brief introduction to YiiPress.
 permalink: /custom/path/
+aliases:
+  - /old-path/
+  - /legacy/path/
 layout: post
 theme: custom
 weight: 10
@@ -135,6 +138,7 @@ extra:
 - **image** — featured image URL (absolute, or root-relative path resolved against `base_url`); used as `og:image` for social sharing. Falls back to the site-level `image` in `config.yaml`
 - **summary** — manual excerpt; if omitted, auto-generated from content
 - **permalink** — per-entry URL override; takes precedence over collection pattern. Permalinks must be root-relative paths with a trailing slash, must not contain repeated `/`, `.` or `..` path segments, and must be unique across generated entries and standalone pages.
+- **aliases** — old URLs for this entry. YiiPress writes redirect pages from each alias to the entry permalink, or to `redirect_to` when the entry is itself a redirect. Aliases are site-root paths, must be unique across aliases and generated page permalinks, and are not added to feeds, listings, or sitemap
 - **layout** — template layout name (default: collection-specific or `entry`)
 - **theme** — theme name for this entry; overrides the site-level default (see [Templates](templates.md))
 - **weight** — integer for custom sorting in non-blog collections (lower = first)

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -137,9 +137,6 @@
     <MixedArrayOffset>
       <code><![CDATA[$entriesByAuthor[$authorSlug]]]></code>
     </MixedArrayOffset>
-    <MixedMethodCall>
-      <code><![CDATA[write]]></code>
-    </MixedMethodCall>
     <MixedPropertyFetch>
       <code><![CDATA[$entry->authors]]></code>
     </MixedPropertyFetch>

--- a/roadmap.md
+++ b/roadmap.md
@@ -89,6 +89,7 @@
 - [x] Canonical URL support
 - [x] Configurable `robots.txt` generation
 - [x] Redirect support (e.g., when changing permalinks, output redirect HTML or config)
+- [x] Entry aliases in front matter for old URL redirects
 - [x] Root-relative redirects resolve against deployment paths from `base_url`
 - [x] 404 page in static build output for static hosting providers (Netlify, GitHub Pages, etc.)
 - [x] Deployment helpers/docs for common static hosts (GitHub Pages, Netlify, Vercel, Cloudflare Pages)

--- a/src/Console/BuildCommand.php
+++ b/src/Console/BuildCommand.php
@@ -403,6 +403,8 @@ final class BuildCommand extends Command
         $rawEntriesByCollection = [];
         $fileToPermalink = [];
         $permalinkSources = [];
+        $aliasRedirectTasks = [];
+        $aliasOutputsBySource = [];
 
         try {
             foreach ($collections as $collectionName => $collection) {
@@ -417,6 +419,9 @@ final class BuildCommand extends Command
                     $relativePath = substr($sourcePath, strlen($contentDir) + 1);
                     $permalink = PermalinkResolver::resolve($entry, $collection, $siteConfig->i18n);
                     $this->registerPermalink($permalinkSources, $permalink, $sourcePath);
+                    foreach ($entry->aliases as $alias) {
+                        $this->registerAliasPermalink($permalinkSources, $this->normalizeAliasPermalink($alias), $sourcePath);
+                    }
                     $fileToPermalink[$relativePath] = $permalink;
                 }
                 $rawEntriesByCollection[$collectionName] = $collectionEntries;
@@ -434,6 +439,9 @@ final class BuildCommand extends Command
                 $basePermalink = $page->permalink !== '' ? $page->permalink : '/' . $page->slug . '/';
                 $permalink = PermalinkResolver::applyLanguagePrefix($basePermalink, $page->language, $siteConfig->i18n);
                 $this->registerPermalink($permalinkSources, $permalink, $sourcePath);
+                foreach ($page->aliases as $alias) {
+                    $this->registerAliasPermalink($permalinkSources, $this->normalizeAliasPermalink($alias), $sourcePath);
+                }
                 $fileToPermalink[$relativePath] = $permalink;
             }
         } catch (FriendlyExceptionInterface $e) {
@@ -491,10 +499,32 @@ final class BuildCommand extends Command
 
                 if ($entry->redirectTo !== '') {
                     $redirectTasks[] = ['entry' => $entry, 'filePath' => $filePath, 'permalink' => $permalink, 'sourcePath' => $sourcePath];
+                    foreach ($entry->aliases as $alias) {
+                        $aliasPermalink = $this->normalizeAliasPermalink($alias);
+                        $aliasFilePath = $this->aliasFilePath($outputDir, $aliasPermalink);
+                        $aliasRedirectTasks[] = [
+                            'entry' => $entry,
+                            'filePath' => $aliasFilePath,
+                            'permalink' => $aliasPermalink,
+                            'sourcePath' => $sourcePath,
+                        ];
+                        $aliasOutputsBySource[$sourcePath][] = $aliasFilePath;
+                    }
                     continue;
                 }
 
                 $filtered[] = $entry;
+                foreach ($entry->aliases as $alias) {
+                    $aliasPermalink = $this->normalizeAliasPermalink($alias);
+                    $aliasFilePath = $this->aliasFilePath($outputDir, $aliasPermalink);
+                    $aliasRedirectTasks[] = [
+                        'entry' => $entry->withRedirectTo($permalink),
+                        'filePath' => $aliasFilePath,
+                        'permalink' => $aliasPermalink,
+                        'sourcePath' => $sourcePath,
+                    ];
+                    $aliasOutputsBySource[$sourcePath][] = $aliasFilePath;
+                }
                 $allTasks[] = [
                     'entry' => $entry,
                     'filePath' => $filePath,
@@ -557,6 +587,8 @@ final class BuildCommand extends Command
         );
 
         $profile->switchTo('write redirects');
+        /** @var RedirectPageWriter|null $redirectWriter */
+        $redirectWriter = null;
         if ($redirectTasks !== []) {
             $redirectWriter = new RedirectPageWriter();
             foreach ($redirectTasks as $task) {
@@ -571,15 +603,37 @@ final class BuildCommand extends Command
                     $task['permalink'],
                 );
             }
-            $output->writeln('  Redirects ' . ($noWrite ? 'rendered' : 'written') . ': <comment>' . count($redirectTasks) . '</comment>');
+        }
+
+        if ($aliasRedirectTasks !== []) {
+            $redirectWriter ??= new RedirectPageWriter();
+            foreach ($aliasRedirectTasks as $task) {
+                $language = $task['entry']->language !== '' ? $task['entry']->language : $siteConfig->defaultLanguage;
+                $redirectWriter->write(
+                    $task['entry'],
+                    $task['filePath'],
+                    $language,
+                    UiText::forTheme($siteConfig->defaultLanguage, $this->templateResolver, $siteConfig->theme, $siteConfig->defaultLanguage),
+                    $noWrite,
+                    $siteConfig,
+                    $task['permalink'],
+                );
+            }
+        }
+
+        $redirectCount = count($redirectTasks) + count($aliasRedirectTasks);
+        if ($redirectCount > 0) {
+            $output->writeln('  Redirects ' . ($noWrite ? 'rendered' : 'written') . ': <comment>' . $redirectCount . '</comment>');
         }
 
         if ($manifest !== null) {
             foreach ($allTasks as $task) {
-                $this->removeStaleOutputs($manifest->replace($task['sourcePath'], [$task['filePath']]), $outputDir);
+                $outputs = [$task['filePath'], ...($aliasOutputsBySource[$task['sourcePath']] ?? [])];
+                $this->removeStaleOutputs($manifest->replace($task['sourcePath'], $outputs), $outputDir);
             }
             foreach ($redirectTasks as $task) {
-                $this->removeStaleOutputs($manifest->replace($task['sourcePath'], [$task['filePath']]), $outputDir);
+                $outputs = [$task['filePath'], ...($aliasOutputsBySource[$task['sourcePath']] ?? [])];
+                $this->removeStaleOutputs($manifest->replace($task['sourcePath'], $outputs), $outputDir);
             }
             foreach ($rawEntriesByCollection as $entries) {
                 foreach ($entries as $entry) {
@@ -600,6 +654,7 @@ final class BuildCommand extends Command
         $profile->switchTo('write standalone pages');
         $standaloneTasks = [];
         $standaloneRedirectTasks = [];
+        $standaloneAliasRedirectTasks = [];
         foreach ($standalonePages as $page) {
             $sourcePath = $page->filePath;
             $basePermalink = $page->permalink !== '' ? $page->permalink : '/' . $page->slug . '/';
@@ -607,13 +662,39 @@ final class BuildCommand extends Command
             $filePath = $outputDir . $permalink . 'index.html';
 
             if ($changedSet !== null && !isset($changedSet[$sourcePath])) {
-                $manifest?->record($sourcePath, [$filePath]);
+                $outputs = [$filePath];
+                foreach ($page->aliases as $alias) {
+                    $outputs[] = $this->aliasFilePath($outputDir, $this->normalizeAliasPermalink($alias));
+                }
+                $manifest?->record($sourcePath, $outputs);
                 continue;
             }
 
             if ($page->redirectTo !== '') {
                 $standaloneRedirectTasks[] = ['entry' => $page, 'filePath' => $filePath, 'permalink' => $permalink, 'sourcePath' => $sourcePath];
+                foreach ($page->aliases as $alias) {
+                    $aliasPermalink = $this->normalizeAliasPermalink($alias);
+                    $aliasFilePath = $this->aliasFilePath($outputDir, $aliasPermalink);
+                    $standaloneAliasRedirectTasks[] = [
+                        'entry' => $page,
+                        'filePath' => $aliasFilePath,
+                        'permalink' => $aliasPermalink,
+                        'sourcePath' => $sourcePath,
+                    ];
+                    $aliasOutputsBySource[$sourcePath][] = $aliasFilePath;
+                }
             } else {
+                foreach ($page->aliases as $alias) {
+                    $aliasPermalink = $this->normalizeAliasPermalink($alias);
+                    $aliasFilePath = $this->aliasFilePath($outputDir, $aliasPermalink);
+                    $standaloneAliasRedirectTasks[] = [
+                        'entry' => $page->withRedirectTo($permalink),
+                        'filePath' => $aliasFilePath,
+                        'permalink' => $aliasPermalink,
+                        'sourcePath' => $sourcePath,
+                    ];
+                    $aliasOutputsBySource[$sourcePath][] = $aliasFilePath;
+                }
                 $standaloneTask = [
                     'entry' => $page,
                     'filePath' => $filePath,
@@ -653,14 +734,28 @@ final class BuildCommand extends Command
                 $task['permalink'],
             );
         }
-        $standalonePagesWritten += count($standaloneRedirectTasks);
+        foreach ($standaloneAliasRedirectTasks as $task) {
+            $language = $task['entry']->language !== '' ? $task['entry']->language : $siteConfig->defaultLanguage;
+            $redirectWriter->write(
+                $task['entry'],
+                $task['filePath'],
+                $language,
+                UiText::forTheme($siteConfig->defaultLanguage, $this->templateResolver, $siteConfig->theme, $siteConfig->defaultLanguage),
+                $noWrite,
+                $siteConfig,
+                $task['permalink'],
+            );
+        }
+        $standalonePagesWritten += count($standaloneRedirectTasks) + count($standaloneAliasRedirectTasks);
 
         if ($manifest !== null) {
             foreach ($standaloneTasks as $task) {
-                $this->removeStaleOutputs($manifest->replace($task['sourcePath'], [$task['filePath']]), $outputDir);
+                $outputs = [$task['filePath'], ...($aliasOutputsBySource[$task['sourcePath']] ?? [])];
+                $this->removeStaleOutputs($manifest->replace($task['sourcePath'], $outputs), $outputDir);
             }
             foreach ($standaloneRedirectTasks as $task) {
-                $this->removeStaleOutputs($manifest->replace($task['sourcePath'], [$task['filePath']]), $outputDir);
+                $outputs = [$task['filePath'], ...($aliasOutputsBySource[$task['sourcePath']] ?? [])];
+                $this->removeStaleOutputs($manifest->replace($task['sourcePath'], $outputs), $outputDir);
             }
         }
 
@@ -1152,6 +1247,9 @@ final class BuildCommand extends Command
                 }
                 $permalink = PermalinkResolver::resolve($entry, $collection, $siteConfig->i18n);
                 $files[] = $outputDir . $permalink . 'index.html';
+                foreach ($entry->aliases as $alias) {
+                    $files[] = $this->aliasFilePath($outputDir, $this->normalizeAliasPermalink($alias));
+                }
                 if ($entry->redirectTo === '') {
                     $entries[] = $entry;
                 }
@@ -1208,6 +1306,9 @@ final class BuildCommand extends Command
             }
             $permalink = $page->permalink !== '' ? $page->permalink : '/' . $page->slug . '/';
             $files[] = $outputDir . $permalink . 'index.html';
+            foreach ($page->aliases as $alias) {
+                $files[] = $this->aliasFilePath($outputDir, $this->normalizeAliasPermalink($alias));
+            }
         }
 
         $contentAssetCopier = new ContentAssetCopier();
@@ -1423,6 +1524,28 @@ final class BuildCommand extends Command
         $permalinkSources[$normalized] = $sourcePath;
     }
 
+    /**
+     * @param array<string, string> $permalinkSources
+     */
+    private function registerAliasPermalink(array &$permalinkSources, string $aliasPermalink, string $sourcePath): void
+    {
+        $normalized = $aliasPermalink === '/' ? '/' : rtrim($aliasPermalink, '/');
+        if (isset($permalinkSources[$normalized])) {
+            throw new InvalidContentConfigException(
+                sprintf(
+                    'Duplicate alias "%s" in %s and %s.',
+                    $aliasPermalink,
+                    $permalinkSources[$normalized],
+                    $sourcePath,
+                ),
+                $sourcePath,
+                'Change one of the alias or permalink values so each generated output path is unique.',
+            );
+        }
+
+        $permalinkSources[$normalized] = $sourcePath;
+    }
+
     private function validatePermalink(string $permalink, string $sourcePath): void
     {
         if ($permalink === '' || !str_starts_with($permalink, '/')) {
@@ -1489,6 +1612,37 @@ final class BuildCommand extends Command
         if (is_file($outputFile)) {
             unlink($outputFile);
         }
+    }
+
+    private function normalizeAliasPermalink(string $alias): string
+    {
+        $alias = trim($alias);
+        if ($alias === '') {
+            throw new RuntimeException('Entry aliases must not be empty.');
+        }
+
+        if (str_contains($alias, '://') || str_starts_with($alias, '//') || str_contains($alias, '?') || str_contains($alias, '#')) {
+            throw new RuntimeException(sprintf('Entry alias "%s" must be a site-root path.', $alias));
+        }
+
+        $alias = '/' . trim($alias, '/') . '/';
+        $segments = explode('/', trim($alias, '/'));
+        foreach ($segments as $segment) {
+            if ($segment === '.' || $segment === '..') {
+                throw new RuntimeException(sprintf('Entry alias "%s" must not contain "." or ".." path segments.', $alias));
+            }
+        }
+
+        return $alias === '//' ? '/' : preg_replace('#/+#', '/', $alias) ?? $alias;
+    }
+
+    private function aliasFilePath(string $outputDir, string $aliasPermalink): string
+    {
+        if ($aliasPermalink === '/') {
+            return $outputDir . '/index.html';
+        }
+
+        return $outputDir . rtrim($aliasPermalink, '/') . '/index.html';
     }
 
     private function assetFingerprintEnabled(string $contentDir): bool

--- a/src/Content/Model/Entry.php
+++ b/src/Content/Model/Entry.php
@@ -14,6 +14,7 @@ final class Entry
      * @param list<string> $categories
      * @param list<string> $authors
      * @param array<string, mixed> $extra
+     * @param list<string> $aliases
      */
     public function __construct(
         public string $filePath,
@@ -39,6 +40,7 @@ final class Entry
         public array $inlineTags = [],
         public string $translationKey = '',
         public bool $showTitle = true,
+        public array $aliases = [],
     ) {}
 
     private ?string $bodyCache = null;
@@ -47,6 +49,36 @@ final class Entry
     public function sourceFilePath(): string
     {
         return $this->filePath;
+    }
+
+    public function withRedirectTo(string $redirectTo): self
+    {
+        return new self(
+            filePath: $this->filePath,
+            collection: $this->collection,
+            slug: $this->slug,
+            title: $this->title,
+            date: $this->date,
+            draft: $this->draft,
+            tags: $this->tags,
+            categories: $this->categories,
+            authors: $this->authors,
+            summary: $this->summary,
+            permalink: $this->permalink,
+            layout: $this->layout,
+            theme: $this->theme,
+            weight: $this->weight,
+            language: $this->language,
+            redirectTo: $redirectTo,
+            extra: $this->extra,
+            bodyOffset: $this->bodyOffset,
+            bodyLength: $this->bodyLength,
+            image: $this->image,
+            inlineTags: $this->inlineTags,
+            translationKey: $this->translationKey,
+            showTitle: $this->showTitle,
+            aliases: $this->aliases,
+        );
     }
 
     private const int SUMMARY_LENGTH = 300;

--- a/src/Content/Parser/EntryParser.php
+++ b/src/Content/Parser/EntryParser.php
@@ -103,6 +103,9 @@ final readonly class EntryParser
             image: (string) ($fields['image'] ?? ''),
             translationKey: (string) ($fields['translation_key'] ?? ''),
             showTitle: (bool) ($fields['showTitle'] ?? true),
+            aliases: isset($fields['aliases']) && is_array($fields['aliases'])
+                ? array_values(array_map(strval(...), $fields['aliases']))
+                : [],
         );
     }
 

--- a/tests/Unit/Console/BuildCommandTest.php
+++ b/tests/Unit/Console/BuildCommandTest.php
@@ -569,6 +569,83 @@ PHP,
         assertStringNotContainsString('No Date Post', $atom);
     }
 
+    public function testBuildGeneratesRedirectsForEntryAliases(): void
+    {
+        $tempDir = sys_get_temp_dir() . '/yiipress-build-alias-test-' . uniqid();
+        $contentDir = $tempDir . '/content';
+        $outputDir = $tempDir . '/output';
+        mkdir($contentDir . '/blog', 0o755, true);
+        $this->tempContentDirs[] = $tempDir;
+
+        file_put_contents($contentDir . '/config.yaml', "title: Alias Site\nbase_url: https://example.com\nlanguages: [en]\n");
+        file_put_contents($contentDir . '/blog/_collection.yaml', "title: Blog\npermalink: /blog/:slug/\n");
+        file_put_contents($contentDir . '/blog/post.md', "---\ntitle: Post\naliases:\n  - /old-post/\n  - legacy/post\n---\n\nBody.\n");
+
+        $yii = dirname(__DIR__, 3) . '/yii';
+        exec(
+            $yii . ' build'
+            . ' --content-dir=' . escapeshellarg($contentDir)
+            . ' --output-dir=' . escapeshellarg($outputDir)
+            . ' --no-cache'
+            . ' 2>&1',
+            $output,
+            $exitCode,
+        );
+
+        assertSame(0, $exitCode, implode("\n", $output));
+
+        $oldPost = file_get_contents($outputDir . '/old-post/index.html');
+        assertNotFalse($oldPost);
+        assertStringContainsString('http-equiv="refresh"', $oldPost);
+        assertStringContainsString('href="/blog/post/"', $oldPost);
+
+        $legacy = file_get_contents($outputDir . '/legacy/post/index.html');
+        assertNotFalse($legacy);
+        assertStringContainsString('href="/blog/post/"', $legacy);
+
+        $sitemap = file_get_contents($outputDir . '/sitemap.xml');
+        assertNotFalse($sitemap);
+        assertStringContainsString('/blog/post/', $sitemap);
+        assertStringNotContainsString('/old-post/', $sitemap);
+        assertStringNotContainsString('/legacy/post/', $sitemap);
+    }
+
+    public function testBuildGeneratesAliasRedirectsForRedirectEntries(): void
+    {
+        $tempDir = sys_get_temp_dir() . '/yiipress-build-redirect-alias-test-' . uniqid();
+        $contentDir = $tempDir . '/content';
+        $outputDir = $tempDir . '/output';
+        mkdir($contentDir . '/blog', 0o755, true);
+        $this->tempContentDirs[] = $tempDir;
+
+        file_put_contents($contentDir . '/config.yaml', "title: Alias Redirect Site\nbase_url: https://example.com\nlanguages: [en]\n");
+        file_put_contents($contentDir . '/blog/_collection.yaml', "title: Blog\npermalink: /blog/:slug/\n");
+        file_put_contents($contentDir . '/blog/post.md', "---\ntitle: Post\nredirect_to: /new-post/\naliases:\n  - /old-post/\n---\n");
+
+        $yii = dirname(__DIR__, 3) . '/yii';
+        exec(
+            $yii . ' build'
+            . ' --content-dir=' . escapeshellarg($contentDir)
+            . ' --output-dir=' . escapeshellarg($outputDir)
+            . ' --no-cache'
+            . ' 2>&1',
+            $output,
+            $exitCode,
+        );
+
+        assertSame(0, $exitCode, implode("\n", $output));
+
+        $redirect = file_get_contents($outputDir . '/blog/post/index.html');
+        assertNotFalse($redirect);
+        assertStringContainsString('href="/new-post/"', $redirect);
+
+        $alias = file_get_contents($outputDir . '/old-post/index.html');
+        assertNotFalse($alias);
+        assertStringContainsString('http-equiv="refresh"', $alias);
+        assertStringContainsString('href="/new-post/"', $alias);
+        assertStringNotContainsString('href="/blog/post/"', $alias);
+    }
+
     public function testBuildExcludesFutureDatedEntriesByDefault(): void
     {
         $yii = dirname(__DIR__, 3) . '/yii';
@@ -1247,6 +1324,32 @@ PHP,
 
         assertSame(65, $result['exitCode'], $result['output']);
         assertStringContainsString('Duplicate permalink "/same/"', $result['output']);
+    }
+
+    public function testBuildRejectsAliasThatDuplicatesPermalink(): void
+    {
+        $contentDir = $this->createMinimalContent([
+            'index.md' => "---\ntitle: Home\npermalink: /\naliases:\n  - /about/\n---\n\nHello.\n",
+            'about.md' => "---\ntitle: About\npermalink: /about/\n---\n\nAbout.\n",
+        ]);
+
+        $result = $this->runBuildResult($contentDir);
+
+        assertSame(65, $result['exitCode'], $result['output']);
+        assertStringContainsString('Duplicate permalink "/about/"', $result['output']);
+    }
+
+    public function testBuildRejectsDuplicateAliases(): void
+    {
+        $contentDir = $this->createMinimalContent([
+            'index.md' => "---\ntitle: Home\npermalink: /\naliases:\n  - /old/\n---\n\nHello.\n",
+            'about.md' => "---\ntitle: About\npermalink: /about/\naliases:\n  - old\n---\n\nAbout.\n",
+        ]);
+
+        $result = $this->runBuildResult($contentDir);
+
+        assertSame(65, $result['exitCode'], $result['output']);
+        assertStringContainsString('Duplicate alias "/old/"', $result['output']);
     }
 
     public function testBuildRejectsTraversingPermalink(): void

--- a/tests/Unit/Content/Parser/EntryParserTest.php
+++ b/tests/Unit/Content/Parser/EntryParserTest.php
@@ -61,6 +61,20 @@ final class EntryParserTest extends TestCase
         assertSame(['custom_field' => 'value'], $entry->extra);
     }
 
+    public function testParseEntryAliases(): void
+    {
+        $file = tempnam(sys_get_temp_dir(), 'yiipress-entry-aliases-') . '.md';
+        file_put_contents($file, "---\ntitle: Aliased\naliases:\n  - /old-url/\n  - legacy-url\n---\n\nBody.\n");
+
+        try {
+            $entry = $this->parser->parse($file, 'blog');
+
+            assertSame(['/old-url/', 'legacy-url'], $entry->aliases);
+        } finally {
+            unlink($file);
+        }
+    }
+
     public function testEntryBodyIsLoadedLazily(): void
     {
         $entry = $this->parser->parse($this->dataDir . '/blog/2024-03-15-test-post.md', 'blog');


### PR DESCRIPTION
## Summary
- parse aliases front matter on entries
- write redirect pages from aliases to the resolved entry permalink
- include aliases in dry-run/output tracking while keeping them out of feeds and sitemap
- document aliases and mark the roadmap item complete

## Tests
- make test -- --filter testParseEntryAliases
- make test -- --filter testBuildGeneratesRedirectsForEntryAliases
- make psalm
- make test