### PR TITLE
Minify CSS and JavaScript assets

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -74,7 +74,7 @@ editor: code
 - **toc** — generate a table of contents from headings (default: `true`); set to `false` to disable globally. When enabled, heading tags receive `id` attributes and a `$toc` variable is passed to templates
 - **search** — opt-in client-side search (see below)
 - **related** — opt-in related content suggestions (see below)
-- **minify** — minify generated HTML output (default: `true`); set to `false` to keep rendered template whitespace
+- **minify** — minify generated HTML output and copied CSS/JavaScript assets (default: `true`); set to `false` to keep rendered template and asset whitespace
 - **last_updated** — set to `true` to show each entry source file's last modification time below its content (default: `false`)
 - **edit_page** — URL template for an optional "Edit this page" link below entry content (see below)
 - **report_issue** — URL template for an optional "Report an issue" link below entry content (see below)
@@ -216,14 +216,15 @@ the current output page, so they remain valid when `base_url` contains a deploym
 
 ### Output minification
 
-Generated HTML pages are minified by default:
+Generated HTML pages and copied CSS/JavaScript assets are minified by default:
 
 ```yaml
 minify: true
 ```
 
-Set `minify: false` to keep template indentation and line breaks in generated `*.html` files.
-Whitespace inside `pre`, `textarea`, `script`, and `style` elements is preserved either way.
+Set `minify: false` to keep template indentation and line breaks in generated `*.html` files
+and to copy `*.css` / `*.js` assets without rewriting them. Whitespace inside `pre`, `textarea`,
+`script`, and `style` elements is preserved either way.
 
 ### Editor
 

--- a/roadmap.md
+++ b/roadmap.md
@@ -79,7 +79,7 @@
 - [x] Static file copying (fonts, downloads, PDFs from source to output)
 - [x] Root-relative asset URLs stay valid when deploying under a subdirectory
 - [x] Nightly Linux binary published for GitHub Actions preview builds
-- [x] Configurable generated HTML output minification
+- [x] Configurable generated HTML and CSS/JavaScript asset minification
 
 ## Priority 6: SEO and web standards
 

--- a/src/Build/AssetFileWriter.php
+++ b/src/Build/AssetFileWriter.php
@@ -1,0 +1,58 @@
+<?php
+
+declare(strict_types=1);
+
+namespace YiiPress\Build;
+
+use RuntimeException;
+
+use function clearstatcache;
+use function file_get_contents;
+use function file_put_contents;
+use function filemtime;
+use function is_file;
+use function sprintf;
+use function touch;
+
+final class AssetFileWriter
+{
+    public function writeIfChanged(string $sourcePath, string $targetPath, bool $minify): bool
+    {
+        if (!$minify || !AssetMinifier::supports($sourcePath)) {
+            return FileCopy::copyIfChanged($sourcePath, $targetPath);
+        }
+
+        $content = file_get_contents($sourcePath);
+        if ($content === false) {
+            throw new RuntimeException(sprintf('Unable to read asset "%s".', $sourcePath));
+        }
+
+        $content = AssetMinifier::minify($sourcePath, $content);
+        if ($this->destinationMatchesContent($targetPath, $content)) {
+            return false;
+        }
+
+        if (file_put_contents($targetPath, $content) === false) {
+            throw new RuntimeException(sprintf('Unable to write asset "%s".', $targetPath));
+        }
+
+        $mtime = filemtime($sourcePath);
+        if ($mtime !== false) {
+            touch($targetPath, $mtime);
+        }
+
+        return true;
+    }
+
+    private function destinationMatchesContent(string $targetPath, string $content): bool
+    {
+        if (!is_file($targetPath)) {
+            return false;
+        }
+
+        clearstatcache(true, $targetPath);
+        $targetContent = file_get_contents($targetPath);
+
+        return $targetContent === $content;
+    }
+}

--- a/src/Build/AssetMinifier.php
+++ b/src/Build/AssetMinifier.php
@@ -1,0 +1,256 @@
+<?php
+
+declare(strict_types=1);
+
+namespace YiiPress\Build;
+
+use function pathinfo;
+use function preg_match;
+use function preg_replace;
+use function rtrim;
+use function str_contains;
+use function strlen;
+use function strtolower;
+use function substr;
+use function trim;
+
+use const PATHINFO_EXTENSION;
+
+final class AssetMinifier
+{
+    public static function supports(string $path): bool
+    {
+        $extension = strtolower(pathinfo($path, PATHINFO_EXTENSION));
+
+        return $extension === 'css' || $extension === 'js';
+    }
+
+    public static function minify(string $path, string $content): string
+    {
+        return match (strtolower(pathinfo($path, PATHINFO_EXTENSION))) {
+            'css' => self::css($content),
+            'js' => self::js($content),
+            default => $content,
+        };
+    }
+
+    private static function css(string $content): string
+    {
+        $content = self::stripComments($content, preserveNewLines: false, stripLineComments: false);
+        $content = self::collapseCssWhitespace($content);
+        $content = (string) preg_replace('/\s*([{}:;,>~=\[\]])\s*/', '$1', $content);
+        $content = (string) preg_replace('/;}/', '}', $content);
+
+        return trim($content);
+    }
+
+    private static function js(string $content): string
+    {
+        $content = self::stripComments($content, preserveNewLines: true, stripLineComments: true, preserveJsRegex: true);
+
+        return rtrim((string) preg_replace('/[ \t]+/', ' ', $content));
+    }
+
+    private static function stripComments(string $content, bool $preserveNewLines, bool $stripLineComments = true, bool $preserveJsRegex = false): string
+    {
+        $length = strlen($content);
+        $result = '';
+        $quote = '';
+        $escaped = false;
+
+        for ($i = 0; $i < $length; $i++) {
+            $char = $content[$i];
+            $next = $i + 1 < $length ? $content[$i + 1] : '';
+
+            if ($quote !== '') {
+                $result .= $char;
+                if ($escaped) {
+                    $escaped = false;
+                    continue;
+                }
+                if ($char === '\\') {
+                    $escaped = true;
+                    continue;
+                }
+                if ($char === $quote) {
+                    $quote = '';
+                }
+                continue;
+            }
+
+            if ($char === '"' || $char === "'" || $char === '`') {
+                $quote = $char;
+                $result .= $char;
+                continue;
+            }
+
+            if ($char === '/' && $next !== '/' && $next !== '*' && $preserveJsRegex && self::startsRegexLiteral($result)) {
+                $result .= $char;
+                $inCharacterClass = false;
+                $regexEscaped = false;
+                $i++;
+
+                while ($i < $length) {
+                    $regexChar = $content[$i];
+                    $result .= $regexChar;
+
+                    if ($regexEscaped) {
+                        $regexEscaped = false;
+                        $i++;
+                        continue;
+                    }
+
+                    if ($regexChar === '\\') {
+                        $regexEscaped = true;
+                        $i++;
+                        continue;
+                    }
+
+                    if ($regexChar === '[') {
+                        $inCharacterClass = true;
+                        $i++;
+                        continue;
+                    }
+
+                    if ($regexChar === ']') {
+                        $inCharacterClass = false;
+                        $i++;
+                        continue;
+                    }
+
+                    if ($regexChar === '/' && !$inCharacterClass) {
+                        break;
+                    }
+
+                    $i++;
+                }
+
+                while ($i + 1 < $length && preg_match('/[A-Za-z]/', $content[$i + 1]) === 1) {
+                    $i++;
+                    $result .= $content[$i];
+                }
+
+                continue;
+            }
+
+            if ($char === '/' && $next === '*') {
+                $comment = '';
+                $i += 2;
+                while ($i < $length) {
+                    if ($content[$i] === '*' && $i + 1 < $length && $content[$i + 1] === '/') {
+                        $i++;
+                        break;
+                    }
+                    if ($preserveNewLines && ($content[$i] === "\n" || $content[$i] === "\r")) {
+                        $comment .= $content[$i];
+                    }
+                    $i++;
+                }
+                $result .= $preserveNewLines && str_contains($comment, "\n") ? $comment : ' ';
+                continue;
+            }
+
+            if ($stripLineComments && $char === '/' && $next === '/') {
+                $i += 2;
+                while ($i < $length && $content[$i] !== "\n") {
+                    $i++;
+                }
+                if ($i < $length) {
+                    $result .= "\n";
+                }
+                continue;
+            }
+
+            $result .= $char;
+        }
+
+        return $result;
+    }
+
+    private static function startsRegexLiteral(string $code): bool
+    {
+        $code = rtrim($code);
+        if ($code === '') {
+            return true;
+        }
+
+        $last = substr($code, -1);
+        if (match ($last) {
+            '(', '[', '{', '=', ',', ':', ';', '!', '&', '|', '?', '+', '-', '*', '~', '^', '<', '>', '%' => true,
+            default => false,
+        }) {
+            return true;
+        }
+
+        return preg_match('/(?:^|[^A-Za-z0-9_$])(?:return|throw|case|delete|typeof|void|new|yield)$/', $code) === 1;
+    }
+
+    private static function collapseCssWhitespace(string $content): string
+    {
+        $length = strlen($content);
+        $result = '';
+        $quote = '';
+        $escaped = false;
+        $pendingSpace = false;
+
+        for ($i = 0; $i < $length; $i++) {
+            $char = $content[$i];
+
+            if ($quote !== '') {
+                if ($pendingSpace) {
+                    $result .= ' ';
+                    $pendingSpace = false;
+                }
+                $result .= $char;
+                if ($escaped) {
+                    $escaped = false;
+                    continue;
+                }
+                if ($char === '\\') {
+                    $escaped = true;
+                    continue;
+                }
+                if ($char === $quote) {
+                    $quote = '';
+                }
+                continue;
+            }
+
+            if ($char === '"' || $char === "'") {
+                if ($pendingSpace) {
+                    $result .= ' ';
+                    $pendingSpace = false;
+                }
+                $quote = $char;
+                $result .= $char;
+                continue;
+            }
+
+            if ($char === ' ' || $char === "\t" || $char === "\n" || $char === "\r") {
+                $pendingSpace = $result !== '';
+                continue;
+            }
+
+            if ($pendingSpace && self::needsCssSpace($result, $char)) {
+                $result .= ' ';
+            }
+            $pendingSpace = false;
+            $result .= $char;
+        }
+
+        return $result;
+    }
+
+    private static function needsCssSpace(string $previousContent, string $next): bool
+    {
+        $previous = substr($previousContent, -1);
+
+        return (self::isIdentifierChar($previous) && self::isIdentifierChar($next))
+            || ($next === '(' && preg_match('/(?:^|[^A-Za-z0-9_-])(?:and|or|not|only)$/i', $previousContent) === 1);
+    }
+
+    private static function isIdentifierChar(string $char): bool
+    {
+        return $char !== '' && preg_match('/[A-Za-z0-9_-]/', $char) === 1;
+    }
+}

--- a/src/Build/ContentAssetCopier.php
+++ b/src/Build/ContentAssetCopier.php
@@ -21,9 +21,10 @@ final class ContentAssetCopier
     /**
      * @return int number of assets copied
      */
-    public function copy(string $contentDir, string $outputDir, ?AssetFingerprintManifest $assetManifest = null, bool $noWrite = false): int
+    public function copy(string $contentDir, string $outputDir, ?AssetFingerprintManifest $assetManifest = null, bool $noWrite = false, bool $minify = true): int
     {
         $copied = 0;
+        $writer = new AssetFileWriter();
 
         foreach ($this->mappings($contentDir) as $sourcePath => $targetRelativePath) {
             $resolvedTarget = $assetManifest?->resolve($targetRelativePath) ?? $targetRelativePath;
@@ -39,7 +40,7 @@ final class ContentAssetCopier
                 throw new RuntimeException(sprintf('Directory "%s" was not created', $targetDir));
             }
 
-            if (FileCopy::copyIfChanged($sourcePath, $targetPath)) {
+            if ($writer->writeIfChanged($sourcePath, $targetPath, $minify)) {
                 $copied++;
             }
         }

--- a/src/Build/ThemeAssetCopier.php
+++ b/src/Build/ThemeAssetCopier.php
@@ -18,9 +18,10 @@ final class ThemeAssetCopier
     /**
      * @return int number of assets copied
      */
-    public function copy(ThemeRegistry $themeRegistry, string $outputDir, ?AssetFingerprintManifest $assetManifest = null, bool $noWrite = false): int
+    public function copy(ThemeRegistry $themeRegistry, string $outputDir, ?AssetFingerprintManifest $assetManifest = null, bool $noWrite = false, bool $minify = true): int
     {
         $copied = 0;
+        $writer = new AssetFileWriter();
 
         foreach ($this->mappings($themeRegistry) as $sourcePath => $targetRelativePath) {
             $resolvedTarget = $assetManifest?->resolve($targetRelativePath) ?? $targetRelativePath;
@@ -36,7 +37,7 @@ final class ThemeAssetCopier
                 throw new RuntimeException(sprintf('Directory "%s" was not created', $targetDir));
             }
 
-            if (FileCopy::copyIfChanged($sourcePath, $targetPath)) {
+            if ($writer->writeIfChanged($sourcePath, $targetPath, $minify)) {
                 $copied++;
             }
         }

--- a/src/Console/BuildCommand.php
+++ b/src/Console/BuildCommand.php
@@ -10,6 +10,7 @@ use YiiPress\Build\BuildCache;
 use YiiPress\Build\BuildManifest;
 use YiiPress\Build\BuildDiagnostics;
 use YiiPress\Build\BuildProfile;
+use YiiPress\Build\AssetFileWriter;
 use YiiPress\Build\CollectionListingWriter;
 use YiiPress\Build\ContentAssetCopier;
 use YiiPress\Build\DateArchiveWriter;
@@ -668,8 +669,9 @@ final class BuildCommand extends Command
         }
 
         $profile->switchTo('copy assets');
-        $assetsCopied = $contentAssetCopier->copy($contentDir, $outputDir, $assetManifest, $noWrite);
-        $assetsCopied += $themeAssetCopier->copy($this->themeRegistry, $outputDir, $assetManifest, $noWrite);
+        $assetsCopied = $contentAssetCopier->copy($contentDir, $outputDir, $assetManifest, $noWrite, $siteConfig->minify);
+        $assetsCopied += $themeAssetCopier->copy($this->themeRegistry, $outputDir, $assetManifest, $noWrite, $siteConfig->minify);
+        $assetWriter = new AssetFileWriter();
 
         foreach ($pipelineAssetMappings as $source => $target) {
             $resolvedTarget = $assetManifest?->resolve($target) ?? $target;
@@ -682,7 +684,7 @@ final class BuildCommand extends Command
             if (!is_dir($targetDir) && !mkdir($targetDir, 0o755, true) && !is_dir($targetDir)) {
                 throw new RuntimeException(sprintf('Directory "%s" was not created', $targetDir));
             }
-            if (FileCopy::copyIfChanged($source, $targetPath)) {
+            if ($assetWriter->writeIfChanged($source, $targetPath, $siteConfig->minify)) {
                 $assetsCopied++;
             }
         }

--- a/tests/Unit/Build/AssetFileWriterTest.php
+++ b/tests/Unit/Build/AssetFileWriterTest.php
@@ -1,0 +1,61 @@
+<?php
+
+declare(strict_types=1);
+
+namespace YiiPress\Tests\Unit\Build;
+
+use PHPUnit\Framework\TestCase;
+use YiiPress\Build\AssetFileWriter;
+
+use function PHPUnit\Framework\assertFalse;
+use function PHPUnit\Framework\assertStringEqualsFile;
+use function PHPUnit\Framework\assertTrue;
+
+final class AssetFileWriterTest extends TestCase
+{
+    private string $tempDir;
+
+    protected function setUp(): void
+    {
+        $this->tempDir = sys_get_temp_dir() . '/yiipress-asset-writer-test-' . uniqid();
+        mkdir($this->tempDir, 0o755, true);
+    }
+
+    protected function tearDown(): void
+    {
+        foreach (glob($this->tempDir . '/*') ?: [] as $file) {
+            unlink($file);
+        }
+        rmdir($this->tempDir);
+    }
+
+    public function testWritesMinifiedSupportedAssets(): void
+    {
+        $source = $this->tempDir . '/style.css';
+        $target = $this->tempDir . '/style.out.css';
+        file_put_contents($source, 'body { color: red; }');
+
+        $writer = new AssetFileWriter();
+
+        assertTrue($writer->writeIfChanged($source, $target, minify: true));
+        assertStringEqualsFile($target, 'body{color:red}');
+        assertFalse($writer->writeIfChanged($source, $target, minify: true));
+    }
+
+    public function testCopiesUnsupportedOrUnminifiedAssetsUnchanged(): void
+    {
+        $source = $this->tempDir . '/logo.svg';
+        $target = $this->tempDir . '/logo.out.svg';
+        file_put_contents($source, '<svg>  </svg>');
+
+        $writer = new AssetFileWriter();
+
+        assertTrue($writer->writeIfChanged($source, $target, minify: true));
+        assertStringEqualsFile($target, '<svg>  </svg>');
+
+        file_put_contents($source, '<svg></svg>');
+
+        assertTrue($writer->writeIfChanged($source, $target, minify: false));
+        assertStringEqualsFile($target, '<svg></svg>');
+    }
+}

--- a/tests/Unit/Build/AssetMinifierTest.php
+++ b/tests/Unit/Build/AssetMinifierTest.php
@@ -1,0 +1,77 @@
+<?php
+
+declare(strict_types=1);
+
+namespace YiiPress\Tests\Unit\Build;
+
+use PHPUnit\Framework\TestCase;
+use YiiPress\Build\AssetMinifier;
+
+use function PHPUnit\Framework\assertFalse;
+use function PHPUnit\Framework\assertSame;
+use function PHPUnit\Framework\assertTrue;
+
+final class AssetMinifierTest extends TestCase
+{
+    public function testSupportsCssAndJavaScriptAssets(): void
+    {
+        assertTrue(AssetMinifier::supports('theme/app.css'));
+        assertTrue(AssetMinifier::supports('theme/app.JS'));
+        assertFalse(AssetMinifier::supports('theme/logo.svg'));
+    }
+
+    public function testMinifiesCssWithoutBreakingUrlsOrStrings(): void
+    {
+        $css = <<<'CSS'
+            /* heading */
+            body {
+                color: red;
+                background: url(https://example.com/assets/banner.png);
+                content: "a /* not a comment */ b";
+            }
+            CSS;
+
+        assertSame(
+            'body{color:red;background:url(https://example.com/assets/banner.png);content:"a /* not a comment */ b"}',
+            AssetMinifier::minify('app.css', $css),
+        );
+    }
+
+    public function testMinifiesCssWithoutBreakingMediaQueries(): void
+    {
+        $css = <<<'CSS'
+            @media screen and (min-width: 600px) {
+                body { color: red; }
+            }
+            CSS;
+
+        assertSame(
+            '@media screen and (min-width:600px){body{color:red}}',
+            AssetMinifier::minify('app.css', $css),
+        );
+    }
+
+    public function testMinifiesJavaScriptWithoutBreakingRegexOrStrings(): void
+    {
+        $js = <<<'JS'
+            const url = "https://example.com"; // comment
+            const re = /https?:\/\/example\.com\/[a-z]+/gi;
+            const block = "/* not a comment */";
+            if (re.test(url)) {
+                console.log(block); /* done */
+            }
+            JS;
+
+        assertSame(
+            <<<'JS'
+            const url = "https://example.com"; 
+            const re = /https?:\/\/example\.com\/[a-z]+/gi;
+            const block = "/* not a comment */";
+            if (re.test(url)) {
+             console.log(block); 
+            }
+            JS,
+            AssetMinifier::minify('app.js', $js),
+        );
+    }
+}

--- a/tests/Unit/Build/ContentAssetCopierTest.php
+++ b/tests/Unit/Build/ContentAssetCopierTest.php
@@ -51,6 +51,34 @@ final class ContentAssetCopierTest extends TestCase
         assertStringEqualsFile($this->outputDir . '/blog/assets/banner.svg', '<svg/>');
     }
 
+    public function testMinifiesCssAndJavaScriptAssetsByDefault(): void
+    {
+        file_put_contents($this->contentDir . '/blog/assets/app.css', "/* theme */\nbody { color: red; }\n");
+        file_put_contents($this->contentDir . '/blog/assets/app.js', "const value = 1; // keep code\nconsole.log(value);\n");
+
+        $copier = new ContentAssetCopier();
+        $copied = $copier->copy($this->contentDir, $this->outputDir);
+
+        assertSame(2, $copied);
+        assertStringEqualsFile($this->outputDir . '/blog/assets/app.css', 'body{color:red}');
+        assertStringEqualsFile($this->outputDir . '/blog/assets/app.js', "const value = 1; \nconsole.log(value);");
+    }
+
+    public function testCanCopyCssAndJavaScriptAssetsWithoutMinifying(): void
+    {
+        $css = "/* theme */\nbody { color: red; }\n";
+        $js = "const value = 1; // keep code\nconsole.log(value);\n";
+        file_put_contents($this->contentDir . '/blog/assets/app.css', $css);
+        file_put_contents($this->contentDir . '/blog/assets/app.js', $js);
+
+        $copier = new ContentAssetCopier();
+        $copied = $copier->copy($this->contentDir, $this->outputDir, minify: false);
+
+        assertSame(2, $copied);
+        assertStringEqualsFile($this->outputDir . '/blog/assets/app.css', $css);
+        assertStringEqualsFile($this->outputDir . '/blog/assets/app.js', $js);
+    }
+
     public function testSkipsUnchangedOutputAsset(): void
     {
         $source = $this->contentDir . '/blog/assets/banner.svg';

--- a/tests/Unit/Build/ThemeAssetCopierTest.php
+++ b/tests/Unit/Build/ThemeAssetCopierTest.php
@@ -16,7 +16,7 @@ use RecursiveIteratorIterator;
 
 use function PHPUnit\Framework\assertFileExists;
 use function PHPUnit\Framework\assertSame;
-use function PHPUnit\Framework\assertStringContainsString;
+use function PHPUnit\Framework\assertStringEqualsFile;
 
 final class ThemeAssetCopierTest extends TestCase
 {
@@ -46,7 +46,22 @@ final class ThemeAssetCopierTest extends TestCase
 
         assertSame(1, $copied);
         assertFileExists($this->tempDir . '/output/assets/theme/style.css');
-        assertStringContainsString('color: red', file_get_contents($this->tempDir . '/output/assets/theme/style.css'));
+        assertStringEqualsFile($this->tempDir . '/output/assets/theme/style.css', 'body{color:red}');
+    }
+
+    public function testCanCopyThemeAssetsWithoutMinifying(): void
+    {
+        $css = 'body { color: red; }';
+        file_put_contents($this->tempDir . '/theme/assets/style.css', $css);
+
+        $registry = new ThemeRegistry();
+        $registry->register(new Theme('test', $this->tempDir . '/theme'));
+
+        $copier = new ThemeAssetCopier();
+        $copied = $copier->copy($registry, $this->tempDir . '/output', minify: false);
+
+        assertSame(1, $copied);
+        assertStringEqualsFile($this->tempDir . '/output/assets/theme/style.css', $css);
     }
 
     public function testReturnsZeroWhenNoAssetsDir(): void


### PR DESCRIPTION
## Summary
- minify copied CSS and JavaScript assets when site minification is enabled
- preserve unminified asset copies when `minify: false` is configured
- document the broader minification behavior and update the roadmap item

## Tests
- `make test -- --filter AssetMinifierTest`
- `make test -- --filter AssetFileWriterTest`
- `make test -- --filter ContentAssetCopierTest`
- `make test -- --filter ThemeAssetCopierTest`
- `make psalm`
- `make test`