### PR TITLE
Detect duplicate build output paths

### DIFF
--- a/src/Console/BuildCommand.php
+++ b/src/Console/BuildCommand.php
@@ -80,6 +80,7 @@ use function explode;
 use function file_get_contents;
 use function hash;
 use function hrtime;
+use function implode;
 use function is_array;
 use function is_file;
 use function is_readable;
@@ -487,6 +488,7 @@ final class BuildCommand extends Command
         $allTasks = [];
         $redirectTasks = [];
         $entriesByCollection = [];
+        $outputClaims = [];
         foreach ($collections as $collectionName => $collection) {
             $filtered = [];
             foreach ($rawEntriesByCollection[$collectionName] as $entry) {
@@ -507,6 +509,7 @@ final class BuildCommand extends Command
                     $this->writeProfile($output, $profile);
                     return ExitCode::DATAERR;
                 }
+                $outputClaims[] = ['filePath' => $filePath, 'permalink' => $permalink, 'sourcePath' => $sourcePath];
 
                 if ($entry->redirectTo !== '') {
                     $redirectTasks[] = ['entry' => $entry, 'filePath' => $filePath, 'permalink' => $permalink, 'sourcePath' => $sourcePath];
@@ -544,6 +547,32 @@ final class BuildCommand extends Command
                 ];
             }
             $entriesByCollection[$collectionName] = EntrySorter::sort($filtered, $collection);
+        }
+
+        foreach ($standalonePages as $page) {
+            if (!$includeDrafts && $page->draft) {
+                continue;
+            }
+            if (!$includeFuture && $page->date !== null && $page->date > $now) {
+                continue;
+            }
+
+            $basePermalink = $page->permalink !== '' ? $page->permalink : '/' . $page->slug . '/';
+            $permalink = PermalinkResolver::applyLanguagePrefix($basePermalink, $page->language, $siteConfig->i18n);
+            $outputClaims[] = [
+                'filePath' => $outputDir . $permalink . 'index.html',
+                'permalink' => $permalink,
+                'sourcePath' => $page->filePath,
+            ];
+        }
+
+        $duplicateOutputClaims = $this->duplicateOutputClaims($outputClaims, $contentDir);
+        foreach ($duplicateOutputClaims as $message) {
+            $output->writeln('<error>  ' . OutputFormatter::escape($message) . '</error>');
+        }
+        if ($duplicateOutputClaims !== []) {
+            $this->writeProfile($output, $profile);
+            return ExitCode::DATAERR;
         }
 
         foreach ($allTasks as $index => $task) {
@@ -1846,6 +1875,51 @@ final class BuildCommand extends Command
         return $task;
     }
 
+    /**
+     * @param list<array{filePath: string, permalink: string, sourcePath: string}> $claims
+     * @return list<string>
+     */
+    private function duplicateOutputClaims(array $claims, string $contentDir): array
+    {
+        $claimsByOutput = [];
+        foreach ($claims as $claim) {
+            $claimsByOutput[$claim['filePath']][] = $claim;
+        }
+
+        $messages = [];
+        foreach ($claimsByOutput as $filePath => $outputClaims) {
+            if (count($outputClaims) < 2) {
+                continue;
+            }
+
+            $sources = [];
+            foreach ($outputClaims as $claim) {
+                $sources[] = sprintf(
+                    '%s (%s)',
+                    $this->contentRelativePath($claim['sourcePath'], $contentDir),
+                    $claim['permalink'],
+                );
+            }
+
+            $messages[] = sprintf(
+                'Duplicate output path "%s" is claimed by %s.',
+                $filePath,
+                implode(' and ', $sources),
+            );
+        }
+
+        return $messages;
+    }
+
+    private function contentRelativePath(string $sourcePath, string $contentDir): string
+    {
+        $prefix = $contentDir . '/';
+        if (str_starts_with($sourcePath, $prefix)) {
+            return substr($sourcePath, strlen($prefix));
+        }
+
+        return $sourcePath;
+    }
 
     /**
      * @return list<string>

--- a/tests/Unit/Console/BuildCommandTest.php
+++ b/tests/Unit/Console/BuildCommandTest.php
@@ -322,6 +322,37 @@ PHP,
         assertFalse(is_file($tempDir . '/outside/index.html'));
     }
 
+    public function testBuildFailsOnDuplicateEntryPermalinksWithWorkers(): void
+    {
+        $tempDir = sys_get_temp_dir() . '/yiipress-build-duplicate-permalink-test-' . uniqid();
+        $contentDir = $tempDir . '/content';
+        $outputDir = $tempDir . '/output';
+        mkdir($contentDir . '/blog', 0o755, true);
+        $this->tempContentDirs[] = $tempDir;
+
+        file_put_contents($contentDir . '/config.yaml', "title: Duplicate Site\nlanguages: [en]\n");
+        file_put_contents($contentDir . '/blog/_collection.yaml', "title: Blog\npermalink: /blog/:slug/\n");
+        file_put_contents($contentDir . '/blog/first.md', "---\ntitle: First\npermalink: /blog/same/\n---\n\nFirst.\n");
+        file_put_contents($contentDir . '/blog/second.md', "---\ntitle: Second\npermalink: /blog/same/\n---\n\nSecond.\n");
+
+        $yii = dirname(__DIR__, 3) . '/yii';
+        exec(
+            $yii . ' build'
+            . ' --content-dir=' . escapeshellarg($contentDir)
+            . ' --output-dir=' . escapeshellarg($outputDir)
+            . ' --workers=2'
+            . ' --no-cache'
+            . ' 2>&1',
+            $output,
+            $exitCode,
+        );
+        $outputText = implode("\n", $output);
+
+        assertSame(ExitCode::DATAERR, $exitCode, $outputText);
+        assertStringContainsString('Duplicate permalink "/blog/same/"', $outputText);
+        assertFalse(is_file($outputDir . '/blog/same/index.html'));
+    }
+
     public function testBuildOutputContainsRenderedHtml(): void
     {
         $yii = dirname(__DIR__, 3) . '/yii';


### PR DESCRIPTION
## Summary
- fail builds when multiple included entries or standalone pages claim the same output file
- report each colliding content file with its permalink before rendering starts
- cover duplicate entry permalinks under multi-worker builds

## Tests
- `make test -- --filter testBuildFailsOnDuplicateEntryPermalinks`
- `make psalm`
- `make test`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Build command now detects and prevents duplicate output paths, providing clear error messages when multiple sources claim the same destination file.

* **Tests**
  * Added test coverage for duplicate output path detection in build operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->