### PR TITLE
Paginate taxonomy term pages

### DIFF
--- a/docs/commands.md
+++ b/docs/commands.md
@@ -54,7 +54,7 @@ The command:
 7. Generates Atom (`feed.xml`), RSS 2.0 (`rss.xml`), and JSON Feed (`feed.json`) feeds for each collection with `feed: true`, capped by collection `feed_limit` (`20` by default, `0` for unlimited).
 8. Generates paginated collection listing pages (e.g., `/blog/`, `/blog/page/2/`) for collections with `listing: true`.
 9. Generates `sitemap.xml` containing all entry URLs, standalone page URLs, collection listing URLs, and the home page.
-10. Generates taxonomy pages for each taxonomy defined in `config.yaml` (e.g., `/tags/`, `/tags/php/`, `/categories/`).
+10. Generates taxonomy pages for each taxonomy defined in `config.yaml` (e.g., `/tags/`, `/tags/php/`, `/tags/php/page/2/`, `/categories/`).
 
 With `--workers=N` (N > 1), entry rendering and writing is parallelized across N forked processes. With `--workers=auto`, YiiPress uses up to the detected worker count and lets page writers clamp back to sequential mode for smaller workloads. Feeds are generated after entry writing and can be split per collection across workers. Sitemap generation remains serial.
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -63,7 +63,7 @@ editor: code
 - **default_author** — author slug (referencing a file in `content/authors/`), used when entries have no explicit `authors` field
 - **author_pages** — set to `true` to generate `/authors/` and `/authors/:slug/` pages and link known entry authors to them (default: `false`)
 - **date_format** — PHP date format string for displaying dates in templates (e.g., `Y.m.d` for "2026.03.23", `F j, Y` for "March 23, 2026"). See [PHP date format](https://www.php.net/manual/en/datetime.format.php) for all available format characters
-- **entries_per_page** — default pagination size (overridden by collection `_collection.yaml`)
+- **entries_per_page** — default pagination size for taxonomy term pages and collection listings (overridden by collection `_collection.yaml` for collection listings)
 - **permalink** — default permalink pattern (overridden by collection or entry)
 - **taxonomies** — list of enabled taxonomy types
 - **theme** — default theme name for the site (see [Templates](templates.md))

--- a/docs/templates.md
+++ b/docs/templates.md
@@ -275,7 +275,8 @@ Example:
 | `$siteTitle`    | `string`                                                | Site title                  |
 | `$taxonomyName` | `string`                                                | Taxonomy name               |
 | `$term`         | `string`                                                | Term value                  |
-| `$entries`      | `list<array{title: string, url: string, date: string}>` | Entries with this term      |
+| `$entries`      | `list<array{title: string, url: string, date: string}>` | Entries on the current term page |
+| `$pagination`   | `array{currentPage: int, totalPages: int, previousUrl: string, nextUrl: string}` | Pagination data |
 | `$nav`          | `?Navigation`                                           | Navigation object or `null` |
 
 ### Author page template (`author.php`)

--- a/roadmap.md
+++ b/roadmap.md
@@ -32,6 +32,7 @@
 - [x] Cross-references / internal linking helpers (shorthand syntax to link between entries, prevents broken links on permalink changes)
 - [x] Markdown extensions configuration (enable/disable footnotes, definition lists, strikethrough, tables, etc.)
 - [x] KaTeX rendering assets for LaTeX math output
+- [x] Taxonomy term pagination
 
 ## Priority 2: Documentation
 

--- a/src/Build/TaxonomyPageWriter.php
+++ b/src/Build/TaxonomyPageWriter.php
@@ -11,6 +11,10 @@ use YiiPress\Content\Model\SiteConfig;
 use YiiPress\Content\PermalinkResolver;
 use RuntimeException;
 
+use function array_chunk;
+use function count;
+use function rtrim;
+
 final readonly class TaxonomyPageWriter
 {
     public function __construct(
@@ -44,8 +48,7 @@ final readonly class TaxonomyPageWriter
             $pageCount++;
 
             foreach ($terms as $term => $entries) {
-                $this->writeTermPage($renderer, $siteConfig, $taxonomyName, (string) $term, $entries, $collections, $outputDir, $navigation, $noWrite);
-                $pageCount++;
+                $pageCount += $this->writeTermPages($renderer, $siteConfig, $taxonomyName, (string) $term, $entries, $collections, $outputDir, $navigation, $noWrite);
             }
         }
 
@@ -94,7 +97,7 @@ final readonly class TaxonomyPageWriter
      * @param list<Entry> $entries
      * @param array<string, Collection> $collections
      */
-    private function writeTermPage(
+    private function writeTermPages(
         PageTemplateRenderer $renderer,
         SiteConfig $siteConfig,
         string $taxonomyName,
@@ -104,48 +107,89 @@ final readonly class TaxonomyPageWriter
         string $outputDir,
         ?Navigation $navigation,
         bool $noWrite,
-    ): void {
-        $rootPath = UrlResolver::rootPath('/' . $taxonomyName . '/' . $term . '/');
+    ): int {
+        $perPage = $siteConfig->entriesPerPage;
+        if ($perPage <= 0) {
+            $perPage = count($entries) ?: 1;
+        }
+
+        $pages = array_chunk($entries, $perPage);
+        $totalPages = count($pages);
+        $pageCount = 0;
         $uiViewData = UiViewData::forSite($siteConfig, $this->templateResolver, $siteConfig->theme);
         $taxonomyLabel = $uiViewData->ui->taxonomyLabel($taxonomyName);
 
-        $entryData = [];
-        foreach ($entries as $entry) {
-            $collection = $collections[$entry->collection] ?? null;
-            $url = $collection !== null
-                ? UrlResolver::sitePath(PermalinkResolver::resolve($entry, $collection, $siteConfig->i18n), $rootPath)
-                : '#';
+        foreach ($pages as $pageIndex => $pageEntries) {
+            $pageNumber = $pageIndex + 1;
+            $permalink = $this->termPagePermalink($taxonomyName, $term, $pageNumber);
+            $rootPath = UrlResolver::rootPath($permalink);
 
-            $entryData[] = [
-                'title' => $entry->title,
-                'url' => $url,
-                'date' => $entry->date?->format($siteConfig->dateFormat) ?? '',
-            ];
-        }
+            $entryData = [];
+            foreach ($pageEntries as $entry) {
+                $collection = $collections[$entry->collection] ?? null;
+                $url = $collection !== null
+                    ? UrlResolver::sitePath(PermalinkResolver::resolve($entry, $collection, $siteConfig->i18n), $rootPath)
+                    : '#';
 
-        $entries = $entryData;
-
-        $html = $renderer->render('taxonomy_term', [
-            'siteTitle' => $siteConfig->title,
-            'data' => $siteConfig->data,
-            'taxonomyName' => $taxonomyName,
-            'term' => $term,
-            'entries' => $entries,
-            'nav' => $navigation,
-            'rootPath' => $rootPath,
-            'language' => $siteConfig->defaultLanguage,
-            'metaTags' => MetaTagsBuilder::forPage($siteConfig, $term . ' — ' . $taxonomyLabel, $siteConfig->description, '/' . $taxonomyName . '/' . $term . '/'),
-            'search' => $siteConfig->search !== null,
-            'searchResults' => $siteConfig->search?->results ?? 10,
-        ] + $uiViewData->toArray(), $rootPath);
-
-        if (!$noWrite) {
-            $dir = $outputDir . '/' . $taxonomyName . '/' . $term;
-            if (!is_dir($dir) && !mkdir($dir, 0o755, true) && !is_dir($dir)) {
-                throw new RuntimeException(sprintf('Directory "%s" was not created', $dir));
+                $entryData[] = [
+                    'title' => $entry->title,
+                    'url' => $url,
+                    'date' => $entry->date?->format($siteConfig->dateFormat) ?? '',
+                ];
             }
 
-            FileWriter::write($dir . '/index.html', $html);
+            $pagination = [
+                'currentPage' => $pageNumber,
+                'totalPages' => $totalPages,
+                'previousUrl' => $this->resolveTermPageUrl($taxonomyName, $term, $pageNumber - 1, $totalPages, $rootPath),
+                'nextUrl' => $this->resolveTermPageUrl($taxonomyName, $term, $pageNumber + 1, $totalPages, $rootPath),
+            ];
+
+            $html = $renderer->render('taxonomy_term', [
+                'siteTitle' => $siteConfig->title,
+                'data' => $siteConfig->data,
+                'taxonomyName' => $taxonomyName,
+                'term' => $term,
+                'entries' => $entryData,
+                'pagination' => $pagination,
+                'nav' => $navigation,
+                'rootPath' => $rootPath,
+                'language' => $siteConfig->defaultLanguage,
+                'metaTags' => MetaTagsBuilder::forPage($siteConfig, $term . ' — ' . $taxonomyLabel, $siteConfig->description, $permalink),
+                'search' => $siteConfig->search !== null,
+                'searchResults' => $siteConfig->search?->results ?? 10,
+            ] + $uiViewData->toArray(), $rootPath);
+
+            if (!$noWrite) {
+                $dir = $outputDir . rtrim($permalink, '/');
+                if (!is_dir($dir) && !mkdir($dir, 0o755, true) && !is_dir($dir)) {
+                    throw new RuntimeException(sprintf('Directory "%s" was not created', $dir));
+                }
+
+                FileWriter::write($dir . '/index.html', $html);
+            }
+
+            $pageCount++;
         }
+
+        return $pageCount;
+    }
+
+    private function termPagePermalink(string $taxonomyName, string $term, int $pageNumber): string
+    {
+        if ($pageNumber === 1) {
+            return '/' . $taxonomyName . '/' . $term . '/';
+        }
+
+        return '/' . $taxonomyName . '/' . $term . '/page/' . $pageNumber . '/';
+    }
+
+    private function resolveTermPageUrl(string $taxonomyName, string $term, int $pageNumber, int $totalPages, string $rootPath): string
+    {
+        if ($pageNumber < 1 || $pageNumber > $totalPages) {
+            return '';
+        }
+
+        return UrlResolver::sitePath($this->termPagePermalink($taxonomyName, $term, $pageNumber), $rootPath);
     }
 }

--- a/src/Console/BuildCommand.php
+++ b/src/Console/BuildCommand.php
@@ -1377,8 +1377,16 @@ final class BuildCommand extends Command
                     continue;
                 }
                 $files[] = $outputDir . '/' . $taxonomyName . '/index.html';
-                foreach (array_keys($terms) as $term) {
+                foreach ($terms as $term => $termEntries) {
                     $files[] = $outputDir . '/' . $taxonomyName . '/' . $term . '/index.html';
+                    $perPage = $siteConfig->entriesPerPage;
+                    if ($perPage <= 0) {
+                        $perPage = count($termEntries) ?: 1;
+                    }
+                    $totalPages = $termEntries !== [] ? (int) ceil(count($termEntries) / $perPage) : 1;
+                    for ($p = 2; $p <= $totalPages; $p++) {
+                        $files[] = $outputDir . '/' . $taxonomyName . '/' . $term . '/page/' . $p . '/index.html';
+                    }
                 }
             }
         }

--- a/tests/Unit/Build/TaxonomyPageWriterTest.php
+++ b/tests/Unit/Build/TaxonomyPageWriterTest.php
@@ -1,0 +1,165 @@
+<?php
+
+declare(strict_types=1);
+
+namespace YiiPress\Tests\Unit\Build;
+
+use DateTimeImmutable;
+use FilesystemIterator;
+use PHPUnit\Framework\TestCase;
+use RecursiveDirectoryIterator;
+use RecursiveIteratorIterator;
+use SplFileInfo;
+use YiiPress\Build\TaxonomyPageWriter;
+use YiiPress\Build\TemplateResolver;
+use YiiPress\Build\Theme;
+use YiiPress\Build\ThemeRegistry;
+use YiiPress\Content\Model\Collection;
+use YiiPress\Content\Model\Entry;
+use YiiPress\Content\Model\SiteConfig;
+
+use function PHPUnit\Framework\assertFileExists;
+use function PHPUnit\Framework\assertSame;
+use function PHPUnit\Framework\assertStringContainsString;
+use function PHPUnit\Framework\assertStringNotContainsString;
+
+final class TaxonomyPageWriterTest extends TestCase
+{
+    private SiteConfig $siteConfig;
+    private string $outputDir;
+    private string $tempFile;
+
+    protected function setUp(): void
+    {
+        $this->siteConfig = new SiteConfig(
+            title: 'Test Site',
+            description: 'A test site',
+            baseUrl: 'https://test.example.com',
+            defaultLanguage: 'en',
+            charset: 'UTF-8',
+            defaultAuthor: 'john-doe',
+            dateFormat: 'F j, Y',
+            entriesPerPage: 2,
+            permalink: '/:collection/:slug/',
+            taxonomies: ['tags'],
+            params: [],
+        );
+
+        $this->outputDir = sys_get_temp_dir() . '/yiipress-taxonomy-page-test-' . uniqid();
+        mkdir($this->outputDir, 0o755, true);
+
+        $this->tempFile = sys_get_temp_dir() . '/yiipress-taxonomy-page-body-' . uniqid() . '.md';
+        file_put_contents($this->tempFile, "Body.\n");
+    }
+
+    protected function tearDown(): void
+    {
+        if (is_file($this->tempFile)) {
+            unlink($this->tempFile);
+        }
+
+        if (!is_dir($this->outputDir)) {
+            return;
+        }
+
+        $iterator = new RecursiveIteratorIterator(
+            new RecursiveDirectoryIterator($this->outputDir, FilesystemIterator::SKIP_DOTS),
+            RecursiveIteratorIterator::CHILD_FIRST,
+        );
+        foreach ($iterator as $item) {
+            /** @var SplFileInfo $item */
+            if ($item->isDir()) {
+                rmdir($item->getPathname());
+            } else {
+                unlink($item->getPathname());
+            }
+        }
+        rmdir($this->outputDir);
+    }
+
+    public function testWritesPaginatedTaxonomyTermPages(): void
+    {
+        $entries = [
+            $this->createEntry('post-1', 'Post 1', '2024-03-01'),
+            $this->createEntry('post-2', 'Post 2', '2024-03-02'),
+            $this->createEntry('post-3', 'Post 3', '2024-03-03'),
+        ];
+        $collections = ['blog' => $this->createCollection()];
+
+        $writer = new TaxonomyPageWriter($this->createTemplateResolver());
+        $pageCount = $writer->write(
+            $this->siteConfig,
+            ['tags' => ['php' => $entries]],
+            $collections,
+            $this->outputDir,
+        );
+
+        assertSame(3, $pageCount);
+        assertFileExists($this->outputDir . '/tags/index.html');
+        assertFileExists($this->outputDir . '/tags/php/index.html');
+        assertFileExists($this->outputDir . '/tags/php/page/2/index.html');
+
+        $page1 = file_get_contents($this->outputDir . '/tags/php/index.html');
+        assertStringContainsString('Post 1', $page1);
+        assertStringContainsString('Post 2', $page1);
+        assertStringNotContainsString('Post 3', $page1);
+        assertStringContainsString('Page 1 of 2', $page1);
+        assertStringContainsString('rel="next"', $page1);
+        assertStringNotContainsString('rel="prev"', $page1);
+
+        $page2 = file_get_contents($this->outputDir . '/tags/php/page/2/index.html');
+        assertStringContainsString('<title>php — Tags — Page 2 — Test Site</title>', $page2);
+        assertStringContainsString('Post 3', $page2);
+        assertStringContainsString('Page 2 of 2', $page2);
+        assertStringContainsString('rel="prev"', $page2);
+        assertStringNotContainsString('rel="next"', $page2);
+    }
+
+    private function createTemplateResolver(): TemplateResolver
+    {
+        $registry = new ThemeRegistry();
+        $registry->register(new Theme('minimal', dirname(__DIR__, 3) . '/themes/minimal'));
+
+        return new TemplateResolver($registry);
+    }
+
+    private function createCollection(): Collection
+    {
+        return new Collection(
+            name: 'blog',
+            title: 'Blog',
+            description: 'Latest posts',
+            permalink: '/blog/:slug/',
+            sortBy: 'date',
+            sortOrder: 'desc',
+            entriesPerPage: 10,
+            feed: true,
+            listing: true,
+        );
+    }
+
+    private function createEntry(string $slug, string $title, string $date): Entry
+    {
+        return new Entry(
+            filePath: $this->tempFile,
+            collection: 'blog',
+            slug: $slug,
+            title: $title,
+            date: new DateTimeImmutable($date),
+            draft: false,
+            tags: ['php'],
+            categories: [],
+            authors: [],
+            summary: '',
+            permalink: '',
+            layout: '',
+            theme: '',
+            weight: 0,
+            language: '',
+            redirectTo: '',
+            extra: [],
+            bodyOffset: 0,
+            bodyLength: (int) filesize($this->tempFile),
+        );
+    }
+}

--- a/tests/Unit/Console/BuildCommandTest.php
+++ b/tests/Unit/Console/BuildCommandTest.php
@@ -1086,6 +1086,38 @@ PHP,
         assertFalse(is_dir($this->outputDir));
     }
 
+    public function testDryRunListsPaginatedTaxonomyFiles(): void
+    {
+        $tempDir = sys_get_temp_dir() . '/yiipress-dry-run-taxonomy-test-' . uniqid();
+        $contentDir = $tempDir . '/content';
+        $outputDir = $tempDir . '/output';
+        mkdir($contentDir . '/blog', 0o755, true);
+        $this->tempContentDirs[] = $tempDir;
+
+        file_put_contents($contentDir . '/config.yaml', "title: Taxonomy Site\nlanguages: [en]\nentries_per_page: 2\ntaxonomies: [tags]\n");
+        file_put_contents($contentDir . '/blog/_collection.yaml', "title: Blog\npermalink: /blog/:slug/\n");
+        file_put_contents($contentDir . '/blog/first.md', "---\ntitle: First\ntags: [php]\n---\n\nFirst.\n");
+        file_put_contents($contentDir . '/blog/second.md', "---\ntitle: Second\ntags: [php]\n---\n\nSecond.\n");
+        file_put_contents($contentDir . '/blog/third.md', "---\ntitle: Third\ntags: [php]\n---\n\nThird.\n");
+
+        $yii = dirname(__DIR__, 3) . '/yii';
+        exec(
+            $yii . ' build'
+            . ' --content-dir=' . escapeshellarg($contentDir)
+            . ' --output-dir=' . escapeshellarg($outputDir)
+            . ' --dry-run'
+            . ' 2>&1',
+            $output,
+            $exitCode,
+        );
+        $outputText = implode("\n", $output);
+
+        assertSame(0, $exitCode, "Dry run failed: $outputText");
+        assertStringContainsString('/tags/php/index.html', $outputText);
+        assertStringContainsString('/tags/php/page/2/index.html', $outputText);
+        assertFalse(is_dir($outputDir));
+    }
+
     public function testIncrementalBuildSkipsUnchangedEntries(): void
     {
         $yii = dirname(__DIR__, 3) . '/yii';

--- a/themes/minimal/taxonomy_term.php
+++ b/themes/minimal/taxonomy_term.php
@@ -7,6 +7,7 @@ declare(strict_types=1);
  * @var string $taxonomyName
  * @var string $term
  * @var list<array{title: string, url: string, date: string}> $entries
+ * @var array{currentPage: int, totalPages: int, previousUrl: string, nextUrl: string} $pagination
  * @var ?Navigation $nav
  * @var Closure(string, array): string $partial
  * @var string $language
@@ -19,6 +20,7 @@ declare(strict_types=1);
  * @var array<string, array<string, string>> $uiCatalogs
  * @var YiiPress\I18n\UiText $ui
  * @var Closure(string, int, ?string, bool): string $h
+ * @var Closure(string, array): string $t
  */
 
 use YiiPress\Content\Model\Navigation;
@@ -26,11 +28,14 @@ $language ??= 'en';
 $uiLanguage ??= 'en';
 $taxonomyLabel = $ui->taxonomyLabel($taxonomyName);
 $taxonomyKey = 'taxonomy.' . strtolower($taxonomyName);
+$pageTitle = $term . ' — ' . $taxonomyLabel
+    . ($pagination['currentPage'] > 1 ? ' — ' . $t('page_number', ['page' => $pagination['currentPage']]) : '')
+    . ' — ' . $siteTitle;
 ?>
 <!DOCTYPE html>
 <html lang="<?= $h($language) ?>">
 <head>
-<?= $partial('head', ['title' => $term . ' — ' . $taxonomyLabel . ' — ' . $siteTitle, 'rootPath' => $rootPath, 'metaTags' => $metaTags, 'search' => $search ?? false, 'searchResults' => $searchResults ?? 10, 'ui' => $ui, 'uiLanguage' => $uiLanguage, 'uiLanguages' => $uiLanguages ?? [$uiLanguage], 'uiCatalogs' => $uiCatalogs ?? [$uiLanguage => []]]) ?>
+<?= $partial('head', ['title' => $pageTitle, 'rootPath' => $rootPath, 'metaTags' => $metaTags, 'search' => $search ?? false, 'searchResults' => $searchResults ?? 10, 'ui' => $ui, 'uiLanguage' => $uiLanguage, 'uiLanguages' => $uiLanguages ?? [$uiLanguage], 'uiCatalogs' => $uiCatalogs ?? [$uiLanguage => []]]) ?>
 </head>
 <body>
 <?= $partial('header', ['siteTitle' => $siteTitle, 'nav' => $nav, 'rootPath' => $rootPath, 'search' => $search ?? false, 'searchResults' => $searchResults ?? 10, 'ui' => $ui, 'uiLanguage' => $uiLanguage, 'uiLanguages' => $uiLanguages ?? [$uiLanguage]]) ?>
@@ -47,6 +52,17 @@ $taxonomyKey = 'taxonomy.' . strtolower($taxonomyName);
             </li>
 <?php endforeach; ?>
         </ul>
+<?php if ($pagination['totalPages'] > 1): ?>
+        <nav class="pagination">
+<?php if ($pagination['previousUrl'] !== ''): ?>
+            <a href="<?= $h($pagination['previousUrl']) ?>" rel="prev">&larr; <span data-ui-key="previous"><?= $h($t('previous')) ?></span></a>
+<?php endif; ?>
+            <span data-ui-key="page_of" data-ui-params="<?= $h((string) json_encode(['current' => $pagination['currentPage'], 'total' => $pagination['totalPages']], JSON_THROW_ON_ERROR), ENT_QUOTES | ENT_SUBSTITUTE, 'UTF-8') ?>"><?= $h($t('page_of', ['current' => $pagination['currentPage'], 'total' => $pagination['totalPages']])) ?></span>
+<?php if ($pagination['nextUrl'] !== ''): ?>
+            <a href="<?= $h($pagination['nextUrl']) ?>" rel="next"><span data-ui-key="next"><?= $h($t('next')) ?></span> &rarr;</a>
+<?php endif; ?>
+        </nav>
+<?php endif; ?>
     </div>
 </main>
 <?= $partial('footer', ['nav' => $nav, 'rootPath' => $rootPath, 'ui' => $ui, 'uiLanguage' => $uiLanguage]) ?>


### PR DESCRIPTION
## Summary
- paginate taxonomy term pages using the site `entries_per_page` setting
- add previous/next pagination controls and page-number titles to the minimal taxonomy term template
- include paginated taxonomy files in dry-run output and document the template/config changes

## Tests
- `make test -- --filter TaxonomyPageWriterTest`
- `make test -- --filter testDryRunListsPaginatedTaxonomyFiles`
- `make test`
- `make psalm`