### PR TITLE
Add site-wide RSS and Atom feeds

### DIFF
--- a/docs/commands.md
+++ b/docs/commands.md
@@ -51,7 +51,7 @@ The command:
 4. Renders collection entries — converts markdown to HTML via `ext-mdparser`, applies the entry template, writes each entry as `index.html` at its resolved permalink path. Drafts and future-dated entries are excluded by default.
 5. Renders standalone pages — markdown files in the content root directory (e.g., `contact.md` → `/contact/`).
 6. Copies content assets (images, SVGs, etc.) to the output directory.
-7. Generates Atom (`feed.xml`), RSS 2.0 (`rss.xml`), and JSON Feed (`feed.json`) feeds for each collection with `feed: true`, capped by collection `feed_limit` (`20` by default, `0` for unlimited).
+7. Generates site-wide Atom (`/feed.xml`), RSS 2.0 (`/rss.xml`), and JSON Feed (`/feed.json`) feeds, plus Atom (`feed.xml`), RSS 2.0 (`rss.xml`), and JSON Feed (`feed.json`) feeds for each collection with `feed: true`, capped by collection `feed_limit` (`20` by default, `0` for unlimited).
 8. Generates paginated collection listing pages (e.g., `/blog/`, `/blog/page/2/`) for collections with `listing: true`.
 9. Generates `sitemap.xml` containing all entry URLs, standalone page URLs, collection listing URLs, and the home page.
 10. Generates taxonomy pages for each taxonomy defined in `config.yaml` (e.g., `/tags/`, `/tags/php/`, `/tags/php/page/2/`, `/categories/`).

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -327,7 +327,7 @@ Collection `_collection.yaml` fields override content config defaults:
 
 - Collection `entries_per_page` overrides `config.yaml` `entries_per_page`
 - Collection `permalink` overrides `config.yaml` `permalink`
-- Collection `feed_limit` controls how many entries are rendered into that collection's RSS, Atom, and JSON Feed files (`20` by default, `0` for unlimited)
+- Collection `feed_limit` controls how many entries are rendered into that collection's RSS, Atom, and JSON Feed files (`20` by default, `0` for unlimited). Site-wide `/feed.xml`, `/rss.xml`, and `/feed.json` include entries from all feed-enabled collections and use the default limit.
 - Entry `permalink` overrides collection permalink
 
 Resolution order: entry → collection → content config → engine defaults.

--- a/docs/content.md
+++ b/docs/content.md
@@ -78,8 +78,8 @@ feed_limit: 20
 - **sort_by** — field to sort entries by: `date` (default), `weight`, `title`
 - **sort_order** — `desc` (default) or `asc`
 - **entries_per_page** — number of entries per page, `0` for no pagination
-- **feed** — `true` to generate RSS, Atom, and JSON Feed files for this collection
-- **feed_limit** — maximum entries rendered into each feed (default: `20`, `0` for unlimited)
+- **feed** — `true` to generate RSS, Atom, and JSON Feed files for this collection and include its entries in site-wide `/feed.xml`, `/rss.xml`, and `/feed.json`
+- **feed_limit** — maximum entries rendered into each collection feed (default: `20`, `0` for unlimited); site-wide feeds use the default limit
 - **listing** — `true` to generate a collection index page (default: `true`)
 - **navigation_pager** — `true` to render previous/next page links from the configured sidebar navigation (default: `false`)
 

--- a/roadmap.md
+++ b/roadmap.md
@@ -13,7 +13,7 @@
 
 ## Priority 1: Essential blog features
 
-- [x] RSS/Atom/JSON Feed generation. Content should be generated using same plugins as for HTML content
+- [x] Collection and site-wide RSS/Atom/JSON Feed generation. Content should be generated using same plugins as for HTML content
 - [x] Sitemap generation
 - [x] Tags and categories (taxonomies)
 - [x] Draft support (front matter `draft: true` flag, exclude from build by default)

--- a/src/Build/FeedGenerator.php
+++ b/src/Build/FeedGenerator.php
@@ -60,6 +60,55 @@ final class FeedGenerator
     }
 
     /**
+     * @param array<string, Collection> $collections
+     * @param list<Entry> $entries
+     */
+    public function generateSiteAtom(
+        SiteConfig $siteConfig,
+        array $collections,
+        array $entries,
+    ): string {
+        $xml = $this->createInMemoryWriter();
+        $collection = $this->siteFeedCollection($siteConfig);
+        $this->writeAtomDocument($xml, $siteConfig, $collection, $this->limitEntries($collection, $entries), $collections);
+
+        return $xml->outputMemory();
+    }
+
+    /**
+     * @param array<string, Collection> $collections
+     * @param list<Entry> $entries
+     */
+    public function generateSiteRss(
+        SiteConfig $siteConfig,
+        array $collections,
+        array $entries,
+    ): string {
+        $xml = $this->createInMemoryWriter();
+        $collection = $this->siteFeedCollection($siteConfig);
+        $this->writeRssDocument($xml, $siteConfig, $collection, $this->limitEntries($collection, $entries), $collections);
+
+        return $xml->outputMemory();
+    }
+
+    /**
+     * @param array<string, Collection> $collections
+     * @param list<Entry> $entries
+     */
+    public function generateSiteJson(
+        SiteConfig $siteConfig,
+        array $collections,
+        array $entries,
+    ): string {
+        $collection = $this->siteFeedCollection($siteConfig);
+
+        return json_encode(
+            $this->jsonDocument($siteConfig, $collection, $this->limitEntries($collection, $entries), $collections),
+            JSON_THROW_ON_ERROR | JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE,
+        );
+    }
+
+    /**
      * @param list<Entry> $entries
      */
     public function generateJson(
@@ -110,20 +159,61 @@ final class FeedGenerator
     }
 
     /**
+     * @param array<string, Collection> $collections
      * @param list<Entry> $entries
+     */
+    public function writeSiteAtomFile(
+        string $path,
+        SiteConfig $siteConfig,
+        array $collections,
+        array $entries,
+    ): void {
+        FileWriter::write($path, $this->generateSiteAtom($siteConfig, $collections, $entries));
+    }
+
+    /**
+     * @param array<string, Collection> $collections
+     * @param list<Entry> $entries
+     */
+    public function writeSiteRssFile(
+        string $path,
+        SiteConfig $siteConfig,
+        array $collections,
+        array $entries,
+    ): void {
+        FileWriter::write($path, $this->generateSiteRss($siteConfig, $collections, $entries));
+    }
+
+    /**
+     * @param array<string, Collection> $collections
+     * @param list<Entry> $entries
+     */
+    public function writeSiteJsonFile(
+        string $path,
+        SiteConfig $siteConfig,
+        array $collections,
+        array $entries,
+    ): void {
+        file_put_contents($path, $this->generateSiteJson($siteConfig, $collections, $entries));
+    }
+
+    /**
+     * @param list<Entry> $entries
+     * @param array<string, Collection>|null $entryCollections
      */
     private function writeAtomDocument(
         XMLWriter $xml,
         SiteConfig $siteConfig,
         Collection $collection,
         array $entries,
+        ?array $entryCollections = null,
     ): void {
         $xml->startDocument('1.0', 'UTF-8');
         $xml->startElement('feed');
         $xml->writeAttribute('xmlns', 'http://www.w3.org/2005/Atom');
 
-        $feedUrl = rtrim($siteConfig->baseUrl, '/') . '/' . $collection->name . '/feed.xml';
-        $collectionUrl = rtrim($siteConfig->baseUrl, '/') . '/' . $collection->name . '/';
+        $feedUrl = rtrim($siteConfig->baseUrl, '/') . $this->feedPath($collection, 'feed.xml');
+        $collectionUrl = rtrim($siteConfig->baseUrl, '/') . $this->collectionPath($collection);
 
         $xml->writeElement('title', $collection->title);
         if ($collection->description !== '') {
@@ -155,7 +245,7 @@ final class FeedGenerator
         }
 
         foreach ($entries as $entry) {
-            $this->writeAtomEntry($xml, $siteConfig, $collection, $entry);
+            $this->writeAtomEntry($xml, $siteConfig, $entryCollections[$entry->collection] ?? $collection, $entry);
         }
 
         $xml->endElement();
@@ -164,12 +254,14 @@ final class FeedGenerator
 
     /**
      * @param list<Entry> $entries
+     * @param array<string, Collection>|null $entryCollections
      */
     private function writeRssDocument(
         XMLWriter $xml,
         SiteConfig $siteConfig,
         Collection $collection,
         array $entries,
+        ?array $entryCollections = null,
     ): void {
         $xml->startDocument('1.0', 'UTF-8');
         $xml->startElement('rss');
@@ -177,8 +269,8 @@ final class FeedGenerator
         $xml->writeAttribute('xmlns:atom', 'http://www.w3.org/2005/Atom');
         $xml->writeAttribute('xmlns:content', 'http://purl.org/rss/1.0/modules/content/');
 
-        $feedUrl = rtrim($siteConfig->baseUrl, '/') . '/' . $collection->name . '/rss.xml';
-        $collectionUrl = rtrim($siteConfig->baseUrl, '/') . '/' . $collection->name . '/';
+        $feedUrl = rtrim($siteConfig->baseUrl, '/') . $this->feedPath($collection, 'rss.xml');
+        $collectionUrl = rtrim($siteConfig->baseUrl, '/') . $this->collectionPath($collection);
 
         $xml->startElement('channel');
         $xml->writeElement('title', $collection->title);
@@ -201,7 +293,7 @@ final class FeedGenerator
         }
 
         foreach ($entries as $entry) {
-            $this->writeRssItem($xml, $siteConfig, $collection, $entry);
+            $this->writeRssItem($xml, $siteConfig, $entryCollections[$entry->collection] ?? $collection, $entry);
         }
 
         $xml->endElement();
@@ -286,18 +378,24 @@ final class FeedGenerator
 
     /**
      * @param list<Entry> $entries
+     * @param array<string, Collection>|null $entryCollections
      * @return array<string, mixed>
      */
-    private function jsonDocument(SiteConfig $siteConfig, Collection $collection, array $entries): array
+    private function jsonDocument(
+        SiteConfig $siteConfig,
+        Collection $collection,
+        array $entries,
+        ?array $entryCollections = null,
+    ): array
     {
-        $collectionUrl = rtrim($siteConfig->baseUrl, '/') . '/' . $collection->name . '/';
+        $collectionUrl = rtrim($siteConfig->baseUrl, '/') . $this->collectionPath($collection);
         $document = [
             'version' => 'https://jsonfeed.org/version/1.1',
             'title' => $collection->title,
             'home_page_url' => $collectionUrl,
-            'feed_url' => rtrim($siteConfig->baseUrl, '/') . '/' . $collection->name . '/feed.json',
+            'feed_url' => rtrim($siteConfig->baseUrl, '/') . $this->feedPath($collection, 'feed.json'),
             'items' => array_map(
-                fn (Entry $entry): array => $this->jsonItem($siteConfig, $collection, $entry),
+                fn (Entry $entry): array => $this->jsonItem($siteConfig, $entryCollections[$entry->collection] ?? $collection, $entry),
                 $entries,
             ),
         ];
@@ -358,6 +456,31 @@ final class FeedGenerator
     private function resolveEntryUrl(SiteConfig $siteConfig, Collection $collection, Entry $entry): string
     {
         return rtrim($siteConfig->baseUrl, '/') . PermalinkResolver::resolve($entry, $collection, $siteConfig->i18n);
+    }
+
+    private function collectionPath(Collection $collection): string
+    {
+        return $collection->name === '' ? '/' : '/' . $collection->name . '/';
+    }
+
+    private function feedPath(Collection $collection, string $feedFile): string
+    {
+        return $collection->name === '' ? '/' . $feedFile : '/' . $collection->name . '/' . $feedFile;
+    }
+
+    private function siteFeedCollection(SiteConfig $siteConfig): Collection
+    {
+        return new Collection(
+            name: '',
+            title: $siteConfig->title,
+            description: $siteConfig->description,
+            permalink: $siteConfig->permalink,
+            sortBy: 'date',
+            sortOrder: 'desc',
+            entriesPerPage: $siteConfig->entriesPerPage,
+            feed: true,
+            listing: false,
+        );
     }
 
     /**

--- a/src/Console/BuildCommand.php
+++ b/src/Console/BuildCommand.php
@@ -101,6 +101,7 @@ use function strtolower;
 use function substr;
 use function strlen;
 use function trim;
+use function usort;
 use function yaml_parse;
 
 #[AsCommand(
@@ -848,16 +849,19 @@ final class BuildCommand extends Command
         /** @var list<array{collectionName: string, collection: Collection, entries: list<Entry>}> $feedTasks */
         $profile->switchTo('write feeds');
         $feedTasks = [];
+        $siteFeedEntries = [];
         foreach ($collections as $collectionName => $collection) {
             if (!$collection->feed) {
                 continue;
             }
 
+            $collectionEntries = $entriesByCollection[$collectionName] ?? [];
             $feedTasks[] = [
                 'collectionName' => $collectionName,
                 'collection' => $collection,
-                'entries' => $entriesByCollection[$collectionName] ?? [],
+                'entries' => $collectionEntries,
             ];
+            array_push($siteFeedEntries, ...$collectionEntries);
         }
 
         $feedCount = (new ParallelTaskRunner())->run(
@@ -905,6 +909,26 @@ final class BuildCommand extends Command
             },
             minTasksPerWorker: 1,
         );
+
+        if ($feedTasks !== []) {
+            usort(
+                $siteFeedEntries,
+                static fn (Entry $a, Entry $b): int => ($b->date?->getTimestamp() ?? -PHP_INT_MAX)
+                    <=> ($a->date?->getTimestamp() ?? -PHP_INT_MAX),
+            );
+
+            $feedGenerator = new FeedGenerator($this->feedPipeline, $authors);
+            if ($noWrite) {
+                $feedGenerator->generateSiteAtom($siteConfig, $collections, $siteFeedEntries);
+                $feedGenerator->generateSiteRss($siteConfig, $collections, $siteFeedEntries);
+                $feedGenerator->generateSiteJson($siteConfig, $collections, $siteFeedEntries);
+            } else {
+                $feedGenerator->writeSiteAtomFile($outputDir . '/feed.xml', $siteConfig, $collections, $siteFeedEntries);
+                $feedGenerator->writeSiteRssFile($outputDir . '/rss.xml', $siteConfig, $collections, $siteFeedEntries);
+                $feedGenerator->writeSiteJsonFile($outputDir . '/feed.json', $siteConfig, $collections, $siteFeedEntries);
+            }
+            $feedCount++;
+        }
 
         if ($feedCount > 0) {
             $output->writeln("  Feeds generated: <comment>$feedCount</comment> (Atom + RSS + JSON)");
@@ -1278,6 +1302,7 @@ final class BuildCommand extends Command
         $output->writeln('<info>Dry run — files that would be generated:</info>');
         $now = new DateTimeImmutable();
         $files = [];
+        $hasFeeds = false;
 
         foreach ($collections as $collectionName => $collection) {
             $entries = [];
@@ -1302,6 +1327,7 @@ final class BuildCommand extends Command
             }
 
             if ($collection->feed) {
+                $hasFeeds = true;
                 $files[] = $outputDir . '/' . $collectionName . '/feed.xml';
                 $files[] = $outputDir . '/' . $collectionName . '/rss.xml';
                 $files[] = $outputDir . '/' . $collectionName . '/feed.json';
@@ -1338,6 +1364,11 @@ final class BuildCommand extends Command
                     $files[] = $outputDir . '/' . $collectionName . '/' . $yearMonth . '/index.html';
                 }
             }
+        }
+        if ($hasFeeds) {
+            $files[] = $outputDir . '/feed.xml';
+            $files[] = $outputDir . '/rss.xml';
+            $files[] = $outputDir . '/feed.json';
         }
 
         foreach ($parser->parseStandalonePages($contentDir) as $page) {

--- a/tests/Unit/Build/FeedGeneratorTest.php
+++ b/tests/Unit/Build/FeedGeneratorTest.php
@@ -322,6 +322,154 @@ final class FeedGeneratorTest extends TestCase
         $this->assertSame(1, $processor->calls);
     }
 
+    public function testSiteFeedsUseSiteMetadataAndEntryCollections(): void
+    {
+        $news = new Collection(
+            name: 'news',
+            title: 'News',
+            description: 'News posts',
+            permalink: '/news/:slug/',
+            sortBy: 'date',
+            sortOrder: 'desc',
+            entriesPerPage: 10,
+            feed: true,
+            listing: true,
+        );
+        $entries = $this->createEntries();
+        $bodyLength = (int) filesize($this->tempFile);
+        $entries[] = new Entry(
+            filePath: $this->tempFile,
+            collection: 'news',
+            slug: 'release',
+            title: 'Release',
+            date: new DateTimeImmutable('2024-04-01'),
+            draft: false,
+            tags: [],
+            categories: [],
+            authors: [],
+            summary: 'Release summary.',
+            permalink: '',
+            layout: '',
+            theme: '',
+            weight: 0,
+            language: 'en',
+            redirectTo: '',
+            extra: [],
+            bodyOffset: 0,
+            bodyLength: $bodyLength,
+        );
+
+        $generator = new FeedGenerator(new ContentProcessorPipeline(new MarkdownProcessor(new MarkdownRenderer())));
+        $collections = ['blog' => $this->collection, 'news' => $news];
+
+        $atom = $generator->generateSiteAtom($this->siteConfig, $collections, $entries);
+        $rss = $generator->generateSiteRss($this->siteConfig, $collections, $entries);
+        $json = $generator->generateSiteJson($this->siteConfig, $collections, $entries);
+        $feed = json_decode($json, true, 512, JSON_THROW_ON_ERROR);
+
+        assertStringContainsString('<title>Test Site</title>', $atom);
+        assertStringContainsString('<link href="https://test.example.com/"/>', $atom);
+        assertStringContainsString('<link href="https://test.example.com/feed.xml" rel="self" type="application/atom+xml"/>', $atom);
+        assertStringContainsString('<link href="https://test.example.com/blog/first-post/"/>', $atom);
+        assertStringContainsString('<link href="https://test.example.com/news/release/"/>', $atom);
+
+        assertStringContainsString('<title>Test Site</title>', $rss);
+        assertStringContainsString('<link>https://test.example.com/</link>', $rss);
+        assertStringContainsString('<atom:link href="https://test.example.com/rss.xml" rel="self" type="application/rss+xml"/>', $rss);
+        assertStringContainsString('<link>https://test.example.com/news/release/</link>', $rss);
+
+        $this->assertSame('Test Site', $feed['title']);
+        $this->assertSame('https://test.example.com/', $feed['home_page_url']);
+        $this->assertSame('https://test.example.com/feed.json', $feed['feed_url']);
+        $this->assertSame('https://test.example.com/blog/first-post/', $feed['items'][0]['url']);
+        $this->assertSame('https://test.example.com/news/release/', $feed['items'][2]['url']);
+    }
+
+    public function testSiteFeedFilesCanBeWrittenDirectly(): void
+    {
+        $news = new Collection(
+            name: 'news',
+            title: 'News',
+            description: 'News posts',
+            permalink: '/news/:slug/',
+            sortBy: 'date',
+            sortOrder: 'desc',
+            entriesPerPage: 10,
+            feed: true,
+            listing: true,
+        );
+        $entries = $this->createEntries();
+        $bodyLength = (int) filesize($this->tempFile);
+        $entries[] = new Entry(
+            filePath: $this->tempFile,
+            collection: 'news',
+            slug: 'release',
+            title: 'Release',
+            date: new DateTimeImmutable('2024-04-01'),
+            draft: false,
+            tags: [],
+            categories: [],
+            authors: [],
+            summary: 'Release summary.',
+            permalink: '',
+            layout: '',
+            theme: '',
+            weight: 0,
+            language: 'en',
+            redirectTo: '',
+            extra: [],
+            bodyOffset: 0,
+            bodyLength: $bodyLength,
+        );
+
+        $generator = new FeedGenerator(new ContentProcessorPipeline(new MarkdownProcessor(new MarkdownRenderer())));
+        $collections = ['blog' => $this->collection, 'news' => $news];
+        $atomPath = sys_get_temp_dir() . '/yiipress-site-feed-atom-' . uniqid() . '.xml';
+        $rssPath = sys_get_temp_dir() . '/yiipress-site-feed-rss-' . uniqid() . '.xml';
+        $jsonPath = sys_get_temp_dir() . '/yiipress-site-feed-json-' . uniqid() . '.json';
+
+        try {
+            $generator->writeSiteAtomFile($atomPath, $this->siteConfig, $collections, $entries);
+            $generator->writeSiteRssFile($rssPath, $this->siteConfig, $collections, $entries);
+            $generator->writeSiteJsonFile($jsonPath, $this->siteConfig, $collections, $entries);
+
+            assertFileExists($atomPath);
+            assertFileExists($rssPath);
+            assertFileExists($jsonPath);
+
+            $atom = (string) file_get_contents($atomPath);
+            assertStringContainsString('<title>Test Site</title>', $atom);
+            assertStringContainsString('<link href="https://test.example.com/"/>', $atom);
+            assertStringContainsString('<link href="https://test.example.com/feed.xml" rel="self" type="application/atom+xml"/>', $atom);
+            assertStringContainsString('<link href="https://test.example.com/blog/first-post/"/>', $atom);
+            assertStringContainsString('<link href="https://test.example.com/news/release/"/>', $atom);
+
+            $rss = (string) file_get_contents($rssPath);
+            assertStringContainsString('<title>Test Site</title>', $rss);
+            assertStringContainsString('<link>https://test.example.com/</link>', $rss);
+            assertStringContainsString('<atom:link href="https://test.example.com/rss.xml" rel="self" type="application/rss+xml"/>', $rss);
+            assertStringContainsString('<link>https://test.example.com/news/release/</link>', $rss);
+
+            $feed = json_decode((string) file_get_contents($jsonPath), true, 512, JSON_THROW_ON_ERROR);
+            $this->assertSame('Test Site', $feed['title']);
+            $this->assertSame('https://test.example.com/', $feed['home_page_url']);
+            $this->assertSame('https://test.example.com/feed.json', $feed['feed_url']);
+            $this->assertSame('https://test.example.com/news/release/', $feed['items'][2]['url']);
+        } finally {
+            if (is_file($atomPath)) {
+                unlink($atomPath);
+            }
+
+            if (is_file($rssPath)) {
+                unlink($rssPath);
+            }
+
+            if (is_file($jsonPath)) {
+                unlink($jsonPath);
+            }
+        }
+    }
+
     public function testInlineTagLinksUseAbsolutePublicRootInFeedContent(): void
     {
         $siteConfig = new SiteConfig(

--- a/tests/Unit/Console/BuildCommandTest.php
+++ b/tests/Unit/Console/BuildCommandTest.php
@@ -527,6 +527,28 @@ PHP,
         assertSame('https://jsonfeed.org/version/1.1', $feed['version']);
         assertStringContainsString('"title":"Test Post"', $json);
         assertStringContainsString('This is the body of the test post.', $json);
+
+        $siteAtomFile = $this->outputDir . '/feed.xml';
+        assertFileExists($siteAtomFile);
+        $siteAtom = file_get_contents($siteAtomFile);
+        assertStringContainsString('<title>Test Site</title>', $siteAtom);
+        assertStringContainsString('<link href="https://test.example.com/feed.xml" rel="self" type="application/atom+xml"/>', $siteAtom);
+        assertStringContainsString('<title>Test Post</title>', $siteAtom);
+
+        $siteRssFile = $this->outputDir . '/rss.xml';
+        assertFileExists($siteRssFile);
+        $siteRss = file_get_contents($siteRssFile);
+        assertStringContainsString('<title>Test Site</title>', $siteRss);
+        assertStringContainsString('<atom:link href="https://test.example.com/rss.xml" rel="self" type="application/rss+xml"/>', $siteRss);
+        assertStringContainsString('<title>Test Post</title>', $siteRss);
+
+        $siteJsonFile = $this->outputDir . '/feed.json';
+        assertFileExists($siteJsonFile);
+        $siteJson = (string) file_get_contents($siteJsonFile);
+        $siteFeed = json_decode($siteJson, true, 512, JSON_THROW_ON_ERROR);
+        assertSame('Test Site', $siteFeed['title']);
+        assertSame('https://test.example.com/feed.json', $siteFeed['feed_url']);
+        assertStringContainsString('"title":"Test Post"', $siteJson);
     }
 
     public function testFeedEntriesAreSortedChronologically(): void
@@ -1112,6 +1134,9 @@ PHP,
         assertSame(0, $exitCode, "Dry run failed: $outputText");
         assertStringContainsString('Dry run', $outputText);
         assertStringContainsString('index.html', $outputText);
+        assertStringContainsString('/feed.xml', $outputText);
+        assertStringContainsString('/rss.xml', $outputText);
+        assertStringContainsString('/feed.json', $outputText);
         assertStringContainsString('sitemap.xml', $outputText);
         assertStringContainsString('Total:', $outputText);
         assertFalse(is_dir($this->outputDir));


### PR DESCRIPTION
## Summary
- generate root `/feed.xml` and `/rss.xml` from all feed-enabled collections
- resolve site-feed entry URLs through each entry collection and list root feed files in dry-run output
- document site-wide feeds and update the roadmap feed item

## Tests
- `make test -- --filter FeedGeneratorTest`
- `make test -- --filter testBuildGeneratesFeedsForCollectionsWithFeedEnabled`
- `make test -- --filter testDryRunListsFilesWithoutWriting`
- `make psalm`
- `make test`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added site-wide Atom (`/feed.xml`), RSS 2.0 (`/rss.xml`), and JSON Feed (`/feed.json`) that aggregate entries from all feed-enabled collections.
  * Site-wide feed generation respects `feed_limit` (default `20`, `0` for unlimited) and emits only when at least one collection enables feeds.

* **Documentation**
  * Updated build command, configuration, and collection documentation to clarify site-wide vs per-collection feed behavior and limits.
  * Refreshed the roadmap wording for both collection and site-wide feeds.

* **Tests**
  * Expanded unit test coverage for site-wide feed content, metadata, URLs, and direct file writing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->