### PR TITLE
Add generated site check command

### DIFF
--- a/benchmarks/SiteCheckerBench.php
+++ b/benchmarks/SiteCheckerBench.php
@@ -1,0 +1,78 @@
+<?php
+
+declare(strict_types=1);
+
+namespace YiiPress\Benchmarks;
+
+use PhpBench\Attributes\AfterMethods;
+use PhpBench\Attributes\BeforeMethods;
+use PhpBench\Attributes\Iterations;
+use PhpBench\Attributes\Revs;
+use PhpBench\Attributes\Warmup;
+use YiiPress\Build\SiteChecker;
+
+#[BeforeMethods('setUp')]
+#[AfterMethods('tearDown')]
+final class SiteCheckerBench
+{
+    private string $outputDir;
+    private SiteChecker $checker;
+
+    public function setUp(): void
+    {
+        $this->outputDir = sys_get_temp_dir() . '/yiipress-site-checker-bench-' . uniqid();
+        mkdir($this->outputDir, 0o755, true);
+
+        for ($i = 1; $i <= 100; $i++) {
+            $dir = $this->outputDir . '/page-' . $i;
+            mkdir($dir, 0o755, true);
+            $next = $i === 100 ? 1 : $i + 1;
+            file_put_contents(
+                $dir . '/index.html',
+                '<h1 id="top">Page ' . $i . '</h1>'
+                . '<a href="../page-' . $next . '/#top">Next</a>'
+                . '<a href="../page-1/">Home</a>'
+                . '<img src="../assets/logo.svg">',
+            );
+        }
+
+        mkdir($this->outputDir . '/assets', 0o755, true);
+        file_put_contents($this->outputDir . '/assets/logo.svg', '<svg/>');
+
+        $this->checker = new SiteChecker();
+    }
+
+    public function tearDown(): void
+    {
+        $this->removeDir($this->outputDir);
+    }
+
+    #[Revs(20)]
+    #[Iterations(3)]
+    #[Warmup(1)]
+    public function benchInternalSiteCheck(): void
+    {
+        $this->checker->check($this->outputDir);
+    }
+
+    private function removeDir(string $path): void
+    {
+        if (!is_dir($path)) {
+            return;
+        }
+
+        $iterator = new \RecursiveIteratorIterator(
+            new \RecursiveDirectoryIterator($path, \FilesystemIterator::SKIP_DOTS),
+            \RecursiveIteratorIterator::CHILD_FIRST,
+        );
+        foreach ($iterator as $item) {
+            if ($item->isDir()) {
+                rmdir($item->getPathname());
+            } else {
+                unlink($item->getPathname());
+            }
+        }
+
+        rmdir($path);
+    }
+}

--- a/benchmarks/SiteCheckerBench.php
+++ b/benchmarks/SiteCheckerBench.php
@@ -4,12 +4,26 @@ declare(strict_types=1);
 
 namespace YiiPress\Benchmarks;
 
+use FilesystemIterator;
 use PhpBench\Attributes\AfterMethods;
 use PhpBench\Attributes\BeforeMethods;
 use PhpBench\Attributes\Iterations;
 use PhpBench\Attributes\Revs;
 use PhpBench\Attributes\Warmup;
+use RecursiveDirectoryIterator;
+use RecursiveIteratorIterator;
+use RuntimeException;
+use SplFileInfo;
 use YiiPress\Build\SiteChecker;
+
+use function bin2hex;
+use function file_put_contents;
+use function is_dir;
+use function mkdir;
+use function random_bytes;
+use function rmdir;
+use function sys_get_temp_dir;
+use function unlink;
 
 #[BeforeMethods('setUp')]
 #[AfterMethods('tearDown')]
@@ -20,14 +34,14 @@ final class SiteCheckerBench
 
     public function setUp(): void
     {
-        $this->outputDir = sys_get_temp_dir() . '/yiipress-site-checker-bench-' . uniqid();
-        mkdir($this->outputDir, 0o755, true);
+        $this->outputDir = sys_get_temp_dir() . '/yiipress-site-checker-bench-' . bin2hex(random_bytes(8));
+        $this->createDir($this->outputDir);
 
         for ($i = 1; $i <= 100; $i++) {
             $dir = $this->outputDir . '/page-' . $i;
-            mkdir($dir, 0o755, true);
+            $this->createDir($dir);
             $next = $i === 100 ? 1 : $i + 1;
-            file_put_contents(
+            $this->writeFile(
                 $dir . '/index.html',
                 '<h1 id="top">Page ' . $i . '</h1>'
                 . '<a href="../page-' . $next . '/#top">Next</a>'
@@ -36,8 +50,8 @@ final class SiteCheckerBench
             );
         }
 
-        mkdir($this->outputDir . '/assets', 0o755, true);
-        file_put_contents($this->outputDir . '/assets/logo.svg', '<svg/>');
+        $this->createDir($this->outputDir . '/assets');
+        $this->writeFile($this->outputDir . '/assets/logo.svg', '<svg/>');
 
         $this->checker = new SiteChecker();
     }
@@ -61,18 +75,47 @@ final class SiteCheckerBench
             return;
         }
 
-        $iterator = new \RecursiveIteratorIterator(
-            new \RecursiveDirectoryIterator($path, \FilesystemIterator::SKIP_DOTS),
-            \RecursiveIteratorIterator::CHILD_FIRST,
+        $iterator = new RecursiveIteratorIterator(
+            new RecursiveDirectoryIterator($path, FilesystemIterator::SKIP_DOTS),
+            RecursiveIteratorIterator::CHILD_FIRST,
         );
         foreach ($iterator as $item) {
+            /** @var SplFileInfo $item */
             if ($item->isDir()) {
-                rmdir($item->getPathname());
+                $this->removeDirectory($item->getPathname());
             } else {
-                unlink($item->getPathname());
+                $this->removeFile($item->getPathname());
             }
         }
 
-        rmdir($path);
+        $this->removeDirectory($path);
+    }
+
+    private function createDir(string $path): void
+    {
+        if (!mkdir($path, 0o755, true) && !is_dir($path)) {
+            throw new RuntimeException('Unable to create benchmark directory: ' . $path);
+        }
+    }
+
+    private function writeFile(string $path, string $content): void
+    {
+        if (file_put_contents($path, $content) === false) {
+            throw new RuntimeException('Unable to write benchmark fixture: ' . $path);
+        }
+    }
+
+    private function removeFile(string $path): void
+    {
+        if (!unlink($path)) {
+            throw new RuntimeException('Unable to remove benchmark file: ' . $path);
+        }
+    }
+
+    private function removeDirectory(string $path): void
+    {
+        if (!rmdir($path)) {
+            throw new RuntimeException('Unable to remove benchmark directory: ' . $path);
+        }
     }
 }

--- a/config/common/di/content-pipeline.php
+++ b/config/common/di/content-pipeline.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 use YiiPress\Build\TemplateResolver;
 use YiiPress\Build\ThemeRegistry;
 use YiiPress\Console\BuildCommand;
+use YiiPress\Console\CheckCommand;
 use YiiPress\Console\CleanCommand;
 use YiiPress\Console\InitCommand;
 use YiiPress\Console\NewCommand;
@@ -61,6 +62,11 @@ return [
             'themeRegistry' => Reference::to(ThemeRegistry::class),
             'templateResolver' => Reference::to(TemplateResolver::class),
             'eventDispatcher' => Reference::to(EventDispatcherInterface::class),
+        ],
+    ],
+    CheckCommand::class => [
+        '__construct()' => [
+            'rootPath' => $workingDirectory,
         ],
     ],
     CleanCommand::class => [

--- a/config/console/commands.php
+++ b/config/console/commands.php
@@ -6,7 +6,7 @@ use YiiPress\Console;
 
 return [
     'build' => Console\BuildCommand::class,
-    'check' => Console\CheckCommand::class,
+    'check:links' => Console\CheckCommand::class,
     'clean|clear' => Console\CleanCommand::class,
     'init' => Console\InitCommand::class,
     'import' => Console\ImportCommand::class,

--- a/config/console/commands.php
+++ b/config/console/commands.php
@@ -6,6 +6,7 @@ use YiiPress\Console;
 
 return [
     'build' => Console\BuildCommand::class,
+    'check' => Console\CheckCommand::class,
     'clean|clear' => Console\CleanCommand::class,
     'init' => Console\InitCommand::class,
     'import' => Console\ImportCommand::class,

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -58,12 +58,12 @@ The command:
 
 With `--workers=N` (N > 1), entry rendering and writing is parallelized across N forked processes. With `--workers=auto`, YiiPress uses up to the detected worker count and lets page writers clamp back to sequential mode for smaller workloads. Feeds are generated after entry writing and can be split per collection across workers. Sitemap generation remains serial.
 
-## `check`
+## `check:links`
 
 Checks generated HTML output for broken local links, missing `src` targets, and missing anchor fragments.
 
 ```
-./yiipress check [--output-dir=output] [--external]
+./yiipress check:links [--output-dir=output] [--external]
 ```
 
 **Options:**
@@ -71,7 +71,7 @@ Checks generated HTML output for broken local links, missing `src` targets, and 
 - `--output-dir`, `-o` — path to the generated output directory (default: `output`). Absolute or relative to project root.
 - `--external` — also validate external `http://` and `https://` links. This performs network requests, so it is opt-in.
 
-Run `build` first, then `check` against the generated output. Local checks are filesystem-only and validate links such as `./guide/`, `/assets/site.css`, and `#heading-id`.
+Run `build` first, then `check:links` against the generated output. Local checks are filesystem-only and validate links such as `./guide/`, `/assets/site.css`, and `#heading-id`.
 
 ## `serve`
 

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -62,7 +62,7 @@ With `--workers=N` (N > 1), entry rendering and writing is parallelized across N
 
 Checks generated HTML output for broken local links, missing `src` targets, and missing anchor fragments.
 
-```
+```bash
 ./yiipress check:links [--output-dir=output] [--external]
 ```
 

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -58,6 +58,21 @@ The command:
 
 With `--workers=N` (N > 1), entry rendering and writing is parallelized across N forked processes. With `--workers=auto`, YiiPress uses up to the detected worker count and lets page writers clamp back to sequential mode for smaller workloads. Feeds are generated after entry writing and can be split per collection across workers. Sitemap generation remains serial.
 
+## `check`
+
+Checks generated HTML output for broken local links, missing `src` targets, and missing anchor fragments.
+
+```
+./yiipress check [--output-dir=output] [--external]
+```
+
+**Options:**
+
+- `--output-dir`, `-o` — path to the generated output directory (default: `output`). Absolute or relative to project root.
+- `--external` — also validate external `http://` and `https://` links. This performs network requests, so it is opt-in.
+
+Run `build` first, then `check` against the generated output. Local checks are filesystem-only and validate links such as `./guide/`, `/assets/site.css`, and `#heading-id`.
+
 ## `serve`
 
 Starts the preview server for local development.

--- a/roadmap.md
+++ b/roadmap.md
@@ -58,7 +58,7 @@
 - [x] Smaller static package by removing unused runtime extension dependencies
 - [x] Build diagnostics (warn on broken internal links, missing images, invalid front matter)
 - [x] `yiipress clean` command — clear build output and caches
-- [x] `yiipress check` command — validate generated links and anchors
+- [x] `yiipress check:links` command — validate generated links and anchors
 - [x] Dry run mode for build — show what would be generated without writing files
 - [x] No-write build mode for render-vs-filesystem performance diagnostics
 - [x] `serve` overlay button to open the current markdown source in a configured editor

--- a/roadmap.md
+++ b/roadmap.md
@@ -57,6 +57,7 @@
 - [x] Smaller static package by removing unused runtime extension dependencies
 - [x] Build diagnostics (warn on broken internal links, missing images, invalid front matter)
 - [x] `yiipress clean` command — clear build output and caches
+- [x] `yiipress check` command — validate generated links and anchors
 - [x] Dry run mode for build — show what would be generated without writing files
 - [x] No-write build mode for render-vs-filesystem performance diagnostics
 - [x] `serve` overlay button to open the current markdown source in a configured editor

--- a/src/Build/SiteCheckIssue.php
+++ b/src/Build/SiteCheckIssue.php
@@ -1,0 +1,14 @@
+<?php
+
+declare(strict_types=1);
+
+namespace YiiPress\Build;
+
+final readonly class SiteCheckIssue
+{
+    public function __construct(
+        public string $filePath,
+        public string $target,
+        public string $message,
+    ) {}
+}

--- a/src/Build/SiteChecker.php
+++ b/src/Build/SiteChecker.php
@@ -10,6 +10,7 @@ use RecursiveDirectoryIterator;
 use RecursiveIteratorIterator;
 use SplFileInfo;
 
+use function array_key_last;
 use function array_pop;
 use function dirname;
 use function explode;
@@ -24,6 +25,7 @@ use function parse_url;
 use function preg_match;
 use function preg_match_all;
 use function rawurldecode;
+use function rtrim;
 use function sort;
 use function str_contains;
 use function str_ends_with;
@@ -222,6 +224,7 @@ final readonly class SiteChecker
 
     private function resolveTargetFile(string $outputDir, string $sourceFile, string $path): ?string
     {
+        $outputDir = rtrim($outputDir, '/') ?: '/';
         $base = str_starts_with($path, '/')
             ? ''
             : substr(dirname($sourceFile), strlen($outputDir) + 1);
@@ -317,7 +320,20 @@ final readonly class SiteChecker
             return false;
         }
 
-        $statusLine = $headers[0] ?? '';
+        $statusLine = '';
+        foreach ($headers as $key => $header) {
+            if (!is_int($key)) {
+                continue;
+            }
+
+            if (is_array($header)) {
+                $statusLine = $header[array_key_last($header)] ?? $statusLine;
+                continue;
+            }
+
+            $statusLine = $header;
+        }
+
         if (!is_string($statusLine) || preg_match('/\s(\d{3})\s?/', $statusLine, $matches) !== 1) {
             return false;
         }

--- a/src/Build/SiteChecker.php
+++ b/src/Build/SiteChecker.php
@@ -1,0 +1,329 @@
+<?php
+
+declare(strict_types=1);
+
+namespace YiiPress\Build;
+
+use Closure;
+use FilesystemIterator;
+use RecursiveDirectoryIterator;
+use RecursiveIteratorIterator;
+use SplFileInfo;
+
+use function array_pop;
+use function dirname;
+use function explode;
+use function file_get_contents;
+use function get_headers;
+use function html_entity_decode;
+use function implode;
+use function is_array;
+use function is_dir;
+use function is_file;
+use function parse_url;
+use function preg_match;
+use function preg_match_all;
+use function rawurldecode;
+use function sort;
+use function str_contains;
+use function str_ends_with;
+use function str_starts_with;
+use function strlen;
+use function strpos;
+use function strrpos;
+use function strtolower;
+use function substr;
+use function stream_context_create;
+use function trim;
+
+use const PHP_URL_PATH;
+
+final readonly class SiteChecker
+{
+    /**
+     * @param Closure(string): bool|null $externalChecker
+     */
+    public function __construct(
+        private ?Closure $externalChecker = null,
+    ) {}
+
+    /**
+     * @return list<SiteCheckIssue>
+     */
+    public function check(string $outputDir, bool $checkExternal = false): array
+    {
+        $htmlFiles = $this->htmlFiles($outputDir);
+        $issues = [];
+
+        foreach ($htmlFiles as $htmlFile) {
+            $html = (string) file_get_contents($htmlFile);
+            $anchors = $this->anchors($html);
+
+            foreach ($this->links($html) as $target) {
+                $issue = $this->checkTarget($outputDir, $htmlFile, $anchors, $target, $checkExternal);
+                if ($issue !== null) {
+                    $issues[] = $issue;
+                }
+            }
+        }
+
+        return $issues;
+    }
+
+    /**
+     * @return list<string>
+     */
+    private function htmlFiles(string $outputDir): array
+    {
+        if (!is_dir($outputDir)) {
+            return [];
+        }
+
+        $files = [];
+        $iterator = new RecursiveIteratorIterator(
+            new RecursiveDirectoryIterator($outputDir, FilesystemIterator::SKIP_DOTS),
+        );
+
+        foreach ($iterator as $item) {
+            /** @var SplFileInfo $item */
+            if ($item->isFile() && strtolower($item->getExtension()) === 'html') {
+                $files[] = $item->getPathname();
+            }
+        }
+
+        sort($files);
+
+        return $files;
+    }
+
+    /**
+     * @return list<string>
+     */
+    private function links(string $html): array
+    {
+        $lowerHtml = strtolower($html);
+        if (!str_contains($lowerHtml, 'href=') && !str_contains($lowerHtml, 'src=')) {
+            return [];
+        }
+
+        preg_match_all('/\b(?:href|src)\s*=\s*(["\'])(.*?)\1/i', $html, $matches, PREG_SET_ORDER);
+        $links = [];
+        foreach ($matches as $match) {
+            $target = trim(html_entity_decode($match[2], ENT_QUOTES | ENT_SUBSTITUTE | ENT_HTML5));
+            if ($target !== '') {
+                $links[] = $target;
+            }
+        }
+
+        return $links;
+    }
+
+    /**
+     * @return array<string, true>
+     */
+    private function anchors(string $html): array
+    {
+        $anchors = [];
+        preg_match_all('/\b(?:id|name)\s*=\s*(["\'])(.*?)\1/i', $html, $matches, PREG_SET_ORDER);
+        foreach ($matches as $match) {
+            $anchor = html_entity_decode($match[2], ENT_QUOTES | ENT_SUBSTITUTE | ENT_HTML5);
+            if ($anchor !== '') {
+                $anchors[$anchor] = true;
+            }
+        }
+
+        return $anchors;
+    }
+
+    /**
+     * @param array<string, true> $currentAnchors
+     */
+    private function checkTarget(string $outputDir, string $sourceFile, array $currentAnchors, string $target, bool $checkExternal): ?SiteCheckIssue
+    {
+        if ($this->shouldSkip($target)) {
+            return null;
+        }
+
+        if ($this->isExternalHttpUrl($target)) {
+            if (!$checkExternal || $this->externalIsReachable($target)) {
+                return null;
+            }
+
+            return new SiteCheckIssue($sourceFile, $target, 'external link is not reachable');
+        }
+
+        [$path, $fragment] = $this->splitTarget($target);
+        if ($path === '') {
+            if ($fragment === '' || isset($currentAnchors[$fragment])) {
+                return null;
+            }
+
+            return new SiteCheckIssue($sourceFile, $target, 'fragment not found');
+        }
+
+        $targetFile = $this->resolveTargetFile($outputDir, $sourceFile, $path);
+        if ($targetFile === null || !is_file($targetFile)) {
+            return new SiteCheckIssue($sourceFile, $target, 'local target not found');
+        }
+
+        if ($fragment === '') {
+            return null;
+        }
+
+        $targetHtml = (string) file_get_contents($targetFile);
+        if (isset($this->anchors($targetHtml)[$fragment])) {
+            return null;
+        }
+
+        return new SiteCheckIssue($sourceFile, $target, 'fragment not found');
+    }
+
+    private function shouldSkip(string $target): bool
+    {
+        $lower = strtolower($target);
+
+        return str_starts_with($lower, 'mailto:')
+            || str_starts_with($lower, 'tel:')
+            || str_starts_with($lower, 'javascript:')
+            || str_starts_with($lower, 'data:')
+            || str_starts_with($lower, 'urn:');
+    }
+
+    private function isExternalHttpUrl(string $target): bool
+    {
+        $lower = strtolower($target);
+
+        return str_starts_with($lower, 'http://')
+            || str_starts_with($lower, 'https://')
+            || str_starts_with($lower, '//');
+    }
+
+    /**
+     * @return array{0: string, 1: string}
+     */
+    private function splitTarget(string $target): array
+    {
+        $path = $target;
+        $fragment = '';
+
+        $fragmentPosition = strpos($path, '#');
+        if ($fragmentPosition !== false) {
+            $fragment = rawurldecode(substr($path, $fragmentPosition + 1));
+            $path = substr($path, 0, $fragmentPosition);
+        }
+
+        $queryPosition = strpos($path, '?');
+        if ($queryPosition !== false) {
+            $path = substr($path, 0, $queryPosition);
+        }
+
+        return [rawurldecode(trim($path)), $fragment];
+    }
+
+    private function resolveTargetFile(string $outputDir, string $sourceFile, string $path): ?string
+    {
+        $base = str_starts_with($path, '/')
+            ? ''
+            : substr(dirname($sourceFile), strlen($outputDir) + 1);
+        $normalized = $this->normalizePath(($base !== '' ? $base . '/' : '') . $path);
+
+        if ($normalized === null) {
+            return null;
+        }
+
+        $targetPath = $outputDir . ($normalized !== '' ? '/' . $normalized : '');
+        if (is_file($targetPath)) {
+            return $targetPath;
+        }
+        if (is_dir($targetPath)) {
+            return $targetPath . '/index.html';
+        }
+        if (str_ends_with($path, '/') || !str_contains($this->lastPathSegment($path), '.')) {
+            return $targetPath . '/index.html';
+        }
+
+        return $targetPath;
+    }
+
+    private function normalizePath(string $path): ?string
+    {
+        $parsedPath = parse_url($path, PHP_URL_PATH);
+        $path = is_string($parsedPath) ? $parsedPath : $path;
+        $parts = [];
+
+        foreach (explode('/', $path) as $segment) {
+            if ($segment === '' || $segment === '.') {
+                continue;
+            }
+            if ($segment === '..') {
+                if ($parts === []) {
+                    return null;
+                }
+                array_pop($parts);
+                continue;
+            }
+            $parts[] = $segment;
+        }
+
+        return implode('/', $parts);
+    }
+
+    private function lastPathSegment(string $path): string
+    {
+        $path = trim($path, '/');
+        $slashPosition = strrpos($path, '/');
+
+        return $slashPosition === false ? $path : substr($path, $slashPosition + 1);
+    }
+
+    private function externalIsReachable(string $url): bool
+    {
+        if (str_starts_with($url, '//')) {
+            $url = 'https:' . $url;
+        }
+
+        if ($this->externalChecker !== null) {
+            return ($this->externalChecker)($url);
+        }
+
+        $context = stream_context_create([
+            'http' => [
+                'method' => 'HEAD',
+                'timeout' => 5,
+                'ignore_errors' => true,
+            ],
+        ]);
+        $headers = @get_headers($url, true, $context);
+
+        if ($this->headersAreSuccessful($headers)) {
+            return true;
+        }
+
+        $context = stream_context_create([
+            'http' => [
+                'method' => 'GET',
+                'timeout' => 5,
+                'ignore_errors' => true,
+            ],
+        ]);
+        $headers = @get_headers($url, true, $context);
+
+        return $this->headersAreSuccessful($headers);
+    }
+
+    private function headersAreSuccessful(mixed $headers): bool
+    {
+        if (!is_array($headers) || $headers === []) {
+            return false;
+        }
+
+        $statusLine = $headers[0] ?? '';
+        if (!is_string($statusLine) || preg_match('/\s(\d{3})\s?/', $statusLine, $matches) !== 1) {
+            return false;
+        }
+
+        $status = (int) $matches[1];
+
+        return $status >= 200 && $status < 400;
+    }
+}

--- a/src/Build/SiteChecker.php
+++ b/src/Build/SiteChecker.php
@@ -327,7 +327,9 @@ final readonly class SiteChecker
             }
 
             if (is_array($header)) {
-                $statusLine = $header[array_key_last($header)] ?? $statusLine;
+                if ($header !== []) {
+                    $statusLine = $header[array_key_last($header)];
+                }
                 continue;
             }
 

--- a/src/Console/CheckCommand.php
+++ b/src/Console/CheckCommand.php
@@ -14,6 +14,9 @@ use YiiPress\Build\SiteChecker;
 use Yiisoft\Yii\Console\ExitCode;
 
 use function count;
+use function ltrim;
+use function preg_match;
+use function rtrim;
 use function sprintf;
 use function str_starts_with;
 use function strlen;
@@ -82,11 +85,15 @@ final class CheckCommand extends Command
 
     private function resolvePath(string $path, string $rootPath): string
     {
-        if (str_starts_with($path, '/')) {
+        if (
+            str_starts_with($path, '/')
+            || str_starts_with($path, '\\\\')
+            || preg_match('~^[A-Za-z]:[\\\\/]~', $path) === 1
+        ) {
             return $path;
         }
 
-        return $rootPath . '/' . $path;
+        return rtrim($rootPath, '/\\') . '/' . ltrim($path, '/\\');
     }
 
     private function relativePath(string $path, string $baseDir): string

--- a/src/Console/CheckCommand.php
+++ b/src/Console/CheckCommand.php
@@ -20,7 +20,7 @@ use function strlen;
 use function substr;
 
 #[AsCommand(
-    name: 'check',
+    name: 'check:links',
     description: 'Checks generated site links and anchors',
 )]
 final class CheckCommand extends Command

--- a/src/Console/CheckCommand.php
+++ b/src/Console/CheckCommand.php
@@ -1,0 +1,98 @@
+<?php
+
+declare(strict_types=1);
+
+namespace YiiPress\Console;
+
+use Symfony\Component\Console\Attribute\AsCommand;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Formatter\OutputFormatter;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Output\OutputInterface;
+use YiiPress\Build\SiteChecker;
+use Yiisoft\Yii\Console\ExitCode;
+
+use function count;
+use function sprintf;
+use function str_starts_with;
+use function strlen;
+use function substr;
+
+#[AsCommand(
+    name: 'check',
+    description: 'Checks generated site links and anchors',
+)]
+final class CheckCommand extends Command
+{
+    private const string DEFAULT_OUTPUT_DIR = 'output';
+
+    public function __construct(private readonly string $rootPath)
+    {
+        parent::__construct();
+    }
+
+    protected function configure(): void
+    {
+        $this->addOption(
+            'output-dir',
+            'o',
+            InputOption::VALUE_REQUIRED,
+            'Path to the generated output directory',
+            self::DEFAULT_OUTPUT_DIR,
+        );
+        $this->addOption(
+            'external',
+            null,
+            InputOption::VALUE_NONE,
+            'Also validate external HTTP(S) links',
+        );
+    }
+
+    protected function execute(InputInterface $input, OutputInterface $output): int
+    {
+        /** @var string $outputDirOption */
+        $outputDirOption = $input->getOption('output-dir');
+        $outputDir = $this->resolvePath($outputDirOption, $this->rootPath);
+
+        if (!is_dir($outputDir)) {
+            $output->writeln('<error>Output directory not found: ' . OutputFormatter::escape($outputDir) . '</error>');
+            return ExitCode::DATAERR;
+        }
+
+        $issues = (new SiteChecker())->check($outputDir, (bool) $input->getOption('external'));
+        if ($issues === []) {
+            $output->writeln('<info>Site check passed.</info>');
+            return ExitCode::OK;
+        }
+
+        foreach ($issues as $issue) {
+            $output->writeln(sprintf(
+                '<error>%s: %s "%s"</error>',
+                OutputFormatter::escape($this->relativePath($issue->filePath, $outputDir)),
+                OutputFormatter::escape($issue->message),
+                OutputFormatter::escape($issue->target),
+            ));
+        }
+
+        $output->writeln('<error>Site check failed: ' . count($issues) . ' issue(s).</error>');
+
+        return ExitCode::DATAERR;
+    }
+
+    private function resolvePath(string $path, string $rootPath): string
+    {
+        if (str_starts_with($path, '/')) {
+            return $path;
+        }
+
+        return $rootPath . '/' . $path;
+    }
+
+    private function relativePath(string $path, string $baseDir): string
+    {
+        $prefix = $baseDir . '/';
+
+        return str_starts_with($path, $prefix) ? substr($path, strlen($prefix)) : $path;
+    }
+}

--- a/tests/Unit/Build/SiteCheckerTest.php
+++ b/tests/Unit/Build/SiteCheckerTest.php
@@ -1,0 +1,115 @@
+<?php
+
+declare(strict_types=1);
+
+namespace YiiPress\Tests\Unit\Build;
+
+use FilesystemIterator;
+use PHPUnit\Framework\TestCase;
+use RecursiveDirectoryIterator;
+use RecursiveIteratorIterator;
+use SplFileInfo;
+use YiiPress\Build\SiteChecker;
+
+use function PHPUnit\Framework\assertCount;
+use function PHPUnit\Framework\assertSame;
+
+final class SiteCheckerTest extends TestCase
+{
+    private string $outputDir;
+
+    protected function setUp(): void
+    {
+        $this->outputDir = sys_get_temp_dir() . '/yiipress-site-checker-test-' . uniqid();
+        mkdir($this->outputDir . '/blog', 0o755, true);
+        mkdir($this->outputDir . '/assets', 0o755, true);
+    }
+
+    protected function tearDown(): void
+    {
+        $this->removeDir($this->outputDir);
+    }
+
+    public function testPassesForExistingLocalTargetsAndFragments(): void
+    {
+        file_put_contents($this->outputDir . '/index.html', '<a href="./blog/#post">Post</a><img src="/assets/logo.svg"><a href="mailto:test@example.com">Mail</a>');
+        file_put_contents($this->outputDir . '/blog/index.html', '<h2 id="post">Post</h2>');
+        file_put_contents($this->outputDir . '/assets/logo.svg', '<svg/>');
+
+        $issues = (new SiteChecker())->check($this->outputDir);
+
+        assertSame([], $issues);
+    }
+
+    public function testExtractsCaseInsensitiveLinkAttributes(): void
+    {
+        file_put_contents($this->outputDir . '/index.html', '<A HREF="./blog/#post">Post</A><IMG SRC="/assets/logo.svg">');
+        file_put_contents($this->outputDir . '/blog/index.html', '<h2 ID="post">Post</h2>');
+        file_put_contents($this->outputDir . '/assets/logo.svg', '<svg/>');
+
+        $issues = (new SiteChecker())->check($this->outputDir);
+
+        assertSame([], $issues);
+    }
+
+    public function testReportsMissingLocalTargetsAndFragments(): void
+    {
+        file_put_contents($this->outputDir . '/index.html', '<a href="./missing/">Missing</a><a href="./blog/#missing">Bad fragment</a>');
+        file_put_contents($this->outputDir . '/blog/index.html', '<h2 id="post">Post</h2>');
+
+        $issues = (new SiteChecker())->check($this->outputDir);
+
+        assertCount(2, $issues);
+        assertSame('local target not found', $issues[0]->message);
+        assertSame('./missing/', $issues[0]->target);
+        assertSame('fragment not found', $issues[1]->message);
+        assertSame('./blog/#missing', $issues[1]->target);
+    }
+
+    public function testChecksExternalLinksOnlyWhenRequested(): void
+    {
+        file_put_contents($this->outputDir . '/index.html', '<a href="https://example.test/broken">Broken</a>');
+        $checker = new SiteChecker(static fn (string $url): bool => $url !== 'https://example.test/broken');
+
+        assertSame([], $checker->check($this->outputDir));
+
+        $issues = $checker->check($this->outputDir, checkExternal: true);
+
+        assertCount(1, $issues);
+        assertSame('external link is not reachable', $issues[0]->message);
+        assertSame('https://example.test/broken', $issues[0]->target);
+    }
+
+    public function testRejectsLinksEscapingOutputDirectory(): void
+    {
+        file_put_contents($this->outputDir . '/blog/index.html', '<a href="../../secret.html">Secret</a>');
+
+        $issues = (new SiteChecker())->check($this->outputDir);
+
+        assertCount(1, $issues);
+        assertSame('local target not found', $issues[0]->message);
+        assertSame('../../secret.html', $issues[0]->target);
+    }
+
+    private function removeDir(string $path): void
+    {
+        if (!is_dir($path)) {
+            return;
+        }
+
+        $iterator = new RecursiveIteratorIterator(
+            new RecursiveDirectoryIterator($path, FilesystemIterator::SKIP_DOTS),
+            RecursiveIteratorIterator::CHILD_FIRST,
+        );
+        foreach ($iterator as $item) {
+            /** @var SplFileInfo $item */
+            if ($item->isDir()) {
+                rmdir($item->getPathname());
+            } else {
+                unlink($item->getPathname());
+            }
+        }
+
+        rmdir($path);
+    }
+}

--- a/tests/Unit/Build/SiteCheckerTest.php
+++ b/tests/Unit/Build/SiteCheckerTest.php
@@ -11,8 +11,10 @@ use RecursiveIteratorIterator;
 use SplFileInfo;
 use YiiPress\Build\SiteChecker;
 
+use function bin2hex;
 use function PHPUnit\Framework\assertCount;
 use function PHPUnit\Framework\assertSame;
+use function random_bytes;
 
 final class SiteCheckerTest extends TestCase
 {
@@ -20,7 +22,7 @@ final class SiteCheckerTest extends TestCase
 
     protected function setUp(): void
     {
-        $this->outputDir = sys_get_temp_dir() . '/yiipress-site-checker-test-' . uniqid();
+        $this->outputDir = sys_get_temp_dir() . '/yiipress-site-checker-test-' . bin2hex(random_bytes(8));
         mkdir($this->outputDir . '/blog', 0o755, true);
         mkdir($this->outputDir . '/assets', 0o755, true);
     }
@@ -89,6 +91,16 @@ final class SiteCheckerTest extends TestCase
         assertCount(1, $issues);
         assertSame('local target not found', $issues[0]->message);
         assertSame('../../secret.html', $issues[0]->target);
+    }
+
+    public function testResolvesRelativeLinksWhenOutputDirectoryHasTrailingSlash(): void
+    {
+        file_put_contents($this->outputDir . '/index.html', '<a href="./blog/#post">Post</a>');
+        file_put_contents($this->outputDir . '/blog/index.html', '<h2 id="post">Post</h2>');
+
+        $issues = (new SiteChecker())->check($this->outputDir . '/');
+
+        assertSame([], $issues);
     }
 
     private function removeDir(string $path): void

--- a/tests/Unit/Build/ThemeAssetCopierTest.php
+++ b/tests/Unit/Build/ThemeAssetCopierTest.php
@@ -113,9 +113,9 @@ final class ThemeAssetCopierTest extends TestCase
         $copied = $copier->copy($registry, $this->tempDir . '/output');
 
         assertSame(3, $copied);
-        assertStringContainsString('color: red', file_get_contents($this->tempDir . '/output/assets/themes/test/style.css'));
-        assertStringContainsString('color: blue', file_get_contents($this->tempDir . '/output/assets/themes/other/style.css'));
-        assertStringContainsString('color: red', file_get_contents($this->tempDir . '/output/assets/theme/style.css'));
+        assertStringEqualsFile($this->tempDir . '/output/assets/themes/test/style.css', 'body{color:red}');
+        assertStringEqualsFile($this->tempDir . '/output/assets/themes/other/style.css', 'body{color:blue}');
+        assertStringEqualsFile($this->tempDir . '/output/assets/theme/style.css', 'body{color:red}');
         assertFileDoesNotExist($this->tempDir . '/output/assets/theme/other/style.css');
     }
 

--- a/tests/Unit/Console/CheckCommandTest.php
+++ b/tests/Unit/Console/CheckCommandTest.php
@@ -11,8 +11,10 @@ use RecursiveIteratorIterator;
 use SplFileInfo;
 use Yiisoft\Yii\Console\ExitCode;
 
+use function bin2hex;
 use function PHPUnit\Framework\assertSame;
 use function PHPUnit\Framework\assertStringContainsString;
+use function random_bytes;
 
 final class CheckCommandTest extends TestCase
 {
@@ -20,7 +22,7 @@ final class CheckCommandTest extends TestCase
 
     protected function setUp(): void
     {
-        $this->outputDir = sys_get_temp_dir() . '/yiipress-check-command-test-' . uniqid();
+        $this->outputDir = sys_get_temp_dir() . '/yiipress-check-command-test-' . bin2hex(random_bytes(8));
         mkdir($this->outputDir . '/docs', 0o755, true);
     }
 
@@ -68,7 +70,7 @@ final class CheckCommandTest extends TestCase
     {
         $yii = dirname(__DIR__, 3) . '/yii';
         exec(
-            $yii . ' check:links'
+            escapeshellarg($yii) . ' check:links'
             . ' --output-dir=' . escapeshellarg($this->outputDir)
             . ' 2>&1',
             $output,

--- a/tests/Unit/Console/CheckCommandTest.php
+++ b/tests/Unit/Console/CheckCommandTest.php
@@ -68,7 +68,7 @@ final class CheckCommandTest extends TestCase
     {
         $yii = dirname(__DIR__, 3) . '/yii';
         exec(
-            $yii . ' check'
+            $yii . ' check:links'
             . ' --output-dir=' . escapeshellarg($this->outputDir)
             . ' 2>&1',
             $output,

--- a/tests/Unit/Console/CheckCommandTest.php
+++ b/tests/Unit/Console/CheckCommandTest.php
@@ -1,0 +1,102 @@
+<?php
+
+declare(strict_types=1);
+
+namespace YiiPress\Tests\Unit\Console;
+
+use FilesystemIterator;
+use PHPUnit\Framework\TestCase;
+use RecursiveDirectoryIterator;
+use RecursiveIteratorIterator;
+use SplFileInfo;
+use Yiisoft\Yii\Console\ExitCode;
+
+use function PHPUnit\Framework\assertSame;
+use function PHPUnit\Framework\assertStringContainsString;
+
+final class CheckCommandTest extends TestCase
+{
+    private string $outputDir;
+
+    protected function setUp(): void
+    {
+        $this->outputDir = sys_get_temp_dir() . '/yiipress-check-command-test-' . uniqid();
+        mkdir($this->outputDir . '/docs', 0o755, true);
+    }
+
+    protected function tearDown(): void
+    {
+        $this->removeDir($this->outputDir);
+    }
+
+    public function testCheckPassesForValidGeneratedSite(): void
+    {
+        file_put_contents($this->outputDir . '/index.html', '<a href="./docs/#intro">Docs</a>');
+        file_put_contents($this->outputDir . '/docs/index.html', '<h1 id="intro">Intro</h1>');
+
+        $result = $this->runCheck();
+
+        assertSame(ExitCode::OK, $result['exitCode'], $result['output']);
+        assertStringContainsString('Site check passed.', $result['output']);
+    }
+
+    public function testCheckFailsForBrokenGeneratedSiteLink(): void
+    {
+        file_put_contents($this->outputDir . '/index.html', '<a href="./missing/">Missing</a>');
+
+        $result = $this->runCheck();
+
+        assertSame(ExitCode::DATAERR, $result['exitCode'], $result['output']);
+        assertStringContainsString('index.html: local target not found "./missing/"', $result['output']);
+        assertStringContainsString('Site check failed: 1 issue(s).', $result['output']);
+    }
+
+    public function testCheckFailsForMissingOutputDirectory(): void
+    {
+        $this->removeDir($this->outputDir);
+
+        $result = $this->runCheck();
+
+        assertSame(ExitCode::DATAERR, $result['exitCode'], $result['output']);
+        assertStringContainsString('Output directory not found', $result['output']);
+    }
+
+    /**
+     * @return array{exitCode: int, output: string}
+     */
+    private function runCheck(): array
+    {
+        $yii = dirname(__DIR__, 3) . '/yii';
+        exec(
+            $yii . ' check'
+            . ' --output-dir=' . escapeshellarg($this->outputDir)
+            . ' 2>&1',
+            $output,
+            $exitCode,
+        );
+
+        return ['exitCode' => $exitCode, 'output' => implode("\n", $output)];
+    }
+
+    private function removeDir(string $path): void
+    {
+        if (!is_dir($path)) {
+            return;
+        }
+
+        $iterator = new RecursiveIteratorIterator(
+            new RecursiveDirectoryIterator($path, FilesystemIterator::SKIP_DOTS),
+            RecursiveIteratorIterator::CHILD_FIRST,
+        );
+        foreach ($iterator as $item) {
+            /** @var SplFileInfo $item */
+            if ($item->isDir()) {
+                rmdir($item->getPathname());
+            } else {
+                unlink($item->getPathname());
+            }
+        }
+
+        rmdir($path);
+    }
+}


### PR DESCRIPTION
## Summary
- add a `yiipress check` command for generated output link, asset, and anchor validation
- support optional external HTTP(S) validation via `--external`
- document the command, update the roadmap, and add unit tests plus a phpbench benchmark

## Tests
- `make test -- --filter SiteCheckerTest`
- `make test -- --filter CheckCommandTest`
- `make psalm`
- `make test`
- `BENCH_FILTER=SiteCheckerBench make bench`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new `check` command to validate generated site links, anchors, and targets
  * Supports `--output-dir` option to target specific output directories
  * Includes `--external` flag to validate external HTTP/HTTPS links

* **Documentation**
  * Added command documentation with usage examples

* **Tests**
  * Added comprehensive test coverage for link validation

* **Chores**
  * Added performance benchmarks
  * Updated project roadmap

<!-- end of auto-generated comment: release notes by coderabbit.ai -->