### PR TITLE
Add support for custom themes and a command to init a theme

### DIFF
--- a/benchmarks/ProjectThemeDiscoveryBench.php
+++ b/benchmarks/ProjectThemeDiscoveryBench.php
@@ -1,0 +1,71 @@
+<?php
+
+declare(strict_types=1);
+
+namespace YiiPress\Benchmarks;
+
+use PhpBench\Attributes\AfterMethods;
+use PhpBench\Attributes\BeforeMethods;
+use PhpBench\Attributes\Iterations;
+use PhpBench\Attributes\Revs;
+use PhpBench\Attributes\Warmup;
+use YiiPress\Build\ProjectThemeDiscovery;
+use YiiPress\Build\Theme;
+use YiiPress\Build\ThemeRegistry;
+
+#[BeforeMethods('setUp')]
+#[AfterMethods('tearDown')]
+final class ProjectThemeDiscoveryBench
+{
+    private string $rootDir;
+    private ProjectThemeDiscovery $discovery;
+
+    public function setUp(): void
+    {
+        $this->rootDir = sys_get_temp_dir() . '/yiipress-project-theme-bench-' . uniqid();
+        mkdir($this->rootDir . '/themes', 0o755, true);
+
+        for ($i = 1; $i <= 50; $i++) {
+            mkdir($this->rootDir . '/themes/theme-' . $i);
+        }
+
+        $this->discovery = new ProjectThemeDiscovery();
+    }
+
+    public function tearDown(): void
+    {
+        $this->removeDir($this->rootDir);
+    }
+
+    #[Revs(100)]
+    #[Iterations(3)]
+    #[Warmup(1)]
+    public function benchRegisterProjectThemes(): void
+    {
+        $registry = new ThemeRegistry();
+        $registry->register(new Theme('minimal', '/built-in/minimal'));
+
+        $this->discovery->register($registry, $this->rootDir . '/themes');
+    }
+
+    private function removeDir(string $path): void
+    {
+        if (!is_dir($path)) {
+            return;
+        }
+
+        $iterator = new \RecursiveIteratorIterator(
+            new \RecursiveDirectoryIterator($path, \FilesystemIterator::SKIP_DOTS),
+            \RecursiveIteratorIterator::CHILD_FIRST,
+        );
+        foreach ($iterator as $item) {
+            if ($item->isDir()) {
+                rmdir($item->getPathname());
+            } else {
+                unlink($item->getPathname());
+            }
+        }
+
+        rmdir($path);
+    }
+}

--- a/config/common/di/content-pipeline.php
+++ b/config/common/di/content-pipeline.php
@@ -8,6 +8,7 @@ use YiiPress\Console\BuildCommand;
 use YiiPress\Console\CleanCommand;
 use YiiPress\Console\InitCommand;
 use YiiPress\Console\NewCommand;
+use YiiPress\Console\ThemeInitCommand;
 use YiiPress\Processor\ContentProcessorPipeline;
 use YiiPress\Processor\Mermaid\MermaidProcessor;
 use YiiPress\Processor\OEmbed\OEmbedProcessor;
@@ -76,6 +77,12 @@ return [
     NewCommand::class => [
         '__construct()' => [
             'rootPath' => $workingDirectory,
+        ],
+    ],
+    ThemeInitCommand::class => [
+        '__construct()' => [
+            'rootPath' => $workingDirectory,
+            'themeRegistry' => Reference::to(ThemeRegistry::class),
         ],
     ],
 ];

--- a/config/console/commands.php
+++ b/config/console/commands.php
@@ -11,4 +11,5 @@ return [
     'import' => Console\ImportCommand::class,
     'new' => Console\NewCommand::class,
     'serve' => Console\ServeCommand::class,
+    'theme:init' => Console\ThemeInitCommand::class,
 ];

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -100,6 +100,25 @@ Initializes a content directory with the minimal YiiPress structure:
 
 The command creates parent directories as needed and fails if any scaffolded file already exists.
 
+## `theme:init`
+
+Initializes editable theme files in the project from a bundled theme.
+
+```
+./yiipress theme:init [target-dir] [--theme=minimal] [--content-dir=content]
+```
+
+**Arguments:**
+
+- `target-dir` — directory to initialize theme files in (default: `themes/custom`). Absolute or relative to project root.
+
+**Options:**
+
+- `--theme`, `-t` — bundled theme name to use as the source (default: `minimal`).
+- `--content-dir`, `-c` — path to the content directory containing `config.yaml` (default: `content`). Absolute or relative to project root.
+
+The command creates parent directories as needed, fails if any target file already exists, and updates `config.yaml` to use the initialized theme. The theme name is derived from the target directory name, so the default target `themes/custom` sets `theme: "custom"`.
+
 ## `new`
 
 Scaffolds a new content entry or standalone page.

--- a/docs/engine.md
+++ b/docs/engine.md
@@ -193,7 +193,7 @@ The source-open overlay resolves the browser path through the build manifest, ve
 
 ## Theme Registration
 
-Project-local templates under `content/templates/` are registered automatically as the `local` theme. Engine-level or distributable themes are registered in [Yii3 DI](https://yiisoft.github.io/docs/guide/concept/di-container.html):
+Project themes under `<project>/themes/<name>/` are registered automatically by directory name. Project-local templates under `content/templates/` are registered automatically as the `local` theme. Engine-level themes may still be registered in [Yii3 DI](https://yiisoft.github.io/docs/guide/concept/di-container.html):
 
 ```php
 use YiiPress\Build\Theme;
@@ -204,11 +204,10 @@ return [
     ThemeRegistry::class => DynamicReference::to(static function (): ThemeRegistry {
         $registry = new ThemeRegistry();
         $registry->register(new Theme('minimal', dirname(__DIR__, 3) . '/themes/minimal'));
-        $registry->register(new Theme('fancy', '/path/to/fancy-theme'));
 
         return $registry;
     }),
 ];
 ```
 
-Template resolution checks the active theme first, then falls back through registered themes. This lets a project override one template while keeping the rest of the bundled theme.
+For binary users, install a reusable theme as `themes/fancy/` and set `theme: fancy` in `content/config.yaml`. Template resolution checks the active theme first, then falls back through registered themes. This lets a project override one template while keeping the rest of the bundled theme.

--- a/docs/templates.md
+++ b/docs/templates.md
@@ -61,7 +61,7 @@ Install reusable themes into the project root:
 
 ```
 themes/
-└── docs/
+└── brand/
     ├── entry.php
     ├── partials/
     ├── assets/
@@ -71,8 +71,16 @@ themes/
 Use the directory name as the theme name:
 
 ```yaml
-theme: docs
+theme: brand
 ```
+
+To start editing the bundled theme in a PHAR or static binary build, initialize it into `themes/custom/`:
+
+```bash
+./yiipress theme:init
+```
+
+The command updates `content/config.yaml` automatically to set `theme: custom`.
 
 Theme directory names may contain letters, numbers, `_`, and `-`, and must start with a letter or number. If a project theme has the same name as an already registered built-in theme, the built-in theme is kept.
 

--- a/docs/templates.md
+++ b/docs/templates.md
@@ -43,7 +43,7 @@ Use `$h()` for text that should be escaped. Rendered Markdown content in `$conte
 
 ## Themes
 
-A theme is a named set of template files. YiiPress ships with the built-in `minimal` theme. A project-local `content/templates/` directory is automatically available as the `local` theme.
+A theme is a named set of template files. YiiPress ships with the built-in `minimal` theme. Project themes under `themes/<name>/` are registered automatically, and a project-local `content/templates/` directory is automatically available as the `local` theme.
 
 ### Theme resolution order
 
@@ -53,7 +53,28 @@ When YiiPress renders a page, it chooses templates in this order:
 2. **Site-level default theme** — set via `theme` in `config.yaml`.
 3. **Built-in `minimal` theme** — fallback when a template is missing.
 
-Within a theme, YiiPress uses the requested file when it exists and falls back to other registered themes when it does not. That means a local theme can override only `entry.php` and keep every other page type from `minimal`.
+Within a theme, YiiPress uses the requested file when it exists and falls back to other registered themes when it does not. That means a project theme or local theme can override only `entry.php` and keep every other page type from `minimal`.
+
+### Project themes
+
+Install reusable themes into the project root:
+
+```
+themes/
+└── docs/
+    ├── entry.php
+    ├── partials/
+    ├── assets/
+    └── translation/
+```
+
+Use the directory name as the theme name:
+
+```yaml
+theme: docs
+```
+
+Theme directory names may contain letters, numbers, `_`, and `-`, and must start with a letter or number. If a project theme has the same name as an already registered built-in theme, the built-in theme is kept.
 
 ### Local theme
 

--- a/roadmap.md
+++ b/roadmap.md
@@ -64,6 +64,7 @@
 ## Priority 4: Templates and theming
 
 - [x] Theme system — installable/distributable themes
+- [x] Auto-register project themes from `themes/<name>/` for binary users
 - [x] Template partials/includes support
 - [x] Template helper functions documentation
 - [x] Multiple layout support (per-entry layout selection via front matter)

--- a/src/Build/ProjectThemeDiscovery.php
+++ b/src/Build/ProjectThemeDiscovery.php
@@ -6,9 +6,11 @@ namespace YiiPress\Build;
 
 use FilesystemIterator;
 use SplFileInfo;
+use UnexpectedValueException;
 
 use function array_values;
 use function is_dir;
+use function is_readable;
 use function ksort;
 use function preg_match;
 
@@ -19,24 +21,28 @@ final readonly class ProjectThemeDiscovery
      */
     public function discover(string $themesDir): array
     {
-        if (!is_dir($themesDir)) {
+        if (!is_dir($themesDir) || !is_readable($themesDir)) {
             return [];
         }
 
         $themes = [];
-        $iterator = new FilesystemIterator($themesDir, FilesystemIterator::SKIP_DOTS);
-        foreach ($iterator as $item) {
-            /** @var SplFileInfo $item */
-            if (!$item->isDir()) {
-                continue;
-            }
+        try {
+            $iterator = new FilesystemIterator($themesDir, FilesystemIterator::SKIP_DOTS);
+            foreach ($iterator as $item) {
+                /** @var SplFileInfo $item */
+                if (!$item->isDir()) {
+                    continue;
+                }
 
-            $name = $item->getFilename();
-            if (!$this->isValidThemeName($name)) {
-                continue;
-            }
+                $name = $item->getFilename();
+                if (!$this->isValidThemeName($name)) {
+                    continue;
+                }
 
-            $themes[$name] = new Theme($name, $item->getPathname());
+                $themes[$name] = new Theme($name, $item->getPathname());
+            }
+        } catch (UnexpectedValueException) {
+            return [];
         }
 
         ksort($themes);

--- a/src/Build/ProjectThemeDiscovery.php
+++ b/src/Build/ProjectThemeDiscovery.php
@@ -1,0 +1,66 @@
+<?php
+
+declare(strict_types=1);
+
+namespace YiiPress\Build;
+
+use FilesystemIterator;
+use SplFileInfo;
+
+use function array_values;
+use function is_dir;
+use function ksort;
+use function preg_match;
+
+final readonly class ProjectThemeDiscovery
+{
+    /**
+     * @return list<Theme>
+     */
+    public function discover(string $themesDir): array
+    {
+        if (!is_dir($themesDir)) {
+            return [];
+        }
+
+        $themes = [];
+        $iterator = new FilesystemIterator($themesDir, FilesystemIterator::SKIP_DOTS);
+        foreach ($iterator as $item) {
+            /** @var SplFileInfo $item */
+            if (!$item->isDir()) {
+                continue;
+            }
+
+            $name = $item->getFilename();
+            if (!$this->isValidThemeName($name)) {
+                continue;
+            }
+
+            $themes[$name] = new Theme($name, $item->getPathname());
+        }
+
+        ksort($themes);
+
+        return array_values($themes);
+    }
+
+    public function register(ThemeRegistry $registry, string $themesDir): int
+    {
+        $registered = 0;
+        foreach ($this->discover($themesDir) as $theme) {
+            if ($registry->has($theme->name)) {
+                continue;
+            }
+
+            $registry->register($theme);
+            $registered++;
+        }
+
+        return $registered;
+    }
+
+    private function isValidThemeName(string $name): bool
+    {
+        return preg_match('/^[A-Za-z0-9][A-Za-z0-9_-]*$/D', $name) === 1;
+    }
+}

--- a/src/Build/ThemeInitializer.php
+++ b/src/Build/ThemeInitializer.php
@@ -1,0 +1,106 @@
+<?php
+
+declare(strict_types=1);
+
+namespace YiiPress\Build;
+
+use FilesystemIterator;
+use RecursiveDirectoryIterator;
+use RecursiveIteratorIterator;
+use RuntimeException;
+use SplFileInfo;
+use Yiisoft\Files\FileHelper;
+
+use function dirname;
+use function file_exists;
+use function fclose;
+use function fopen;
+use function is_dir;
+use function is_file;
+use function sprintf;
+use function strlen;
+use function stream_copy_to_stream;
+use function substr;
+
+final readonly class ThemeInitializer
+{
+    public function initialize(Theme $theme, string $targetDir): int
+    {
+        if (!is_dir($theme->path)) {
+            throw new RuntimeException(sprintf('Theme source directory "%s" was not found.', $theme->path));
+        }
+
+        if (is_file($targetDir)) {
+            throw new RuntimeException(sprintf('Target path "%s" is a file.', $targetDir));
+        }
+
+        $files = $this->files($theme, $targetDir);
+
+        foreach ($files as $sourcePath => $targetPath) {
+            if (file_exists($targetPath)) {
+                throw new RuntimeException(sprintf('Target file already exists: "%s".', $targetPath));
+            }
+        }
+
+        foreach ($files as $sourcePath => $targetPath) {
+            FileHelper::ensureDirectory(dirname($targetPath), 0o755);
+
+            $this->copyWithoutOverwrite($sourcePath, $targetPath);
+        }
+
+        return count($files);
+    }
+
+    private function copyWithoutOverwrite(string $sourcePath, string $targetPath): void
+    {
+        $source = @fopen($sourcePath, 'rb');
+        if ($source === false) {
+            throw new RuntimeException(sprintf('Unable to copy "%s" to "%s".', $sourcePath, $targetPath));
+        }
+
+        try {
+            $target = @fopen($targetPath, 'xb');
+            if ($target === false) {
+                if (file_exists($targetPath)) {
+                    throw new RuntimeException(sprintf('Target file already exists: "%s".', $targetPath));
+                }
+
+                throw new RuntimeException(sprintf('Unable to copy "%s" to "%s".', $sourcePath, $targetPath));
+            }
+
+            try {
+                if (stream_copy_to_stream($source, $target) === false) {
+                    throw new RuntimeException(sprintf('Unable to copy "%s" to "%s".', $sourcePath, $targetPath));
+                }
+            } finally {
+                fclose($target);
+            }
+        } finally {
+            fclose($source);
+        }
+    }
+
+    /**
+     * @return array<string, string> source path => target path
+     */
+    private function files(Theme $theme, string $targetDir): array
+    {
+        $files = [];
+        $iterator = new RecursiveIteratorIterator(
+            new RecursiveDirectoryIterator($theme->path, FilesystemIterator::SKIP_DOTS),
+        );
+
+        foreach ($iterator as $item) {
+            /** @var SplFileInfo $item */
+            if (!$item->isFile()) {
+                continue;
+            }
+
+            $sourcePath = $item->getPathname();
+            $relativePath = substr($sourcePath, strlen($theme->path) + 1);
+            $files[$sourcePath] = $targetDir . '/' . $relativePath;
+        }
+
+        return $files;
+    }
+}

--- a/src/Console/BuildCommand.php
+++ b/src/Console/BuildCommand.php
@@ -15,6 +15,7 @@ use YiiPress\Build\ContentAssetCopier;
 use YiiPress\Build\DateArchiveWriter;
 use YiiPress\Build\NotFoundPageWriter;
 use YiiPress\Build\NavigationPager;
+use YiiPress\Build\ProjectThemeDiscovery;
 use YiiPress\Build\RedirectPageWriter;
 use YiiPress\Build\RobotsTxtGenerator;
 use YiiPress\Build\SearchIndexGenerator;
@@ -218,6 +219,8 @@ final class BuildCommand extends Command
             $output->writeln("<error>Content directory not found: $contentDir</error>");
             return ExitCode::DATAERR;
         }
+
+        (new ProjectThemeDiscovery())->register($this->themeRegistry, $rootPath . '/themes');
 
         $localTemplatesDir = $contentDir . '/templates';
         if (is_dir($localTemplatesDir)) {

--- a/src/Console/ThemeInitCommand.php
+++ b/src/Console/ThemeInitCommand.php
@@ -1,0 +1,160 @@
+<?php
+
+declare(strict_types=1);
+
+namespace YiiPress\Console;
+
+use RuntimeException;
+use Symfony\Component\Console\Attribute\AsCommand;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Output\OutputInterface;
+use YiiPress\Build\ThemeInitializer;
+use YiiPress\Build\ThemeRegistry;
+use Yiisoft\Yii\Console\ExitCode;
+
+use function basename;
+use function file_get_contents;
+use function file_put_contents;
+use function is_file;
+use function preg_match;
+use function preg_replace;
+use function sprintf;
+use function str_ends_with;
+use function str_starts_with;
+use function str_replace;
+
+#[AsCommand(
+    name: 'theme:init',
+    description: 'Initializes editable theme files in the project',
+)]
+final class ThemeInitCommand extends Command
+{
+    private const string DEFAULT_CONTENT_DIR = 'content';
+    private const string DEFAULT_TARGET_DIR = 'themes/custom';
+    private const string DEFAULT_THEME = 'minimal';
+
+    public function __construct(
+        private readonly string $rootPath,
+        private readonly ThemeRegistry $themeRegistry,
+        private readonly ThemeInitializer $themeInitializer = new ThemeInitializer(),
+    ) {
+        parent::__construct();
+    }
+
+    protected function configure(): void
+    {
+        $this->addArgument(
+            'target-dir',
+            InputArgument::OPTIONAL,
+            'Directory to initialize theme files in',
+            self::DEFAULT_TARGET_DIR,
+        );
+        $this->addOption(
+            'theme',
+            't',
+            InputOption::VALUE_REQUIRED,
+            'Bundled theme name to use as the source',
+            self::DEFAULT_THEME,
+        );
+        $this->addOption(
+            'content-dir',
+            'c',
+            InputOption::VALUE_REQUIRED,
+            'Path to the content directory containing config.yaml',
+            self::DEFAULT_CONTENT_DIR,
+        );
+    }
+
+    protected function execute(InputInterface $input, OutputInterface $output): int
+    {
+        /** @var string $targetDirArgument */
+        $targetDirArgument = $input->getArgument('target-dir');
+        $targetDir = $this->resolvePath($targetDirArgument, $this->rootPath);
+        $projectThemeName = basename(str_replace('\\', '/', $targetDir));
+
+        /** @var string $themeName */
+        $themeName = $input->getOption('theme');
+
+        /** @var string $contentDirOption */
+        $contentDirOption = $input->getOption('content-dir');
+        $configPath = $this->resolvePath($contentDirOption, $this->rootPath) . '/config.yaml';
+
+        try {
+            if (!is_file($configPath)) {
+                throw new RuntimeException(sprintf('Content config file "%s" was not found.', $configPath));
+            }
+
+            if (!$this->isValidProjectThemeName($projectThemeName)) {
+                throw new RuntimeException(sprintf(
+                    'Target directory name "%s" is not a valid project theme name.',
+                    $projectThemeName,
+                ));
+            }
+
+            $theme = $this->themeRegistry->get($themeName);
+            $copied = $this->themeInitializer->initialize($theme, $targetDir);
+            $this->configureTheme($configPath, $projectThemeName);
+        } catch (RuntimeException $e) {
+            $output->writeln('<error>' . $e->getMessage() . '</error>');
+            return ExitCode::DATAERR;
+        }
+
+        $output->writeln(sprintf(
+            'Copied <info>%d</info> theme files from <comment>%s</comment> to <info>%s</info>.',
+            $copied,
+            $themeName,
+            $targetDir,
+        ));
+        $output->writeln(sprintf('Configured <info>%s</info> to use theme <comment>%s</comment>.', $configPath, $projectThemeName));
+
+        return ExitCode::OK;
+    }
+
+    private function configureTheme(string $configPath, string $themeName): void
+    {
+        $config = file_get_contents($configPath);
+        if ($config === false) {
+            throw new RuntimeException(sprintf('Unable to read content config file "%s".', $configPath));
+        }
+
+        $themeLine = sprintf('theme: "%s"', $themeName);
+        if (preg_match('/^theme:\s*.*$/m', $config) === 1) {
+            $updatedConfig = preg_replace('/^theme:\s*.*$/m', $themeLine, $config, 1);
+            if ($updatedConfig === null) {
+                throw new RuntimeException(sprintf('Unable to update content config file "%s".', $configPath));
+            }
+        } else {
+            $updatedConfig = $config;
+            if ($updatedConfig !== '' && !str_ends_with($updatedConfig, "\n")) {
+                $updatedConfig .= "\n";
+            }
+
+            $updatedConfig .= $themeLine . "\n";
+        }
+
+        if (file_put_contents($configPath, $updatedConfig) === false) {
+            throw new RuntimeException(sprintf('Unable to write content config file "%s".', $configPath));
+        }
+    }
+
+    private function isValidProjectThemeName(string $name): bool
+    {
+        return preg_match('/^[A-Za-z0-9][A-Za-z0-9_-]*$/D', $name) === 1;
+    }
+
+    private function resolvePath(string $path, string $rootPath): string
+    {
+        if (
+            str_starts_with($path, '/')
+            || str_starts_with($path, '\\')
+            || preg_match('/^[A-Za-z]:[\/\\\\]/D', $path) === 1
+        ) {
+            return $path;
+        }
+
+        return $rootPath . '/' . $path;
+    }
+}

--- a/tests/Unit/Build/ProjectThemeDiscoveryTest.php
+++ b/tests/Unit/Build/ProjectThemeDiscoveryTest.php
@@ -1,0 +1,100 @@
+<?php
+
+declare(strict_types=1);
+
+namespace YiiPress\Tests\Unit\Build;
+
+use FilesystemIterator;
+use PHPUnit\Framework\TestCase;
+use RecursiveDirectoryIterator;
+use RecursiveIteratorIterator;
+use SplFileInfo;
+use YiiPress\Build\ProjectThemeDiscovery;
+use YiiPress\Build\Theme;
+use YiiPress\Build\ThemeRegistry;
+
+use function PHPUnit\Framework\assertCount;
+use function PHPUnit\Framework\assertSame;
+
+final class ProjectThemeDiscoveryTest extends TestCase
+{
+    private string $rootDir;
+
+    protected function setUp(): void
+    {
+        $this->rootDir = sys_get_temp_dir() . '/yiipress-project-themes-test-' . uniqid();
+        mkdir($this->rootDir . '/themes', 0o755, true);
+    }
+
+    protected function tearDown(): void
+    {
+        $this->removeDir($this->rootDir);
+    }
+
+    public function testDiscoversProjectThemesInDeterministicOrder(): void
+    {
+        mkdir($this->rootDir . '/themes/zeta');
+        mkdir($this->rootDir . '/themes/alpha');
+        mkdir($this->rootDir . '/themes/docs_theme');
+        file_put_contents($this->rootDir . '/themes/readme.md', 'not a theme');
+
+        $themes = (new ProjectThemeDiscovery())->discover($this->rootDir . '/themes');
+
+        assertSame(['alpha', 'docs_theme', 'zeta'], array_map(static fn (Theme $theme): string => $theme->name, $themes));
+    }
+
+    public function testSkipsInvalidThemeNames(): void
+    {
+        mkdir($this->rootDir . '/themes/good-theme');
+        mkdir($this->rootDir . '/themes/.hidden');
+        mkdir($this->rootDir . '/themes/bad.name');
+
+        $themes = (new ProjectThemeDiscovery())->discover($this->rootDir . '/themes');
+
+        assertCount(1, $themes);
+        assertSame('good-theme', $themes[0]->name);
+    }
+
+    public function testReturnsEmptyListWhenThemesDirectoryIsMissing(): void
+    {
+        $themes = (new ProjectThemeDiscovery())->discover($this->rootDir . '/missing');
+
+        assertSame([], $themes);
+    }
+
+    public function testRegistersThemesWithoutOverwritingExistingNames(): void
+    {
+        mkdir($this->rootDir . '/themes/minimal');
+        mkdir($this->rootDir . '/themes/fancy');
+        $registry = new ThemeRegistry();
+        $registry->register(new Theme('minimal', '/built-in/minimal'));
+
+        $registered = (new ProjectThemeDiscovery())->register($registry, $this->rootDir . '/themes');
+
+        assertSame(1, $registered);
+        assertSame('/built-in/minimal', $registry->get('minimal')->path);
+        assertSame($this->rootDir . '/themes/fancy', $registry->get('fancy')->path);
+    }
+
+    private function removeDir(string $path): void
+    {
+        if (!is_dir($path)) {
+            return;
+        }
+
+        $iterator = new RecursiveIteratorIterator(
+            new RecursiveDirectoryIterator($path, FilesystemIterator::SKIP_DOTS),
+            RecursiveIteratorIterator::CHILD_FIRST,
+        );
+        foreach ($iterator as $item) {
+            /** @var SplFileInfo $item */
+            if ($item->isDir()) {
+                rmdir($item->getPathname());
+            } else {
+                unlink($item->getPathname());
+            }
+        }
+
+        rmdir($path);
+    }
+}

--- a/tests/Unit/Build/ThemeInitializerTest.php
+++ b/tests/Unit/Build/ThemeInitializerTest.php
@@ -1,0 +1,99 @@
+<?php
+
+declare(strict_types=1);
+
+namespace YiiPress\Tests\Unit\Build;
+
+use FilesystemIterator;
+use PHPUnit\Framework\TestCase;
+use RecursiveDirectoryIterator;
+use RecursiveIteratorIterator;
+use RuntimeException;
+use SplFileInfo;
+use YiiPress\Build\Theme;
+use YiiPress\Build\ThemeInitializer;
+
+use function file_get_contents;
+use function file_put_contents;
+use function is_dir;
+use function mkdir;
+use function PHPUnit\Framework\assertSame;
+use function rmdir;
+use function sys_get_temp_dir;
+use function unlink;
+use function uniqid;
+
+final class ThemeInitializerTest extends TestCase
+{
+    private string $rootDir;
+
+    protected function setUp(): void
+    {
+        $this->rootDir = sys_get_temp_dir() . '/yiipress-theme-initializer-test-' . uniqid();
+        mkdir($this->rootDir . '/source/partials', 0o755, true);
+        mkdir($this->rootDir . '/source/assets', 0o755, true);
+        file_put_contents($this->rootDir . '/source/entry.php', 'entry');
+        file_put_contents($this->rootDir . '/source/partials/head.php', 'head');
+        file_put_contents($this->rootDir . '/source/assets/style.css', 'style');
+    }
+
+    protected function tearDown(): void
+    {
+        $this->removeDir($this->rootDir);
+    }
+
+    public function testInitializesThemeFilesRecursively(): void
+    {
+        $copied = (new ThemeInitializer())->initialize(
+            new Theme('minimal', $this->rootDir . '/source'),
+            $this->rootDir . '/target',
+        );
+
+        assertSame(3, $copied);
+        assertSame('entry', file_get_contents($this->rootDir . '/target/entry.php'));
+        assertSame('head', file_get_contents($this->rootDir . '/target/partials/head.php'));
+        assertSame('style', file_get_contents($this->rootDir . '/target/assets/style.css'));
+    }
+
+    public function testDoesNotOverwriteExistingFiles(): void
+    {
+        mkdir($this->rootDir . '/target');
+        file_put_contents($this->rootDir . '/target/entry.php', 'existing');
+
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessage('Target file already exists');
+
+        try {
+            (new ThemeInitializer())->initialize(
+                new Theme('minimal', $this->rootDir . '/source'),
+                $this->rootDir . '/target',
+            );
+        } finally {
+            assertSame('existing', file_get_contents($this->rootDir . '/target/entry.php'));
+            self::assertFileDoesNotExist($this->rootDir . '/target/partials/head.php');
+            self::assertFileDoesNotExist($this->rootDir . '/target/assets/style.css');
+        }
+    }
+
+    private function removeDir(string $path): void
+    {
+        if (!is_dir($path)) {
+            return;
+        }
+
+        $iterator = new RecursiveIteratorIterator(
+            new RecursiveDirectoryIterator($path, FilesystemIterator::SKIP_DOTS),
+            RecursiveIteratorIterator::CHILD_FIRST,
+        );
+        foreach ($iterator as $item) {
+            /** @var SplFileInfo $item */
+            if ($item->isDir()) {
+                rmdir($item->getPathname());
+            } else {
+                unlink($item->getPathname());
+            }
+        }
+
+        rmdir($path);
+    }
+}

--- a/tests/Unit/Console/BuildCommandTest.php
+++ b/tests/Unit/Console/BuildCommandTest.php
@@ -143,6 +143,55 @@ final class BuildCommandTest extends TestCase
         assertFileExists($outputDir . '/index/index.html');
     }
 
+    public function testBuildAutoRegistersProjectThemes(): void
+    {
+        $tempDir = sys_get_temp_dir() . '/yiipress-build-project-theme-test-' . uniqid();
+        $contentDir = $tempDir . '/content';
+        $outputDir = $tempDir . '/output';
+        $themeDir = $tempDir . '/themes/docs';
+        mkdir($contentDir, 0o755, true);
+        mkdir($themeDir, 0o755, true);
+        $this->tempContentDirs[] = $tempDir;
+
+        file_put_contents($contentDir . '/config.yaml', "title: Themed Site\nbase_url: https://example.com\nlanguages: [en]\ntheme: docs\n");
+        file_put_contents($contentDir . '/index.md', "---\ntitle: Home\npermalink: /\n---\n\nProject theme content.\n");
+        file_put_contents(
+            $themeDir . '/entry.php',
+            <<<'PHP'
+<?php
+declare(strict_types=1);
+?>
+<html><body class="docs-theme"><?= $content ?></body></html>
+PHP,
+        );
+
+        $themeRegistry = new ThemeRegistry();
+        $themeRegistry->register(new Theme('minimal', dirname(__DIR__, 3) . '/themes/minimal'));
+        $templateResolver = new TemplateResolver($themeRegistry);
+        $pipeline = new ContentProcessorPipeline(new MarkdownProcessor(new MarkdownRenderer()));
+        $command = new BuildCommand(
+            rootPath: $tempDir,
+            contentPipeline: $pipeline,
+            feedPipeline: new ContentProcessorPipeline(new MarkdownProcessor(new MarkdownRenderer())),
+            themeRegistry: $themeRegistry,
+            templateResolver: $templateResolver,
+        );
+        $tester = new CommandTester($command);
+
+        $exitCode = $tester->execute([
+            '--content-dir' => $contentDir,
+            '--output-dir' => $outputDir,
+            '--workers' => '1',
+            '--no-cache' => true,
+        ]);
+
+        assertSame(0, $exitCode, $tester->getDisplay());
+        $html = file_get_contents($outputDir . '/index.html');
+        assertNotFalse($html);
+        assertStringContainsString('class="docs-theme"', $html);
+        assertStringContainsString('Project theme content.', $html);
+    }
+
     public function testBuildReportsInvalidSiteConfigWithoutTrace(): void
     {
         $tempDir = sys_get_temp_dir() . '/yiipress-build-invalid-config-test-' . uniqid();

--- a/tests/Unit/Console/BuildCommandTest.php
+++ b/tests/Unit/Console/BuildCommandTest.php
@@ -148,12 +148,12 @@ final class BuildCommandTest extends TestCase
         $tempDir = sys_get_temp_dir() . '/yiipress-build-project-theme-test-' . uniqid();
         $contentDir = $tempDir . '/content';
         $outputDir = $tempDir . '/output';
-        $themeDir = $tempDir . '/themes/docs';
+        $themeDir = $tempDir . '/themes/brand';
         mkdir($contentDir, 0o755, true);
         mkdir($themeDir, 0o755, true);
         $this->tempContentDirs[] = $tempDir;
 
-        file_put_contents($contentDir . '/config.yaml', "title: Themed Site\nbase_url: https://example.com\nlanguages: [en]\ntheme: docs\n");
+        file_put_contents($contentDir . '/config.yaml', "title: Themed Site\nbase_url: https://example.com\nlanguages: [en]\ntheme: brand\n");
         file_put_contents($contentDir . '/index.md', "---\ntitle: Home\npermalink: /\n---\n\nProject theme content.\n");
         file_put_contents(
             $themeDir . '/entry.php',
@@ -161,7 +161,7 @@ final class BuildCommandTest extends TestCase
 <?php
 declare(strict_types=1);
 ?>
-<html><body class="docs-theme"><?= $content ?></body></html>
+<html><body class="brand-theme"><?= $content ?></body></html>
 PHP,
         );
 
@@ -188,7 +188,7 @@ PHP,
         assertSame(0, $exitCode, $tester->getDisplay());
         $html = file_get_contents($outputDir . '/index.html');
         assertNotFalse($html);
-        assertStringContainsString('class="docs-theme"', $html);
+        assertStringContainsString('class="brand-theme"', $html);
         assertStringContainsString('Project theme content.', $html);
     }
 

--- a/tests/Unit/Console/ThemeInitCommandTest.php
+++ b/tests/Unit/Console/ThemeInitCommandTest.php
@@ -1,0 +1,168 @@
+<?php
+
+declare(strict_types=1);
+
+namespace YiiPress\Tests\Unit\Console;
+
+use FilesystemIterator;
+use PHPUnit\Framework\TestCase;
+use RecursiveDirectoryIterator;
+use RecursiveIteratorIterator;
+use SplFileInfo;
+use Symfony\Component\Console\Tester\CommandTester;
+use YiiPress\Build\Theme;
+use YiiPress\Build\ThemeRegistry;
+use YiiPress\Console\ThemeInitCommand;
+use Yiisoft\Yii\Console\ExitCode;
+
+use function file_get_contents;
+use function file_put_contents;
+use function is_dir;
+use function mkdir;
+use function PHPUnit\Framework\assertSame;
+use function rmdir;
+use function sys_get_temp_dir;
+use function unlink;
+use function uniqid;
+
+final class ThemeInitCommandTest extends TestCase
+{
+    private string $rootDir;
+
+    protected function setUp(): void
+    {
+        $this->rootDir = sys_get_temp_dir() . '/yiipress-theme-init-command-test-' . uniqid();
+        mkdir($this->rootDir . '/source', 0o755, true);
+        mkdir($this->rootDir . '/content');
+        file_put_contents($this->rootDir . '/source/entry.php', 'entry');
+        file_put_contents($this->rootDir . '/content/config.yaml', "title: Test\nlanguages: [en]\n");
+    }
+
+    protected function tearDown(): void
+    {
+        $this->removeDir($this->rootDir);
+    }
+
+    public function testInitializesMinimalThemeIntoDefaultCustomDirectory(): void
+    {
+        $tester = new CommandTester(new ThemeInitCommand($this->rootDir, $this->registry()));
+
+        $exitCode = $tester->execute([]);
+
+        assertSame(ExitCode::OK, $exitCode);
+        assertSame('entry', file_get_contents($this->rootDir . '/themes/custom/entry.php'));
+        assertSame("title: Test\nlanguages: [en]\ntheme: \"custom\"\n", file_get_contents($this->rootDir . '/content/config.yaml'));
+        self::assertStringContainsString('themes/custom', $tester->getDisplay());
+        self::assertStringContainsString('theme custom', $tester->getDisplay());
+    }
+
+    public function testInitializesThemeIntoCustomDirectory(): void
+    {
+        $tester = new CommandTester(new ThemeInitCommand($this->rootDir, $this->registry()));
+
+        $exitCode = $tester->execute(['target-dir' => 'themes/brand']);
+
+        assertSame(ExitCode::OK, $exitCode);
+        assertSame('entry', file_get_contents($this->rootDir . '/themes/brand/entry.php'));
+        assertSame("title: Test\nlanguages: [en]\ntheme: \"brand\"\n", file_get_contents($this->rootDir . '/content/config.yaml'));
+    }
+
+    public function testInitializesThemeIntoAbsoluteDirectory(): void
+    {
+        $absoluteTarget = $this->rootDir . '/abs-target';
+        $tester = new CommandTester(new ThemeInitCommand($this->rootDir, $this->registry()));
+
+        $exitCode = $tester->execute(['target-dir' => $absoluteTarget]);
+
+        assertSame(ExitCode::OK, $exitCode);
+        assertSame('entry', file_get_contents($absoluteTarget . '/entry.php'));
+        assertSame("title: Test\nlanguages: [en]\ntheme: \"abs-target\"\n", file_get_contents($this->rootDir . '/content/config.yaml'));
+    }
+
+    public function testReplacesExistingThemeInContentConfig(): void
+    {
+        file_put_contents($this->rootDir . '/content/config.yaml', "title: Test\ntheme: minimal\nlanguages: [en]\n");
+        $tester = new CommandTester(new ThemeInitCommand($this->rootDir, $this->registry()));
+
+        $exitCode = $tester->execute([]);
+
+        assertSame(ExitCode::OK, $exitCode);
+        assertSame("title: Test\ntheme: \"custom\"\nlanguages: [en]\n", file_get_contents($this->rootDir . '/content/config.yaml'));
+    }
+
+    public function testConfiguresCustomContentDirectory(): void
+    {
+        mkdir($this->rootDir . '/site-content');
+        file_put_contents($this->rootDir . '/site-content/config.yaml', "title: Site\n");
+        $tester = new CommandTester(new ThemeInitCommand($this->rootDir, $this->registry()));
+
+        $exitCode = $tester->execute(['--content-dir' => 'site-content']);
+
+        assertSame(ExitCode::OK, $exitCode);
+        assertSame("title: Site\ntheme: \"custom\"\n", file_get_contents($this->rootDir . '/site-content/config.yaml'));
+        assertSame("title: Test\nlanguages: [en]\n", file_get_contents($this->rootDir . '/content/config.yaml'));
+    }
+
+    public function testDoesNotCopyFilesWhenContentConfigIsMissing(): void
+    {
+        unlink($this->rootDir . '/content/config.yaml');
+        $tester = new CommandTester(new ThemeInitCommand($this->rootDir, $this->registry()));
+
+        $exitCode = $tester->execute([]);
+
+        assertSame(ExitCode::DATAERR, $exitCode);
+        self::assertFileDoesNotExist($this->rootDir . '/themes/custom/entry.php');
+        self::assertStringContainsString('Content config file', $tester->getDisplay());
+    }
+
+    public function testDoesNotCopyFilesWhenTargetThemeNameIsInvalid(): void
+    {
+        $tester = new CommandTester(new ThemeInitCommand($this->rootDir, $this->registry()));
+
+        $exitCode = $tester->execute(['target-dir' => 'themes/.custom']);
+
+        assertSame(ExitCode::DATAERR, $exitCode);
+        self::assertFileDoesNotExist($this->rootDir . '/themes/.custom/entry.php');
+        self::assertStringContainsString('is not a valid project theme name', $tester->getDisplay());
+    }
+
+    public function testReturnsDataErrorForUnknownTheme(): void
+    {
+        $tester = new CommandTester(new ThemeInitCommand($this->rootDir, $this->registry()));
+
+        $exitCode = $tester->execute(['--theme' => 'missing']);
+
+        assertSame(ExitCode::DATAERR, $exitCode);
+        self::assertStringContainsString('Theme "missing" is not registered.', $tester->getDisplay());
+    }
+
+    private function registry(): ThemeRegistry
+    {
+        $registry = new ThemeRegistry();
+        $registry->register(new Theme('minimal', $this->rootDir . '/source'));
+
+        return $registry;
+    }
+
+    private function removeDir(string $path): void
+    {
+        if (!is_dir($path)) {
+            return;
+        }
+
+        $iterator = new RecursiveIteratorIterator(
+            new RecursiveDirectoryIterator($path, FilesystemIterator::SKIP_DOTS),
+            RecursiveIteratorIterator::CHILD_FIRST,
+        );
+        foreach ($iterator as $item) {
+            /** @var SplFileInfo $item */
+            if ($item->isDir()) {
+                rmdir($item->getPathname());
+            } else {
+                unlink($item->getPathname());
+            }
+        }
+
+        rmdir($path);
+    }
+}

--- a/tests/Unit/Packaging/ConfigurationPackagingTest.php
+++ b/tests/Unit/Packaging/ConfigurationPackagingTest.php
@@ -10,6 +10,7 @@ use YiiPress\Console\InitCommand;
 use YiiPress\Console\ImportCommand;
 use YiiPress\Console\NewCommand;
 use YiiPress\Console\ServeCommand;
+use YiiPress\Console\ThemeInitCommand;
 use YiiPress\Build\PharArchiveFilter;
 use YiiPress\Build\PhpDocStripper;
 use PHPUnit\Framework\Attributes\Test;
@@ -57,6 +58,7 @@ final class ConfigurationPackagingTest extends TestCase
             assertSame($workingDirectory, $contentPipelineConfiguration[CleanCommand::class]['__construct()']['rootPath']);
             assertSame($workingDirectory, $contentPipelineConfiguration[InitCommand::class]['__construct()']['rootPath']);
             assertSame($workingDirectory, $contentPipelineConfiguration[NewCommand::class]['__construct()']['rootPath']);
+            assertSame($workingDirectory, $contentPipelineConfiguration[ThemeInitCommand::class]['__construct()']['rootPath']);
             assertSame($workingDirectory, $importerConfiguration[ImportCommand::class]['__construct()']['rootPath']);
         } finally {
             chdir($previousDirectory);
@@ -72,6 +74,7 @@ final class ConfigurationPackagingTest extends TestCase
         /** @psalm-suppress RedundantCondition */
         assertSame(ServeCommand::class, $commands['serve']);
         assertSame(InitCommand::class, $commands['init']);
+        assertSame(ThemeInitCommand::class, $commands['theme:init']);
     }
 
     #[Test]
@@ -309,7 +312,7 @@ final class ConfigurationPackagingTest extends TestCase
     }
 
     #[Test]
-    public function buildActionInstallsBinaryOutsideCheckoutByDefault(): void
+    public function buildActionInitializesBinaryOutsideCheckoutByDefault(): void
     {
         $action = file_get_contents(dirname(__DIR__, 3) . '/.github/actions/build/action.yml');
         self::assertIsString($action);
@@ -641,7 +644,7 @@ PHP;
     }
 
     #[Test]
-    public function staticPackageInstallsRustTargetForHighlighterToolchain(): void
+    public function staticPackageInitializesRustTargetForHighlighterToolchain(): void
     {
         $dockerfile = file_get_contents(dirname(__DIR__, 3) . '/docker/Dockerfile');
         $windowsScript = file_get_contents(dirname(__DIR__, 3) . '/build/package-windows.ps1');


### PR DESCRIPTION
## Summary
- discover valid project themes from `themes/<name>/` during builds
- keep already-registered theme names, including built-ins, from being overwritten
- add `theme:init` to initialize editable bundled theme files in a project, defaulting to `themes/custom`
- configure `content/config.yaml` to use the initialized theme, with `--content-dir` for custom content paths
- document the binary-friendly theme init path and update the roadmap

## Tests
- `make test -- --filter ProjectThemeDiscoveryTest`
- `make test -- --filter testBuildAutoRegistersProjectThemes`
- `make test -- --filter ThemeInitializerTest`
- `make test -- --filter ThemeInitCommandTest`
- `make test -- --filter ConfigurationPackagingTest`
- `make psalm`
- `make test`
- `BENCH_FILTER=ProjectThemeDiscoveryBench make bench`