### PR TITLE
Namespace copied theme assets

### DIFF
--- a/benchmarks/ThemeAssetCopierBench.php
+++ b/benchmarks/ThemeAssetCopierBench.php
@@ -1,0 +1,76 @@
+<?php
+
+declare(strict_types=1);
+
+namespace YiiPress\Benchmarks;
+
+use PhpBench\Attributes\AfterMethods;
+use PhpBench\Attributes\BeforeMethods;
+use PhpBench\Attributes\Iterations;
+use PhpBench\Attributes\Revs;
+use PhpBench\Attributes\Warmup;
+use YiiPress\Build\Theme;
+use YiiPress\Build\ThemeAssetCopier;
+use YiiPress\Build\ThemeRegistry;
+
+#[BeforeMethods('setUp')]
+#[AfterMethods('tearDown')]
+final class ThemeAssetCopierBench
+{
+    private string $rootDir;
+    private ThemeRegistry $registry;
+    private ThemeAssetCopier $copier;
+
+    public function setUp(): void
+    {
+        $this->rootDir = sys_get_temp_dir() . '/yiipress-theme-assets-bench-' . uniqid();
+        mkdir($this->rootDir . '/output', 0o755, true);
+
+        $this->registry = new ThemeRegistry();
+        for ($theme = 1; $theme <= 5; $theme++) {
+            $themeDir = $this->rootDir . '/theme-' . $theme;
+            mkdir($themeDir . '/assets/fonts', 0o755, true);
+            for ($asset = 1; $asset <= 10; $asset++) {
+                file_put_contents($themeDir . '/assets/asset-' . $asset . '.css', '.a{color:red}');
+                file_put_contents($themeDir . '/assets/fonts/font-' . $asset . '.woff2', 'font');
+            }
+            $this->registry->register(new Theme('theme-' . $theme, $themeDir));
+        }
+
+        $this->copier = new ThemeAssetCopier();
+    }
+
+    public function tearDown(): void
+    {
+        $this->removeDir($this->rootDir);
+    }
+
+    #[Revs(20)]
+    #[Iterations(3)]
+    #[Warmup(1)]
+    public function benchMappings(): void
+    {
+        $this->copier->mappings($this->registry);
+    }
+
+    private function removeDir(string $path): void
+    {
+        if (!is_dir($path)) {
+            return;
+        }
+
+        $iterator = new \RecursiveIteratorIterator(
+            new \RecursiveDirectoryIterator($path, \FilesystemIterator::SKIP_DOTS),
+            \RecursiveIteratorIterator::CHILD_FIRST,
+        );
+        foreach ($iterator as $item) {
+            if ($item->isDir()) {
+                rmdir($item->getPathname());
+            } else {
+                unlink($item->getPathname());
+            }
+        }
+
+        rmdir($path);
+    }
+}

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -206,7 +206,7 @@ assets:
 
 When enabled, YiiPress renames copied assets to include a content hash, for example:
 
-- `assets/theme/style.css` → `assets/theme/style.4f8d2d5b1c3a.css`
+- `assets/themes/minimal/style.css` → `assets/themes/minimal/style.4f8d2d5b1c3a.css`
 - `blog/assets/hero.png` → `blog/assets/hero.a12b34c56d78.png`
 
 Built-in templates use the fingerprinted URLs automatically, and existing hardcoded `src` / `href`

--- a/docs/engine.md
+++ b/docs/engine.md
@@ -212,4 +212,4 @@ return [
 ];
 ```
 
-For binary users, install a reusable theme as `themes/fancy/` and set `theme: fancy` in `content/config.yaml`. Template resolution checks the active theme first, then falls back through registered themes. This lets a project override one template while keeping the rest of the bundled theme.
+For binary users, install a reusable theme as `themes/fancy/` and set `theme: fancy` in `content/config.yaml`. Template resolution checks the active theme first, then falls back through registered themes. This lets a project override one template while keeping the rest of the bundled theme. Theme assets are copied under `assets/themes/<theme>/`, and templates should use `$themeAsset('file.css')` so installed themes do not overwrite each other's files.

--- a/docs/templates.md
+++ b/docs/templates.md
@@ -360,24 +360,34 @@ Partials are reusable template fragments stored in a `partials/` subdirectory of
 
 ## Asset helper
 
-Templates and partials should use `Asset::url()` to resolve the final public URL of a copied asset:
+Templates and partials should use `$themeAsset()` for files in the active theme's `assets/` directory:
+
+```php
+<link rel="stylesheet" href="<?= $h($themeAsset('style.css')) ?>">
+<script src="<?= $h($themeAsset('search.js')) ?>" defer></script>
+```
+
+This is especially useful when `assets.fingerprint: true` is enabled in `content/config.yaml`.
+In that mode, `$themeAsset('style.css')` returns the hashed output path rather than the logical one.
+
+Theme assets are copied to a theme-specific namespace:
+
+- `assets/themes/<theme>/style.css`
+- `assets/themes/<theme>/search.js`
+
+For compatibility, YiiPress also writes `assets/theme/...` aliases for the first registered theme. New templates should use `$themeAsset()` so installed themes cannot overwrite each other's asset files.
+
+For non-theme assets, use `Asset::url()` with a logical build-relative path:
 
 ```php
 <?php
 
 use YiiPress\Build\Asset;
 ?>
-<link rel="stylesheet" href="<?= $h(Asset::url('assets/theme/style.css', $rootPath, $assetManifest)) ?>">
-<script src="<?= $h(Asset::url('assets/theme/search.js', $rootPath, $assetManifest)) ?>" defer></script>
+<link rel="stylesheet" href="<?= $h(Asset::url('assets/plugins/mermaid.css', $rootPath, $assetManifest)) ?>">
 ```
 
-This is especially useful when `assets.fingerprint: true` is enabled in `content/config.yaml`.
-In that mode, `Asset::url('assets/theme/style.css', $rootPath, $assetManifest)` returns the hashed output path rather than the logical one.
-
-The helper accepts logical build-relative paths such as:
-
-- `assets/theme/style.css`
-- `assets/plugins/mermaid.css`
+That helper accepts logical build-relative paths such as `assets/plugins/mermaid.css`.
 
 ### Creating a partial
 
@@ -390,14 +400,14 @@ Create a PHP file in `themes/<name>/partials/`:
  * @var string $rootPath
  * @var AssetFingerprintManifest|null $assetManifest
  * @var Closure(string, int, ?string, bool): string $h
+ * @var Closure(string): string $themeAsset
  */
 
-use YiiPress\Build\Asset;
 ?>
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <title><?= $h($title) ?></title>
-    <link rel="stylesheet" href="<?= $h(Asset::url('assets/theme/style.css', $rootPath, $assetManifest)) ?>">
+    <link rel="stylesheet" href="<?= $h($themeAsset('style.css')) ?>">
 ```
 
 ### Variable isolation

--- a/roadmap.md
+++ b/roadmap.md
@@ -66,6 +66,7 @@
 
 - [x] Theme system — installable/distributable themes
 - [x] Auto-register project themes from `themes/<name>/` for binary users
+- [x] Namespaced theme assets for installable themes
 - [x] Template partials/includes support
 - [x] Template helper functions documentation
 - [x] Site data files exposed to templates (`content/data/*.yaml` or `.yml` as `$data`)

--- a/src/Build/Asset.php
+++ b/src/Build/Asset.php
@@ -24,4 +24,17 @@ final class Asset
 
         return $resolved;
     }
+
+    public static function themeUrl(
+        string $path,
+        string $themeName,
+        string $rootPath = '',
+        ?AssetFingerprintManifest $assetManifest = null,
+    ): string {
+        if ($themeName === '') {
+            return self::url(ThemeAssetCopier::legacyLogicalPath($path), $rootPath, $assetManifest);
+        }
+
+        return self::url(ThemeAssetCopier::logicalPath($themeName, $path), $rootPath, $assetManifest);
+    }
 }

--- a/src/Build/EntryRenderer.php
+++ b/src/Build/EntryRenderer.php
@@ -24,6 +24,7 @@ use function date_default_timezone_get;
 use function dirname;
 use function filemtime;
 use function hash;
+use function ltrim;
 use function strlen;
 
 final class EntryRenderer
@@ -223,6 +224,13 @@ final class EntryRenderer
             'partial' => $this->partialClosures[$themeName],
             'rootPath' => $rootPath,
             'assetManifest' => $this->assetManifest,
+            'themeName' => $themeName,
+            'themeAsset' => fn (string $path): string => Asset::themeUrl(
+                $path,
+                $this->templateResolver->resolveResourceThemeName('assets/' . ltrim($path, '/'), $themeName),
+                $rootPath,
+                $this->assetManifest,
+            ),
             'search' => $siteConfig->search !== null,
             'searchResults' => $siteConfig->search?->results ?? 10,
         ] + $uiViewData->toArray();

--- a/src/Build/PageTemplateRenderer.php
+++ b/src/Build/PageTemplateRenderer.php
@@ -6,6 +6,8 @@ namespace YiiPress\Build;
 
 use Closure;
 
+use function ltrim;
+
 final class PageTemplateRenderer
 {
     /** @var array<string, Closure> */
@@ -51,6 +53,13 @@ final class PageTemplateRenderer
 
         $variables['partial'] = $this->partialClosures[$this->themeName];
         $variables['assetManifest'] = $this->assetManifest;
+        $variables['themeName'] = $this->themeName;
+        $variables['themeAsset'] = fn (string $path): string => Asset::themeUrl(
+            $path,
+            $this->templateResolver->resolveResourceThemeName('assets/' . ltrim($path, '/'), $this->themeName),
+            $rootPath,
+            $this->assetManifest,
+        );
         $variables = TemplateHelpers::inject($variables);
 
         $html = ($this->templateClosures[$templatePath])($variables);

--- a/src/Build/TemplateContext.php
+++ b/src/Build/TemplateContext.php
@@ -6,6 +6,8 @@ namespace YiiPress\Build;
 
 use Closure;
 
+use function ltrim;
+
 final class TemplateContext
 {
     /** @var array<string, Closure> */
@@ -23,8 +25,15 @@ final class TemplateContext
     public function partial(string $name, array $variables = []): string
     {
         $variables['partial'] = $this->partial(...);
+        if (!isset($variables['themeName'])) {
+            $variables['themeName'] = $this->themeName;
+        }
         if (!isset($variables['assetManifest'])) {
             $variables['assetManifest'] = $this->assetManifest;
+        }
+        if (!isset($variables['themeAsset'])) {
+            $rootPath = (string) ($variables['rootPath'] ?? '');
+            $variables['themeAsset'] = fn (string $path): string => $this->themeAssetUrl($path, $rootPath);
         }
         $variables = TemplateHelpers::inject($variables);
 
@@ -48,5 +57,12 @@ final class TemplateContext
         }
 
         return new AssetUrlRewriter($this->assetManifest)->rewrite($html, $rootPath);
+    }
+
+    private function themeAssetUrl(string $path, string $rootPath): string
+    {
+        $ownerThemeName = $this->templateResolver->resolveResourceThemeName('assets/' . ltrim($path, '/'), $this->themeName);
+
+        return Asset::themeUrl($path, $ownerThemeName, $rootPath, $this->assetManifest);
     }
 }

--- a/src/Build/TemplateHelpers.php
+++ b/src/Build/TemplateHelpers.php
@@ -25,6 +25,18 @@ final class TemplateHelpers
             $variables['url'] = static fn (string $path): string => UrlResolver::sitePath($path, $rootPath);
         }
 
+        if (!isset($variables['themeAsset'])) {
+            $themeName = (string) ($variables['themeName'] ?? '');
+            $rootPath = (string) ($variables['rootPath'] ?? '');
+            $assetManifest = $variables['assetManifest'] ?? null;
+            $variables['themeAsset'] = static fn (string $path): string => Asset::themeUrl(
+                $path,
+                $themeName,
+                $rootPath,
+                $assetManifest instanceof AssetFingerprintManifest ? $assetManifest : null,
+            );
+        }
+
         $ui = $variables['ui'] ?? null;
         if ($ui instanceof UiText && !isset($variables['t'])) {
             $variables['t'] = static fn (string $key, array $params = []): string => $ui->get($key, $params);

--- a/src/Build/TemplateResolver.php
+++ b/src/Build/TemplateResolver.php
@@ -75,6 +75,33 @@ final class TemplateResolver
         return $this->resourceCache[$key] = null;
     }
 
+    public function resolveResourceThemeName(string $resourcePath, string $themeName = ''): string
+    {
+        if ($themeName !== '' && $this->themeRegistry->has($themeName)) {
+            $path = $this->themeRegistry->get($themeName)->path . '/' . $resourcePath;
+            if (is_file($path)) {
+                return $themeName;
+            }
+        }
+
+        foreach ($this->themeRegistry->all() as $theme) {
+            if ($theme->name === $themeName) {
+                continue;
+            }
+            $path = $theme->path . '/' . $resourcePath;
+            if (is_file($path)) {
+                return $theme->name;
+            }
+        }
+
+        return $themeName !== '' ? $themeName : $this->defaultThemeName();
+    }
+
+    public function defaultThemeName(): string
+    {
+        return $this->themeRegistry->all()[0]->name ?? '';
+    }
+
     /**
      * @return list<string>
      */

--- a/src/Build/ThemeAssetCopier.php
+++ b/src/Build/ThemeAssetCopier.php
@@ -11,7 +11,10 @@ use RuntimeException;
 use SplFileInfo;
 
 use function dirname;
+use function ltrim;
+use function preg_replace;
 use function strlen;
+use function trim;
 
 final class ThemeAssetCopier
 {
@@ -31,6 +34,24 @@ final class ThemeAssetCopier
             }
 
             $targetPath = $outputDir . '/' . $resolvedTarget;
+            $targetDir = dirname($targetPath);
+
+            if (!is_dir($targetDir) && !mkdir($targetDir, 0o755, true) && !is_dir($targetDir)) {
+                throw new RuntimeException(sprintf('Directory "%s" was not created', $targetDir));
+            }
+
+            if ($writer->writeIfChanged($sourcePath, $targetPath, $minify)) {
+                $copied++;
+            }
+        }
+
+        foreach ($this->legacyMappings($themeRegistry) as $sourcePath => $targetRelativePath) {
+            if ($noWrite) {
+                $copied++;
+                continue;
+            }
+
+            $targetPath = $outputDir . '/' . $targetRelativePath;
             $targetDir = dirname($targetPath);
 
             if (!is_dir($targetDir) && !mkdir($targetDir, 0o755, true) && !is_dir($targetDir)) {
@@ -69,10 +90,60 @@ final class ThemeAssetCopier
                 }
 
                 $relativePath = substr($item->getPathname(), strlen($assetsDir) + 1);
-                $assets[$item->getPathname()] = 'assets/theme/' . $relativePath;
+                $assets[$item->getPathname()] = self::logicalPath($theme->name, $relativePath);
             }
         }
 
         return $assets;
+    }
+
+    /**
+     * @return array<string, string>
+     */
+    public function legacyMappings(ThemeRegistry $themeRegistry): array
+    {
+        $theme = $themeRegistry->all()[0] ?? null;
+        if ($theme === null) {
+            return [];
+        }
+
+        $assetsDir = $theme->path . '/assets';
+        if (!is_dir($assetsDir)) {
+            return [];
+        }
+
+        $assets = [];
+        $iterator = new RecursiveIteratorIterator(
+            new RecursiveDirectoryIterator($assetsDir, FilesystemIterator::SKIP_DOTS),
+        );
+
+        foreach ($iterator as $item) {
+            /** @var SplFileInfo $item */
+            if (!$item->isFile()) {
+                continue;
+            }
+
+            $relativePath = substr($item->getPathname(), strlen($assetsDir) + 1);
+            $assets[$item->getPathname()] = self::legacyLogicalPath($relativePath);
+        }
+
+        return $assets;
+    }
+
+    public static function logicalPath(string $themeName, string $relativePath): string
+    {
+        return 'assets/themes/' . self::safeThemeName($themeName) . '/' . ltrim($relativePath, '/');
+    }
+
+    public static function legacyLogicalPath(string $relativePath): string
+    {
+        return 'assets/theme/' . ltrim($relativePath, '/');
+    }
+
+    private static function safeThemeName(string $themeName): string
+    {
+        $safeName = trim((string) preg_replace('/[^A-Za-z0-9_-]+/', '-', $themeName), '-');
+
+        return $safeName !== '' ? $safeName : 'theme';
     }
 }

--- a/tests/Unit/Build/EntryRendererTest.php
+++ b/tests/Unit/Build/EntryRendererTest.php
@@ -511,8 +511,8 @@ PHP);
         assertStringContainsString('id="search-close"', $html);
         assertStringContainsString('data-ui-attr-aria-label="search_close"', $html);
         assertStringContainsString('<span class="search-hint" aria-hidden="true">ESC</span>', $html);
-        assertStringContainsString('assets/theme/search.css', $html);
-        assertStringContainsString('assets/theme/search.js', $html);
+        assertStringContainsString('assets/themes/minimal/search.css', $html);
+        assertStringContainsString('assets/themes/minimal/search.js', $html);
     }
 
     public function testRenderHooksCanObserveAndModifyRenderedHtml(): void

--- a/tests/Unit/Build/NotFoundPageWriterTest.php
+++ b/tests/Unit/Build/NotFoundPageWriterTest.php
@@ -43,14 +43,14 @@ final class NotFoundPageWriterTest extends TestCase
         assertFileExists($filePath);
 
         $html = (string) file_get_contents($filePath);
-        assertStringContainsString('href="./assets/theme/style.css"', $html);
-        assertStringContainsString('src="./assets/theme/dark-mode.js"', $html);
-        assertStringContainsString('src="./assets/theme/code-copy.js"', $html);
-        assertStringContainsString('src="./assets/theme/toc-highlight.js"', $html);
-        assertStringContainsString('src="./assets/theme/ui-language.js"', $html);
+        assertStringContainsString('href="./assets/themes/minimal/style.css"', $html);
+        assertStringContainsString('src="./assets/themes/minimal/dark-mode.js"', $html);
+        assertStringContainsString('src="./assets/themes/minimal/code-copy.js"', $html);
+        assertStringContainsString('src="./assets/themes/minimal/toc-highlight.js"', $html);
+        assertStringContainsString('src="./assets/themes/minimal/ui-language.js"', $html);
         assertStringContainsString('href="./" data-ui-key="go_to_home_page">Go to home page</a>', $html);
-        assertStringNotContainsString('href="/assets/theme/style.css"', $html);
-        assertStringNotContainsString('src="/assets/theme/dark-mode.js"', $html);
+        assertStringNotContainsString('href="/assets/themes/minimal/style.css"', $html);
+        assertStringNotContainsString('src="/assets/themes/minimal/dark-mode.js"', $html);
     }
 
     private function createTemplateResolver(): TemplateResolver

--- a/tests/Unit/Build/TemplateContextTest.php
+++ b/tests/Unit/Build/TemplateContextTest.php
@@ -107,6 +107,25 @@ final class TemplateContextTest extends TestCase
         assertSame('../../' . $fingerprinted, Asset::url('assets/theme/style.css', '../../', $manifest));
     }
 
+    public function testThemeAssetHelperReturnsFingerprintedNamespacedThemeAsset(): void
+    {
+        mkdir($this->tempDir . '/assets', 0o755, true);
+        file_put_contents(
+            $this->tempDir . '/partials/asset.php',
+            '<?= $themeAsset("style.css") ?>',
+        );
+        $source = $this->tempDir . '/assets/style.css';
+        file_put_contents($source, 'body{}');
+
+        $manifest = new AssetFingerprintManifest();
+        $fingerprinted = $manifest->register('assets/themes/test/style.css', $source);
+        $context = $this->createContext($manifest);
+
+        $result = $context->partial('asset', ['rootPath' => '../../']);
+
+        assertSame('../../' . $fingerprinted, $result);
+    }
+
     public function testRewriteHtmlUpdatesReferencedAssets(): void
     {
         $source = $this->tempDir . '/style.css';

--- a/tests/Unit/Build/TemplateResolverTest.php
+++ b/tests/Unit/Build/TemplateResolverTest.php
@@ -83,6 +83,43 @@ final class TemplateResolverTest extends TestCase
         assertSame(['/a', '/b'], $resolver->templateDirs());
     }
 
+    public function testResolveResourceThemeNameReturnsOwningTheme(): void
+    {
+        $tempDir = sys_get_temp_dir() . '/yiipress-theme-test-' . uniqid();
+        mkdir($tempDir . '/assets', 0o755, true);
+        file_put_contents($tempDir . '/assets/style.css', 'body{}');
+
+        try {
+            $registry = new ThemeRegistry();
+            $registry->register(new Theme('minimal', dirname(__DIR__, 3) . '/themes/minimal'));
+            $registry->register(new Theme('custom', $tempDir));
+            $resolver = new TemplateResolver($registry);
+
+            assertSame('custom', $resolver->resolveResourceThemeName('assets/style.css', 'custom'));
+        } finally {
+            unlink($tempDir . '/assets/style.css');
+            rmdir($tempDir . '/assets');
+            rmdir($tempDir);
+        }
+    }
+
+    public function testResolveResourceThemeNameFallsBackToDefaultTheme(): void
+    {
+        $tempDir = sys_get_temp_dir() . '/yiipress-theme-test-' . uniqid();
+        mkdir($tempDir, 0o755, true);
+
+        try {
+            $registry = new ThemeRegistry();
+            $registry->register(new Theme('minimal', dirname(__DIR__, 3) . '/themes/minimal'));
+            $registry->register(new Theme('custom', $tempDir));
+            $resolver = new TemplateResolver($registry);
+
+            assertSame('minimal', $resolver->resolveResourceThemeName('assets/style.css', 'custom'));
+        } finally {
+            rmdir($tempDir);
+        }
+    }
+
     private function createResolver(): TemplateResolver
     {
         $registry = new ThemeRegistry();

--- a/tests/Unit/Build/ThemeAssetCopierTest.php
+++ b/tests/Unit/Build/ThemeAssetCopierTest.php
@@ -15,7 +15,9 @@ use RecursiveDirectoryIterator;
 use RecursiveIteratorIterator;
 
 use function PHPUnit\Framework\assertFileExists;
+use function PHPUnit\Framework\assertFileDoesNotExist;
 use function PHPUnit\Framework\assertSame;
+use function PHPUnit\Framework\assertStringContainsString;
 use function PHPUnit\Framework\assertStringEqualsFile;
 
 final class ThemeAssetCopierTest extends TestCase
@@ -44,8 +46,10 @@ final class ThemeAssetCopierTest extends TestCase
         $copier = new ThemeAssetCopier();
         $copied = $copier->copy($registry, $this->tempDir . '/output');
 
-        assertSame(1, $copied);
+        assertSame(2, $copied);
+        assertFileExists($this->tempDir . '/output/assets/themes/test/style.css');
         assertFileExists($this->tempDir . '/output/assets/theme/style.css');
+        assertStringEqualsFile($this->tempDir . '/output/assets/themes/test/style.css', 'body{color:red}');
         assertStringEqualsFile($this->tempDir . '/output/assets/theme/style.css', 'body{color:red}');
     }
 
@@ -60,7 +64,8 @@ final class ThemeAssetCopierTest extends TestCase
         $copier = new ThemeAssetCopier();
         $copied = $copier->copy($registry, $this->tempDir . '/output', minify: false);
 
-        assertSame(1, $copied);
+        assertSame(2, $copied);
+        assertStringEqualsFile($this->tempDir . '/output/assets/themes/test/style.css', $css);
         assertStringEqualsFile($this->tempDir . '/output/assets/theme/style.css', $css);
     }
 
@@ -87,12 +92,34 @@ final class ThemeAssetCopierTest extends TestCase
         $copier = new ThemeAssetCopier();
         $copied = $copier->copy($registry, $this->tempDir . '/output');
 
-        assertSame(2, $copied);
+        assertSame(4, $copied);
+        assertFileExists($this->tempDir . '/output/assets/themes/test/style.css');
+        assertFileExists($this->tempDir . '/output/assets/themes/test/fonts/mono.woff2');
         assertFileExists($this->tempDir . '/output/assets/theme/style.css');
         assertFileExists($this->tempDir . '/output/assets/theme/fonts/mono.woff2');
     }
 
-    public function testCopiesFingerprintedThemeAssetsWhenManifestProvided(): void
+    public function testCopiesThemeAssetsWithoutCrossThemeCollisions(): void
+    {
+        mkdir($this->tempDir . '/other/assets', 0o755, true);
+        file_put_contents($this->tempDir . '/theme/assets/style.css', 'body { color: red; }');
+        file_put_contents($this->tempDir . '/other/assets/style.css', 'body { color: blue; }');
+
+        $registry = new ThemeRegistry();
+        $registry->register(new Theme('test', $this->tempDir . '/theme'));
+        $registry->register(new Theme('other', $this->tempDir . '/other'));
+
+        $copier = new ThemeAssetCopier();
+        $copied = $copier->copy($registry, $this->tempDir . '/output');
+
+        assertSame(3, $copied);
+        assertStringContainsString('color: red', file_get_contents($this->tempDir . '/output/assets/themes/test/style.css'));
+        assertStringContainsString('color: blue', file_get_contents($this->tempDir . '/output/assets/themes/other/style.css'));
+        assertStringContainsString('color: red', file_get_contents($this->tempDir . '/output/assets/theme/style.css'));
+        assertFileDoesNotExist($this->tempDir . '/output/assets/theme/other/style.css');
+    }
+
+    public function testCopiesFingerprintedCanonicalThemeAssetsWhenManifestProvided(): void
     {
         $source = $this->tempDir . '/theme/assets/style.css';
         file_put_contents($source, 'body { color: red; }');
@@ -101,13 +128,31 @@ final class ThemeAssetCopierTest extends TestCase
         $registry->register(new Theme('test', $this->tempDir . '/theme'));
 
         $manifest = new AssetFingerprintManifest();
-        $resolved = $manifest->register('assets/theme/style.css', $source);
+        $resolved = $manifest->register('assets/themes/test/style.css', $source);
 
         $copier = new ThemeAssetCopier();
         $copied = $copier->copy($registry, $this->tempDir . '/output', $manifest);
 
-        assertSame(1, $copied);
+        assertSame(2, $copied);
         assertFileExists($this->tempDir . '/output/' . $resolved);
+        assertFileExists($this->tempDir . '/output/assets/theme/style.css');
+    }
+
+    public function testMappingsUseNamespacedLogicalPaths(): void
+    {
+        file_put_contents($this->tempDir . '/theme/assets/style.css', 'body {}');
+
+        $registry = new ThemeRegistry();
+        $registry->register(new Theme('test', $this->tempDir . '/theme'));
+
+        $mappings = (new ThemeAssetCopier())->mappings($registry);
+
+        assertSame('assets/themes/test/style.css', $mappings[$this->tempDir . '/theme/assets/style.css']);
+    }
+
+    public function testLogicalPathSanitizesThemeName(): void
+    {
+        assertSame('assets/themes/bad-theme/style.css', ThemeAssetCopier::logicalPath('../bad theme', 'style.css'));
     }
 
     private function removeDir(string $dir): void

--- a/themes/minimal/partials/footer.php
+++ b/themes/minimal/partials/footer.php
@@ -2,15 +2,13 @@
 
 use YiiPress\Content\Model\Navigation;
 use YiiPress\Render\NavigationRenderer;
-use YiiPress\Build\AssetFingerprintManifest;
-use YiiPress\Build\Asset;
 
 /**
  * @var ?Navigation $nav
  * @var string $rootPath
- * @var AssetFingerprintManifest|null $assetManifest
  * @var string $uiLanguage
  * @var Closure(string, int, ?string, bool): string $h
+ * @var Closure(string): string $themeAsset
  */
 $uiLanguage ??= 'en';
 ?>
@@ -30,4 +28,4 @@ $uiLanguage ??= 'en';
     </div>
 </footer>
 <?php endif; ?>
-<script src="<?= $h(Asset::url('assets/theme/dark-mode.js', $rootPath, $assetManifest)) ?>"></script>
+<script src="<?= $h($themeAsset('dark-mode.js')) ?>"></script>

--- a/themes/minimal/partials/head.php
+++ b/themes/minimal/partials/head.php
@@ -14,11 +14,11 @@
  * @var YiiPress\I18n\UiText $ui
  * @var Closure(string, int, ?string, bool): string $h
  * @var Closure(string): string $url
+ * @var Closure(string): string $themeAsset
  * @var Closure(string, array): string $t
  */
 
 use YiiPress\Build\AssetFingerprintManifest;
-use YiiPress\Build\Asset;
 use YiiPress\Build\MetaTags;
 
 $headAssets ??= '';
@@ -178,18 +178,18 @@ $uiCatalogs ??= [$uiLanguage => []];
         })();
     </script>
     <script id="yiipress-ui-catalogs" type="application/json" data-default-language="<?= $h($uiLanguage) ?>"><?= json_encode($uiCatalogs, JSON_THROW_ON_ERROR | JSON_UNESCAPED_UNICODE | JSON_HEX_TAG | JSON_HEX_AMP | JSON_HEX_APOS | JSON_HEX_QUOT) ?></script>
-    <link rel="stylesheet" href="<?= $h(Asset::url('assets/theme/style.css', $rootPath, $assetManifest)) ?>">
+    <link rel="stylesheet" href="<?= $h($themeAsset('style.css')) ?>">
 <?php if ($collectionName !== null): ?>
     <link rel="alternate" type="application/rss+xml" title="<?= $h($t('rss_feed')) ?>" data-ui-attr-title="rss_feed" href="<?= $h($url($collectionName . '/rss.xml')) ?>">
     <link rel="alternate" type="application/atom+xml" title="<?= $h($t('atom_feed')) ?>" data-ui-attr-title="atom_feed" href="<?= $h($url($collectionName . '/feed.xml')) ?>">
     <link rel="alternate" type="application/feed+json" title="JSON Feed" href="<?= $h($url($collectionName . '/feed.json')) ?>">
 <?php endif; ?>
-    <script src="<?= $h(Asset::url('assets/theme/image-zoom.js', $rootPath, $assetManifest)) ?>" defer></script>
-    <script src="<?= $h(Asset::url('assets/theme/code-copy.js', $rootPath, $assetManifest)) ?>" defer></script>
-    <script src="<?= $h(Asset::url('assets/theme/toc-highlight.js', $rootPath, $assetManifest)) ?>" defer></script>
-    <script src="<?= $h(Asset::url('assets/theme/ui-language.js', $rootPath, $assetManifest)) ?>" defer></script>
+    <script src="<?= $h($themeAsset('image-zoom.js')) ?>" defer></script>
+    <script src="<?= $h($themeAsset('code-copy.js')) ?>" defer></script>
+    <script src="<?= $h($themeAsset('toc-highlight.js')) ?>" defer></script>
+    <script src="<?= $h($themeAsset('ui-language.js')) ?>" defer></script>
 <?php if ($search): ?>
-    <link rel="stylesheet" href="<?= $h(Asset::url('assets/theme/search.css', $rootPath, $assetManifest)) ?>">
-    <script src="<?= $h(Asset::url('assets/theme/search.js', $rootPath, $assetManifest)) ?>" defer></script>
+    <link rel="stylesheet" href="<?= $h($themeAsset('search.css')) ?>">
+    <script src="<?= $h($themeAsset('search.js')) ?>" defer></script>
 <?php endif; ?>
 <?= $headAssets ?>


### PR DESCRIPTION
## Summary
- copy theme assets to `assets/themes/<theme>/...` to prevent installed themes from overwriting each other
- keep `assets/theme/...` aliases for the first registered theme for backwards compatibility
- add a `()` template helper and update the bundled minimal theme/docs to use it

## Tests
- `make test -- --filter ThemeAssetCopierTest`
- `make test -- --filter TemplateContextTest`
- `make test -- --filter TemplateResolverTest`
- `make test -- --filter EntryRendererTest`
- `make test -- --filter NotFoundPageWriterTest`
- `make psalm`
- `make test`
- `BENCH_FILTER=ThemeAssetCopierBench make bench`