### PR TITLE
Fix CSS minifier selector whitespace

### DIFF
--- a/src/Build/AssetMinifier.php
+++ b/src/Build/AssetMinifier.php
@@ -38,7 +38,8 @@ final class AssetMinifier
     {
         $content = self::stripComments($content, preserveNewLines: false, stripLineComments: false);
         $content = self::collapseCssWhitespace($content);
-        $content = (string) preg_replace('/\s*([{}:;,>~=\[\]])\s*/', '$1', $content);
+        $content = (string) preg_replace('/\s*([{};,>~=\[\]])\s*/', '$1', $content);
+        $content = (string) preg_replace('/:\s*/', ':', $content);
         $content = (string) preg_replace('/;}/', '}', $content);
 
         return trim($content);
@@ -245,12 +246,8 @@ final class AssetMinifier
     {
         $previous = substr($previousContent, -1);
 
-        return (self::isIdentifierChar($previous) && self::isIdentifierChar($next))
-            || ($next === '(' && preg_match('/(?:^|[^A-Za-z0-9_-])(?:and|or|not|only)$/i', $previousContent) === 1);
-    }
-
-    private static function isIdentifierChar(string $char): bool
-    {
-        return $char !== '' && preg_match('/[A-Za-z0-9_-]/', $char) === 1;
+        return $previous !== ''
+            && !str_contains('{(:;,>~=[', $previous)
+            && !str_contains('{};,>~=])', $next);
     }
 }

--- a/tests/Unit/Build/AssetMinifierTest.php
+++ b/tests/Unit/Build/AssetMinifierTest.php
@@ -51,6 +51,29 @@ final class AssetMinifierTest extends TestCase
         );
     }
 
+    public function testMinifiesCssWithoutBreakingSelectorOrValueWhitespace(): void
+    {
+        $css = <<<'CSS'
+            .site-header .container {
+                display: grid;
+                padding: 0 .125rem;
+            }
+
+            .container:has(.docs-layout) {
+                max-width: calc(100% - (var(--page-gutter) * 2));
+            }
+
+            .content :is(h1, h2) .header-anchor {
+                margin: 1rem 1.25rem;
+            }
+            CSS;
+
+        assertSame(
+            '.site-header .container{display:grid;padding:0 .125rem}.container:has(.docs-layout){max-width:calc(100% - (var(--page-gutter) * 2))}.content :is(h1,h2) .header-anchor{margin:1rem 1.25rem}',
+            AssetMinifier::minify('app.css', $css),
+        );
+    }
+
     public function testMinifiesJavaScriptWithoutBreakingRegexOrStrings(): void
     {
         $js = <<<'JS'


### PR DESCRIPTION
## Summary
- Preserve required CSS whitespace between descendant/pseudo selectors and multi-token values during asset minification
- Keep colon minification limited to spacing after colons so selectors such as `.content :is(...)` remain valid
- Add regression coverage for selector and value whitespace

## Verification
- `make build-docs`
- `make test -- --filter AssetMinifierTest`
- `make test -- tests/Unit/Build/AssetMinifierTest.php tests/Unit/Build/ThemeAssetCopierTest.php tests/Unit/Build/ContentAssetCopierTest.php tests/Unit/Build/AssetFileWriterTest.php`
- `make test`
- Playwright inspection of docs header at 1440, 1024, 640, and 390 px

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved CSS minification so spacing around selectors and values is preserved correctly, avoiding broken output in cases like advanced selectors and calculated values.
* **Tests**
  * Added coverage for CSS minification edge cases to confirm whitespace is handled safely during compression.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->