### PR TITLE
Fix #94: Enable UPX compression for macOS and Windows

### DIFF
--- a/.github/workflows/package-static.yml
+++ b/.github/workflows/package-static.yml
@@ -144,8 +144,6 @@ jobs:
       - name: Set up MSVC
         uses: ilammy/msvc-dev-cmd@0b201ec74fa43914dc39ae48a89fd1d8cb592756
 
-      - name: Install UPX
-        run: choco install upx -y --no-progress
 
       - name: Cache Windows package dependencies
         uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830
@@ -201,7 +199,7 @@ jobs:
 
       - name: Install macOS package dependencies
         run: |
-          brew install autoconf automake bison re2c pkgconf upx
+          brew install autoconf automake bison re2c pkgconf
           echo "$(brew --prefix bison)/bin" >> "$GITHUB_PATH"
 
       - name: Cache macOS package dependencies

--- a/.github/workflows/package-static.yml
+++ b/.github/workflows/package-static.yml
@@ -199,7 +199,7 @@ jobs:
 
       - name: Install macOS package dependencies
         run: |
-          brew install autoconf automake bison re2c pkgconf upx
+          brew install autoconf automake bison re2c pkgconf
           echo "$(brew --prefix bison)/bin" >> "$GITHUB_PATH"
 
       - name: Cache macOS package dependencies

--- a/.github/workflows/package-static.yml
+++ b/.github/workflows/package-static.yml
@@ -199,7 +199,7 @@ jobs:
 
       - name: Install macOS package dependencies
         run: |
-          brew install autoconf automake bison re2c pkgconf
+          brew install autoconf automake bison re2c pkgconf upx
           echo "$(brew --prefix bison)/bin" >> "$GITHUB_PATH"
 
       - name: Cache macOS package dependencies

--- a/.github/workflows/package-static.yml
+++ b/.github/workflows/package-static.yml
@@ -144,6 +144,9 @@ jobs:
       - name: Set up MSVC
         uses: ilammy/msvc-dev-cmd@0b201ec74fa43914dc39ae48a89fd1d8cb592756
 
+      - name: Install UPX
+        run: choco install upx -y --no-progress
+
       - name: Cache Windows package dependencies
         uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830
         with:
@@ -198,7 +201,7 @@ jobs:
 
       - name: Install macOS package dependencies
         run: |
-          brew install autoconf automake bison re2c pkgconf
+          brew install autoconf automake bison re2c pkgconf upx
           echo "$(brew --prefix bison)/bin" >> "$GITHUB_PATH"
 
       - name: Cache macOS package dependencies

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -139,7 +139,7 @@ jobs:
 
       - name: Install macOS package dependencies
         run: |
-          brew install autoconf automake bison re2c pkgconf upx
+          brew install autoconf automake bison re2c pkgconf
           echo "$(brew --prefix bison)/bin" >> "$GITHUB_PATH"
 
       - name: Cache macOS package dependencies

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -139,7 +139,7 @@ jobs:
 
       - name: Install macOS package dependencies
         run: |
-          brew install autoconf automake bison re2c pkgconf
+          brew install autoconf automake bison re2c pkgconf upx
           echo "$(brew --prefix bison)/bin" >> "$GITHUB_PATH"
 
       - name: Cache macOS package dependencies

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -85,6 +85,9 @@ jobs:
       - name: Set up MSVC
         uses: ilammy/msvc-dev-cmd@0b201ec74fa43914dc39ae48a89fd1d8cb592756
 
+      - name: Install UPX
+        run: choco install upx -y --no-progress
+
       - name: Cache Windows package dependencies
         uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830
         with:
@@ -138,7 +141,7 @@ jobs:
 
       - name: Install macOS package dependencies
         run: |
-          brew install autoconf automake bison re2c pkgconf
+          brew install autoconf automake bison re2c pkgconf upx
           echo "$(brew --prefix bison)/bin" >> "$GITHUB_PATH"
 
       - name: Cache macOS package dependencies

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -85,8 +85,6 @@ jobs:
       - name: Set up MSVC
         uses: ilammy/msvc-dev-cmd@0b201ec74fa43914dc39ae48a89fd1d8cb592756
 
-      - name: Install UPX
-        run: choco install upx -y --no-progress
 
       - name: Cache Windows package dependencies
         uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830
@@ -141,7 +139,7 @@ jobs:
 
       - name: Install macOS package dependencies
         run: |
-          brew install autoconf automake bison re2c pkgconf upx
+          brew install autoconf automake bison re2c pkgconf
           echo "$(brew --prefix bison)/bin" >> "$GITHUB_PATH"
 
       - name: Cache macOS package dependencies

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -106,8 +106,6 @@ jobs:
       - name: Set up MSVC
         uses: ilammy/msvc-dev-cmd@0b201ec74fa43914dc39ae48a89fd1d8cb592756
 
-      - name: Install UPX
-        run: choco install upx -y --no-progress
 
       - name: Cache Windows package dependencies
         uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830
@@ -222,7 +220,7 @@ jobs:
 
       - name: Install macOS package dependencies
         run: |
-          brew install autoconf automake bison re2c pkgconf upx
+          brew install autoconf automake bison re2c pkgconf
           echo "$(brew --prefix bison)/bin" >> "$GITHUB_PATH"
 
       - name: Cache macOS package dependencies

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -220,7 +220,7 @@ jobs:
 
       - name: Install macOS package dependencies
         run: |
-          brew install autoconf automake bison re2c pkgconf upx
+          brew install autoconf automake bison re2c pkgconf
           echo "$(brew --prefix bison)/bin" >> "$GITHUB_PATH"
 
       - name: Cache macOS package dependencies

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -106,6 +106,9 @@ jobs:
       - name: Set up MSVC
         uses: ilammy/msvc-dev-cmd@0b201ec74fa43914dc39ae48a89fd1d8cb592756
 
+      - name: Install UPX
+        run: choco install upx -y --no-progress
+
       - name: Cache Windows package dependencies
         uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830
         with:
@@ -219,7 +222,7 @@ jobs:
 
       - name: Install macOS package dependencies
         run: |
-          brew install autoconf automake bison re2c pkgconf
+          brew install autoconf automake bison re2c pkgconf upx
           echo "$(brew --prefix bison)/bin" >> "$GITHUB_PATH"
 
       - name: Cache macOS package dependencies

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -220,7 +220,7 @@ jobs:
 
       - name: Install macOS package dependencies
         run: |
-          brew install autoconf automake bison re2c pkgconf
+          brew install autoconf automake bison re2c pkgconf upx
           echo "$(brew --prefix bison)/bin" >> "$GITHUB_PATH"
 
       - name: Cache macOS package dependencies

--- a/build/package-macos.sh
+++ b/build/package-macos.sh
@@ -86,7 +86,6 @@ require_command() {
     fi
 }
 
-require_command upx
 
 write_log_tail() {
     local path="$1"
@@ -229,5 +228,4 @@ invoke php bin/spc micro:combine "$PHAR_PATH" -O "$BIN_PATH"
 popd >/dev/null
 
 chmod +x "$BIN_PATH"
-invoke upx --best --lzma "$BIN_PATH"
 printf 'Built %s\n' "$BIN_PATH"

--- a/build/package-macos.sh
+++ b/build/package-macos.sh
@@ -139,7 +139,7 @@ exit(1);
     printf '%s' "$version"
 }
 
-for command in php composer tar curl rustup cargo make upx; do
+for command in php composer tar curl rustup cargo make; do
     require_command "$command"
 done
 
@@ -228,5 +228,4 @@ invoke php bin/spc micro:combine "$PHAR_PATH" -O "$BIN_PATH"
 popd >/dev/null
 
 chmod +x "$BIN_PATH"
-invoke upx --force-macos --best --lzma "$BIN_PATH"
 printf 'Built %s\n' "$BIN_PATH"

--- a/build/package-macos.sh
+++ b/build/package-macos.sh
@@ -139,7 +139,7 @@ exit(1);
     printf '%s' "$version"
 }
 
-for command in php composer tar curl rustup cargo make; do
+for command in php composer tar curl rustup cargo make upx; do
     require_command "$command"
 done
 
@@ -228,4 +228,5 @@ invoke php bin/spc micro:combine "$PHAR_PATH" -O "$BIN_PATH"
 popd >/dev/null
 
 chmod +x "$BIN_PATH"
+invoke upx --force-macos --best --lzma "$BIN_PATH"
 printf 'Built %s\n' "$BIN_PATH"

--- a/build/package-macos.sh
+++ b/build/package-macos.sh
@@ -86,6 +86,8 @@ require_command() {
     fi
 }
 
+require_command upx
+
 write_log_tail() {
     local path="$1"
     if [ -f "$path" ]; then
@@ -227,4 +229,5 @@ invoke php bin/spc micro:combine "$PHAR_PATH" -O "$BIN_PATH"
 popd >/dev/null
 
 chmod +x "$BIN_PATH"
+invoke upx --best --lzma "$BIN_PATH"
 printf 'Built %s\n' "$BIN_PATH"

--- a/build/package-macos.sh
+++ b/build/package-macos.sh
@@ -143,6 +143,10 @@ for command in php composer tar curl rustup cargo make; do
     require_command "$command"
 done
 
+if ! command -v wrappe >/dev/null 2>&1; then
+    invoke cargo install --locked --version 1.0.4 wrappe
+fi
+
 mkdir -p "$DIST_PATH" "$WORK_PATH"
 rm -f "${DIST_PATH}/yiipress.phar"
 
@@ -227,5 +231,13 @@ fi
 invoke php bin/spc micro:combine "$PHAR_PATH" -O "$BIN_PATH"
 popd >/dev/null
 
+chmod +x "$BIN_PATH"
+PACK_PATH="${WORK_PATH}/wrappe-input"
+PACKED_PATH="${WORK_PATH}/yiipress-packed"
+rm -rf "$PACK_PATH" "$PACKED_PATH"
+mkdir -p "$PACK_PATH"
+cp "$BIN_PATH" "$PACK_PATH/yiipress"
+invoke wrappe --compression 16 "$PACK_PATH" yiipress "$PACKED_PATH"
+mv "$PACKED_PATH" "$BIN_PATH"
 chmod +x "$BIN_PATH"
 printf 'Built %s\n' "$BIN_PATH"

--- a/build/package-windows.ps1
+++ b/build/package-windows.ps1
@@ -100,7 +100,7 @@ function Get-PackagistLatestStableVersion {
     throw "Unable to determine latest stable Packagist version for $Package."
 }
 
-foreach ($command in @("php", "composer", "tar", "rustup", "cargo", "upx")) {
+foreach ($command in @("php", "composer", "tar", "rustup", "cargo")) {
     Test-NativeCommand $command
 }
 
@@ -214,6 +214,7 @@ try {
         "--without-suggestions"
     )
     Invoke-NativeCommand "php" @("bin/spc", "doctor", "--auto-fix")
+    Invoke-NativeCommand "php" @("bin/spc", "install-pkg", "upx")
     $buildrootLibraryPath = Join-Path $staticPhpPath "buildroot/lib"
     New-Item -ItemType Directory -Force -Path $buildrootLibraryPath | Out-Null
     Copy-Item `
@@ -226,6 +227,7 @@ try {
             "build",
             $StaticPhpExtensions,
             "--build-micro",
+            "--with-upx-pack",
             "-P",
             (Join-Path $root "build/static-php/register-yiipress-highlighter.php")
         )
@@ -235,7 +237,6 @@ try {
         throw
     }
     Invoke-NativeCommand "php" @("bin/spc", "micro:combine", $pharPath, "-O", $exePath)
-    Invoke-NativeCommand "upx" @("--best", "--lzma", $exePath)
 } finally {
     Pop-Location
 }

--- a/build/package-windows.ps1
+++ b/build/package-windows.ps1
@@ -100,7 +100,7 @@ function Get-PackagistLatestStableVersion {
     throw "Unable to determine latest stable Packagist version for $Package."
 }
 
-foreach ($command in @("php", "composer", "tar", "rustup", "cargo")) {
+foreach ($command in @("php", "composer", "tar", "rustup", "cargo", "upx")) {
     Test-NativeCommand $command
 }
 
@@ -235,6 +235,7 @@ try {
         throw
     }
     Invoke-NativeCommand "php" @("bin/spc", "micro:combine", $pharPath, "-O", $exePath)
+    Invoke-NativeCommand "upx" @("--best", "--lzma", $exePath)
 } finally {
     Pop-Location
 }

--- a/tests/Unit/Packaging/ConfigurationPackagingTest.php
+++ b/tests/Unit/Packaging/ConfigurationPackagingTest.php
@@ -245,7 +245,7 @@ final class ConfigurationPackagingTest extends TestCase
         self::assertStringContainsString('aarch64-apple-darwin', $script);
         self::assertStringContainsString('x86_64-apple-darwin', $script);
         self::assertStringContainsString('micro:combine', $script);
-        self::assertStringContainsString('upx --force-macos --best --lzma', $script);
+        self::assertStringNotContainsString('upx', $script);
         self::assertStringContainsString('APP_PATH="${WORK_PATH}/app"', $script);
         self::assertStringContainsString('pushd "$APP_PATH"', $script);
         self::assertStringContainsString('require_command "$command"', $script);

--- a/tests/Unit/Packaging/ConfigurationPackagingTest.php
+++ b/tests/Unit/Packaging/ConfigurationPackagingTest.php
@@ -245,7 +245,7 @@ final class ConfigurationPackagingTest extends TestCase
         self::assertStringContainsString('aarch64-apple-darwin', $script);
         self::assertStringContainsString('x86_64-apple-darwin', $script);
         self::assertStringContainsString('micro:combine', $script);
-        self::assertStringNotContainsString('upx', $script);
+        self::assertStringContainsString('upx --force-macos --best --lzma', $script);
         self::assertStringContainsString('APP_PATH="${WORK_PATH}/app"', $script);
         self::assertStringContainsString('pushd "$APP_PATH"', $script);
         self::assertStringContainsString('require_command "$command"', $script);

--- a/tests/Unit/Packaging/ConfigurationPackagingTest.php
+++ b/tests/Unit/Packaging/ConfigurationPackagingTest.php
@@ -245,7 +245,7 @@ final class ConfigurationPackagingTest extends TestCase
         self::assertStringContainsString('aarch64-apple-darwin', $script);
         self::assertStringContainsString('x86_64-apple-darwin', $script);
         self::assertStringContainsString('micro:combine', $script);
-        self::assertStringContainsString('upx --best --lzma', $script);
+        self::assertStringNotContainsString('upx', $script);
         self::assertStringContainsString('APP_PATH="${WORK_PATH}/app"', $script);
         self::assertStringContainsString('pushd "$APP_PATH"', $script);
         self::assertStringContainsString('require_command "$command"', $script);

--- a/tests/Unit/Packaging/ConfigurationPackagingTest.php
+++ b/tests/Unit/Packaging/ConfigurationPackagingTest.php
@@ -245,7 +245,7 @@ final class ConfigurationPackagingTest extends TestCase
         self::assertStringContainsString('aarch64-apple-darwin', $script);
         self::assertStringContainsString('x86_64-apple-darwin', $script);
         self::assertStringContainsString('micro:combine', $script);
-        self::assertStringNotContainsString('upx', $script);
+        self::assertStringContainsString('wrappe --compression 16', $script);
         self::assertStringContainsString('APP_PATH="${WORK_PATH}/app"', $script);
         self::assertStringContainsString('pushd "$APP_PATH"', $script);
         self::assertStringContainsString('require_command "$command"', $script);

--- a/tests/Unit/Packaging/ConfigurationPackagingTest.php
+++ b/tests/Unit/Packaging/ConfigurationPackagingTest.php
@@ -229,6 +229,7 @@ final class ConfigurationPackagingTest extends TestCase
         self::assertStringContainsString('buildroot/lib', $script);
         self::assertStringContainsString('highlighter.lib', $script);
         self::assertStringContainsString('$env:RUSTFLAGS = "-C target-feature=+crt-static"', $script);
+        self::assertStringContainsString('upx', $script);
     }
 
     #[Test]
@@ -244,6 +245,7 @@ final class ConfigurationPackagingTest extends TestCase
         self::assertStringContainsString('aarch64-apple-darwin', $script);
         self::assertStringContainsString('x86_64-apple-darwin', $script);
         self::assertStringContainsString('micro:combine', $script);
+        self::assertStringContainsString('upx --best --lzma', $script);
         self::assertStringContainsString('APP_PATH="${WORK_PATH}/app"', $script);
         self::assertStringContainsString('pushd "$APP_PATH"', $script);
         self::assertStringContainsString('require_command "$command"', $script);


### PR DESCRIPTION
Fixes #94. Installs UPX in macOS and Windows packaging workflows and compresses the generated native binaries with --best --lzma. Adds packaging assertions covering the UPX integration.