### PR TITLE
Fix #105: Show language labels on fenced code blocks

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -199,6 +199,18 @@ highlight_theme: "Solarized (dark)"
 
 If `highlight_theme` is omitted, YiiPress uses `InspiredGitHub`.
 
+Language-tagged fenced blocks retain their normalized language identifier in generated HTML:
+
+```html
+<div class="code-block" data-language="php">
+    <span class="code-language-label">PHP</span>
+    <!-- highlighted pre/code output -->
+</div>
+```
+
+The bundled `minimal` theme displays this label next to the copy button. Custom themes can use
+`data-language` and `.code-language-label` without parsing the highlighted code.
+
 ### Assets
 
 Asset fingerprinting is enabled by default. Disable it in `content/config.yaml` if needed:

--- a/docs/plugins.md
+++ b/docs/plugins.md
@@ -65,9 +65,12 @@ defines the PHP API as `YiiPress\Highlighter`, builds a Rust
 library with [syntect](https://github.com/trishume/syntect) and [rayon](https://github.com/rayon-rs/rayon),
 then statically links that library into `ext-highlighter`. It processes all
 `<pre><code class="language-xxx">` blocks in the rendered HTML, replacing them with
-inline-styled highlighted output.
+inline-styled highlighted output. `SyntaxHighlightProcessor` preserves the normalized language
+identifier in a surrounding `<div class="code-block" data-language="php">` and emits a visible
+`.code-language-label`, so custom themes can style or reposition the label without inspecting code.
 
-The bundled `minimal` theme adds a client-side **Copy** button to rendered code blocks.
+The bundled `minimal` theme displays the language label and adds a client-side **Copy** button to
+rendered code blocks. Unlabeled blocks remain unchanged and still receive a copy button.
 
 ## LaTeX math
 

--- a/roadmap.md
+++ b/roadmap.md
@@ -106,6 +106,7 @@
 - [x] Table of contents generation from headings as a plugin
 - [x] Diagram support (Mermaid) as a plugin
 - [x] oEmbed support (auto-expanding URLs to embeds) as a plugin
+- [x] [Code block language labels](https://github.com/yiipress/engine/issues/105)
 
 ## Priority 8: Advanced features
 

--- a/src/Processor/SyntaxHighlightProcessor.php
+++ b/src/Processor/SyntaxHighlightProcessor.php
@@ -9,7 +9,12 @@ use YiiPress\Content\Model\SiteConfig;
 use YiiPress\Highlighter;
 use RuntimeException;
 
+use function htmlspecialchars;
+use function preg_replace_callback;
+use function sprintf;
 use function str_contains;
+use function strtolower;
+use function strtoupper;
 
 final class SyntaxHighlightProcessor implements ContentProcessorInterface, SiteConfigAwareProcessorInterface
 {
@@ -30,10 +35,31 @@ final class SyntaxHighlightProcessor implements ContentProcessorInterface, SiteC
             return $content;
         }
 
+        $content = $this->addLanguageMetadata($content);
+
         try {
             return $this->highlighter->highlightHtml($content, $this->theme === '' ? null : $this->theme);
         } catch (RuntimeException $e) {
             throw new RuntimeException("Failed to highlight code in entry \"{$entry->title}\".", 0, $e);
         }
+    }
+
+    private function addLanguageMetadata(string $content): string
+    {
+        return preg_replace_callback(
+            '~<pre><code class=[^a-zA-Z0-9]*language-([a-zA-Z0-9_+.#-]+)[^>]*>.*?</code></pre>~s',
+            static function (array $matches): string {
+                $language = strtolower($matches[1]);
+                $label = strtoupper($language);
+
+                return sprintf(
+                    '<div class="code-block" data-language="%s"><span class="code-language-label">%s</span>%s</div>',
+                    htmlspecialchars($language, ENT_QUOTES | ENT_SUBSTITUTE, 'UTF-8'),
+                    htmlspecialchars($label, ENT_QUOTES | ENT_SUBSTITUTE, 'UTF-8'),
+                    $matches[0],
+                );
+            },
+            $content,
+        ) ?? $content;
     }
 }

--- a/tests/Unit/Processor/SyntaxHighlightProcessorTest.php
+++ b/tests/Unit/Processor/SyntaxHighlightProcessorTest.php
@@ -14,6 +14,8 @@ use PHPUnit\Framework\TestCase;
 use function PHPUnit\Framework\assertSame;
 use function PHPUnit\Framework\assertNotSame;
 use function PHPUnit\Framework\assertNotFalse;
+use function PHPUnit\Framework\assertStringContainsString;
+use function PHPUnit\Framework\assertStringNotContainsString;
 use function class_exists;
 
 final class SyntaxHighlightProcessorTest extends TestCase
@@ -38,6 +40,40 @@ final class SyntaxHighlightProcessorTest extends TestCase
         $configuredResult = $configuredProcessor->process($html, $this->createEntry());
 
         assertNotSame($defaultResult, $configuredResult);
+    }
+
+    public function testPreservesNormalizedLanguageMetadataAroundHighlightedBlock(): void
+    {
+        $html = '<pre><code class="language-PHP">&lt;?php echo 1;</code></pre>';
+
+        $result = (new SyntaxHighlightProcessor(new Highlighter()))->process($html, $this->createEntry());
+
+        assertStringContainsString(
+            '<div class="code-block" data-language="php"><span class="code-language-label">PHP</span><pre',
+            $result,
+        );
+        assertStringContainsString('style=', $result);
+        assertStringNotContainsString('language-PHP', $result);
+    }
+
+    public function testPreservesUnknownLanguageMetadataWhenHighlighterFallsBackToPlainText(): void
+    {
+        $html = '<pre><code class="language-custom-lang">some code</code></pre>';
+
+        $result = (new SyntaxHighlightProcessor(new Highlighter()))->process($html, $this->createEntry());
+
+        assertStringContainsString('data-language="custom-lang"', $result);
+        assertStringContainsString('<span class="code-language-label">CUSTOM-LANG</span>', $result);
+        assertStringContainsString('some code', $result);
+    }
+
+    public function testLeavesUnlabeledCodeBlockUnwrapped(): void
+    {
+        $html = '<pre><code>plain code</code></pre>';
+
+        $result = (new SyntaxHighlightProcessor(new Highlighter()))->process($html, $this->createEntry());
+
+        assertSame($html, $result);
     }
 
     private function createEntry(): Entry

--- a/tests/Unit/Theme/MinimalThemeAssetsTest.php
+++ b/tests/Unit/Theme/MinimalThemeAssetsTest.php
@@ -97,6 +97,8 @@ final class MinimalThemeAssetsTest extends TestCase
 
         self::assertNotFalse($css);
         assertStringContainsString('.code-block {', $css);
+        assertStringContainsString('.code-language-label {', $css);
+        assertStringContainsString('.code-block:hover .code-language-label,', $css);
         assertStringContainsString('.code-copy-button {', $css);
         assertStringContainsString('pointer-events: none;', $css);
         assertStringContainsString('.code-copy-button.copied {', $css);
@@ -109,6 +111,9 @@ final class MinimalThemeAssetsTest extends TestCase
 
         self::assertNotFalse($script);
         assertStringContainsString("document.querySelectorAll('.content pre')", $script);
+        assertStringContainsString("const existingWrapper = pre.closest('.code-block');", $script);
+        assertStringContainsString("if (existingWrapper?.querySelector('.code-copy-button'))", $script);
+        assertStringContainsString('const wrapper = existingWrapper ?? document.createElement', $script);
         assertStringContainsString("button.className = 'code-copy-button';", $script);
         assertStringContainsString("navigator.clipboard.writeText(text)", $script);
         assertStringContainsString("document.execCommand('copy')", $script);

--- a/themes/minimal/assets/code-copy.js
+++ b/themes/minimal/assets/code-copy.js
@@ -2,23 +2,26 @@ document.addEventListener('DOMContentLoaded', () => {
     const codeBlocks = document.querySelectorAll('.content pre');
 
     codeBlocks.forEach((pre) => {
-        if (pre.closest('.code-block') !== null) {
+        const existingWrapper = pre.closest('.code-block');
+        if (existingWrapper?.querySelector('.code-copy-button')) {
             return;
         }
 
         const code = pre.querySelector('code');
-        const wrapper = document.createElement('div');
+        const wrapper = existingWrapper ?? document.createElement('div');
         const button = document.createElement('button');
 
-        wrapper.className = 'code-block';
         button.className = 'code-copy-button';
         button.type = 'button';
         button.setAttribute('aria-label', 'Copy Code');
         button.title = 'Copy Code';
         button.textContent = 'Copy';
 
-        pre.parentNode?.insertBefore(wrapper, pre);
-        wrapper.appendChild(pre);
+        if (existingWrapper === null) {
+            wrapper.className = 'code-block';
+            pre.parentNode?.insertBefore(wrapper, pre);
+            wrapper.appendChild(pre);
+        }
         wrapper.appendChild(button);
 
         button.addEventListener('click', async () => {

--- a/themes/minimal/assets/style.css
+++ b/themes/minimal/assets/style.css
@@ -304,6 +304,22 @@ article h1 { font-size: 2rem; font-weight: 700; line-height: 1.25; margin-bottom
     margin: 0;
     padding-right: 4.5rem;
 }
+.code-language-label {
+    position: absolute;
+    top: .75rem;
+    right: .75rem;
+    z-index: 1;
+    color: var(--c-text-muted);
+    font-size: .75rem;
+    font-weight: 600;
+    line-height: 1;
+    pointer-events: none;
+    transition: opacity .15s;
+}
+.code-block:hover .code-language-label,
+.code-block:focus-within .code-language-label {
+    opacity: 0;
+}
 .code-copy-button {
     position: absolute;
     top: .5rem;


### PR DESCRIPTION
## Summary

- preserve normalized fenced-code language metadata around native highlighted output
- render server-side language labels that custom themes can style without inspecting code
- make the minimal-theme copy enhancer reuse generated wrappers while still enhancing unlabeled blocks
- document generated markup and mark the roadmap item complete

Closes #105.

## Verification

- `make test tests/Unit/Processor/SyntaxHighlightProcessorTest.php tests/Unit/Theme/MinimalThemeAssetsTest.php` — 17 tests, 93 assertions
- `make psalm` — no errors
- `make composer-dependency-analyser` — no issues
- `git diff --check`
- Full `make test` ran all 822 tests; 821 passed and the pre-existing `MarkdownRendererTest::testRendersTaskList` failed only because this checkout has CRLF in the expected heredoc while the renderer emits LF.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Code blocks now display a normalized language label alongside the copy button.
  * Language metadata is preserved for highlighted and unknown-language code blocks.
  * The minimal theme hides language labels when users hover or focus on a code block.
* **Bug Fixes**
  * Improved copy-button behavior to avoid duplicate wrappers or buttons.
* **Documentation**
  * Added documentation and roadmap updates covering language labels and code-block behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->