### PR TITLE
Fix #113: Add per-entry previous/next pager overrides

### DIFF
--- a/benchmarks/NavigationPagerBench.php
+++ b/benchmarks/NavigationPagerBench.php
@@ -1,0 +1,39 @@
+<?php
+
+declare(strict_types=1);
+
+namespace YiiPress\Benchmarks;
+
+use YiiPress\Build\NavigationPager;
+use YiiPress\Content\Model\Navigation;
+use YiiPress\Content\Model\NavigationItem;
+use PhpBench\Attributes\Iterations;
+use PhpBench\Attributes\Revs;
+use PhpBench\Attributes\Warmup;
+
+final class NavigationPagerBench
+{
+    private Navigation $navigation;
+
+    public function __construct()
+    {
+        $items = [];
+        for ($index = 0; $index < 100; $index++) {
+            $items[] = new NavigationItem('Page ' . $index, '/guide/page-' . $index . '/', []);
+        }
+        $this->navigation = new Navigation(['sidebar' => $items]);
+    }
+
+    #[Revs(1000)]
+    #[Iterations(3)]
+    #[Warmup(1)]
+    public function benchResolveWithCustomOverride(): void
+    {
+        $pager = NavigationPager::forUrl($this->navigation, 'sidebar', '/guide/page-50/');
+        NavigationPager::withOverrides(
+            $pager,
+            false,
+            ['text' => 'Custom next', 'link' => '/guide/custom/'],
+        );
+    }
+}

--- a/docs/content.md
+++ b/docs/content.md
@@ -123,10 +123,6 @@ theme: custom
 weight: 10
 language: en
 redirect_to: /new-url/
-previous: false
-next:
-  text: Continue with deployment
-  link: /deployment/
 extra:
   custom_field: value
 ---
@@ -157,8 +153,8 @@ override inherits the navigation-derived link, and a missing navigation neighbor
 ```yaml
 previous: false
 next:
-  text: Advanced configuration
-  link: /configuration/advanced/
+  text: Advanced guide
+  link: /guide/advanced/
 ```
 
 Front matter must be valid YAML key-value pairs. Syntax errors fail the build with the affected file path instead of being ignored.

--- a/docs/content.md
+++ b/docs/content.md
@@ -123,6 +123,10 @@ theme: custom
 weight: 10
 language: en
 redirect_to: /new-url/
+previous: false
+next:
+  text: Continue with deployment
+  link: /deployment/
 extra:
   custom_field: value
 ---
@@ -144,7 +148,18 @@ extra:
 - **weight** — integer for custom sorting in non-blog collections (lower = first)
 - **language** — language code for multilingual content (e.g., `en`, `ru`)
 - **redirect_to** — URL to redirect to; generates a redirect HTML page (with `<meta http-equiv="refresh">`, JS `window.location.replace()`, and `<link rel="canonical">`) instead of rendering content. Redirect entries are excluded from feeds, sitemaps, listings, archives, and taxonomy pages. Root-relative targets such as `/new-url/` are YiiPress site-root paths; when `base_url` includes a deployment path, YiiPress prefixes that path in the generated redirect target. Absolute URLs are emitted unchanged
+- **previous**, **next** — per-entry pager overrides. Omit a direction to inherit its link from sidebar navigation when `navigation_pager` is enabled for the collection, set it to `false` to hide that direction, or provide both `text` and `link` for a custom link. Custom links also work when collection navigation paging is disabled. Relative and root-relative internal links and absolute HTTP(S) links are accepted; unsafe URL schemes fail the build. Root-relative links are rendered relative to the output page, so they work when `base_url` contains a deployment subdirectory
 - **extra** — arbitrary key-value pairs accessible in templates
+
+Pager precedence is resolved independently for each direction: an entry override wins, an omitted
+override inherits the navigation-derived link, and a missing navigation neighbor produces no link.
+
+```yaml
+previous: false
+next:
+  text: Advanced configuration
+  link: /configuration/advanced/
+```
 
 Front matter must be valid YAML key-value pairs. Syntax errors fail the build with the affected file path instead of being ignored.
 

--- a/docs/templates.md
+++ b/docs/templates.md
@@ -175,7 +175,7 @@ Built-in templates and partials expect `$ui` to be passed by the renderer; `Page
 | `$related`    | `list<RelatedEntry>` | Related entries ordered by relevance or empty list        |
 | `$language`   | `string`      | Effective language code for the current entry                    |
 | `$translations` | `list<Translation>` | Alternate-language versions of the current entry           |
-| `$navigationPager` | `?array{previous: ?array, next: ?array}` | Previous/next links resolved from sidebar navigation when enabled |
+| `$navigationPager` | `?array{previous: ?array, next: ?array}` | Final previous/next links after per-entry overrides are applied to sidebar-derived navigation |
 | `$lastUpdated` | `?array{iso: string, text: string}` | Source file modification time when `last_updated` is enabled |
 | `$editPageUrl` | `string` | Resolved edit-page URL when `edit_page` is configured, otherwise empty |
 | `$reportIssueUrl` | `string` | Resolved issue-report URL when `report_issue` is configured, otherwise empty |

--- a/roadmap.md
+++ b/roadmap.md
@@ -107,6 +107,7 @@
 - [x] Diagram support (Mermaid) as a plugin
 - [x] oEmbed support (auto-expanding URLs to embeds) as a plugin
 - [x] [Code block language labels](https://github.com/yiipress/engine/issues/105)
+- [x] [Per-entry previous/next pager overrides](https://github.com/yiipress/engine/issues/113)
 
 ## Priority 8: Advanced features
 

--- a/src/Build/NavigationPager.php
+++ b/src/Build/NavigationPager.php
@@ -10,6 +10,24 @@ use YiiPress\Content\Model\NavigationItem;
 final class NavigationPager
 {
     /**
+     * @param array{previous: array{title: string, url: string}|null, next: array{title: string, url: string}|null}|null $navigationPager
+     * @param array{text: string, link: string}|false|null $previous
+     * @param array{text: string, link: string}|false|null $next
+     * @return array{previous: array{title: string, url: string}|null, next: array{title: string, url: string}|null}|null
+     */
+    public static function withOverrides(?array $navigationPager, array|false|null $previous, array|false|null $next): ?array
+    {
+        if ($navigationPager === null && $previous === null && $next === null) {
+            return null;
+        }
+
+        return [
+            'previous' => self::resolveOverride($navigationPager['previous'] ?? null, $previous),
+            'next' => self::resolveOverride($navigationPager['next'] ?? null, $next),
+        ];
+    }
+
+    /**
      * @return array{previous: array{title: string, url: string}|null, next: array{title: string, url: string}|null}|null
      */
     public static function forUrl(
@@ -86,5 +104,23 @@ final class NavigationPager
         }
 
         return rtrim($path, '/') ?: '/';
+    }
+
+    /**
+     * @param array{title: string, url: string}|null $inherited
+     * @param array{text: string, link: string}|false|null $override
+     * @return array{title: string, url: string}|null
+     */
+    private static function resolveOverride(?array $inherited, array|false|null $override): ?array
+    {
+        if ($override === null) {
+            return $inherited;
+        }
+
+        if ($override === false) {
+            return null;
+        }
+
+        return ['title' => $override['text'], 'url' => $override['link']];
     }
 }

--- a/src/Console/BuildCommand.php
+++ b/src/Console/BuildCommand.php
@@ -1956,19 +1956,24 @@ final class BuildCommand extends Command
      */
     private function withNavigationPager(array $task, Collection $collection, SiteConfig $siteConfig, Navigation $navigation): array
     {
-        if (!$collection->navigationPager) {
-            return $task;
+        $entry = $task['entry'];
+        $navigationPager = null;
+        if ($collection->navigationPager) {
+            $language = $entry->language !== ''
+                ? $entry->language
+                : ($siteConfig->i18n?->defaultLanguage ?? $siteConfig->defaultLanguage);
+            $navigationPager = NavigationPager::forUrl(
+                $navigation,
+                'sidebar',
+                $task['permalink'],
+                $language,
+                $siteConfig->defaultLanguage,
+            );
         }
-
-        $language = $task['entry']->language !== ''
-            ? $task['entry']->language
-            : ($siteConfig->i18n?->defaultLanguage ?? $siteConfig->defaultLanguage);
-        $navigationPager = NavigationPager::forUrl(
-            $navigation,
-            'sidebar',
-            $task['permalink'],
-            $language,
-            $siteConfig->defaultLanguage,
+        $navigationPager = NavigationPager::withOverrides(
+            $navigationPager,
+            $entry->previous,
+            $entry->next,
         );
 
         if ($navigationPager !== null) {

--- a/src/Content/Model/Entry.php
+++ b/src/Content/Model/Entry.php
@@ -15,6 +15,8 @@ final class Entry
      * @param list<string> $authors
      * @param array<string, mixed> $extra
      * @param list<string> $aliases
+     * @param array{text: string, link: string}|false|null $previous
+     * @param array{text: string, link: string}|false|null $next
      */
     public function __construct(
         public string $filePath,
@@ -41,6 +43,8 @@ final class Entry
         public string $translationKey = '',
         public bool $showTitle = true,
         public array $aliases = [],
+        public array|false|null $previous = null,
+        public array|false|null $next = null,
     ) {}
 
     private ?string $bodyCache = null;
@@ -78,6 +82,8 @@ final class Entry
             translationKey: $this->translationKey,
             showTitle: $this->showTitle,
             aliases: $this->aliases,
+            previous: $this->previous,
+            next: $this->next,
         );
     }
 

--- a/src/Content/Parser/EntryParser.php
+++ b/src/Content/Parser/EntryParser.php
@@ -9,6 +9,7 @@ use DateMalformedStringException;
 use DateTimeImmutable;
 
 use function is_array;
+use function is_string;
 
 final readonly class EntryParser
 {
@@ -106,7 +107,74 @@ final readonly class EntryParser
             aliases: isset($fields['aliases']) && is_array($fields['aliases'])
                 ? array_values(array_map(strval(...), $fields['aliases']))
                 : [],
+            previous: $this->parsePagerOverride($fields, 'previous', $filePath),
+            next: $this->parsePagerOverride($fields, 'next', $filePath),
         );
+    }
+
+    /**
+     * @param array<string, mixed> $fields
+     * @return array{text: string, link: string}|false|null
+     */
+    private function parsePagerOverride(array $fields, string $direction, string $filePath): array|false|null
+    {
+        if (!array_key_exists($direction, $fields)) {
+            return null;
+        }
+
+        $value = $fields[$direction];
+        if ($value === false) {
+            return false;
+        }
+
+        if (
+            !is_array($value)
+            || count($value) !== 2
+            || !array_key_exists('text', $value)
+            || !array_key_exists('link', $value)
+            || !is_string($value['text'])
+            || trim($value['text']) === ''
+            || !is_string($value['link'])
+            || trim($value['link']) === ''
+        ) {
+            throw new InvalidContentConfigException(
+                sprintf('Invalid "%s" pager override in front matter: %s', $direction, $filePath),
+                $filePath,
+                sprintf(
+                    'Omit "%1$s" to inherit it, set "%1$s: false" to disable it, or use "%1$s: {text: Title, link: /page/}".',
+                    $direction,
+                ),
+            );
+        }
+
+        $link = trim($value['link']);
+        if (!$this->isSafePagerUrl($link)) {
+            throw new InvalidContentConfigException(
+                sprintf('Unsafe URL in "%s" pager override: %s', $direction, $filePath),
+                $filePath,
+                'Use a relative or root-relative internal URL, or an absolute http:// or https:// URL.',
+            );
+        }
+
+        return ['text' => trim($value['text']), 'link' => $link];
+    }
+
+    private function isSafePagerUrl(string $url): bool
+    {
+        if (preg_match('/[\x00-\x1F\x7F]/', $url) === 1 || str_starts_with($url, '//')) {
+            return false;
+        }
+
+        $scheme = parse_url($url, PHP_URL_SCHEME);
+
+        if ($scheme === null) {
+            return true;
+        }
+        if ($scheme === false || !in_array(strtolower($scheme), ['http', 'https'], true)) {
+            return false;
+        }
+
+        return filter_var($url, FILTER_VALIDATE_URL) !== false;
     }
 
     /**

--- a/tests/Unit/Build/EntryRendererTest.php
+++ b/tests/Unit/Build/EntryRendererTest.php
@@ -119,6 +119,26 @@ final class EntryRendererTest extends TestCase
         assertStringNotContainsString('class="entry-pager"', $html);
     }
 
+    public function testRendersInternalCustomPagerUrlRelativeToDeploymentPage(): void
+    {
+        $entryFile = $this->contentDir . '/blog/post.md';
+        file_put_contents($entryFile, "---\ntitle: Current\n---\n\nBody.\n");
+
+        $entry = $this->createEntry(filePath: $entryFile, title: 'Current');
+        $renderer = new EntryRenderer($this->createPipeline(), $this->createTemplateResolver(), contentDir: $this->contentDir);
+        $html = $renderer->render(
+            $this->createSiteConfig(baseUrl: 'https://example.com/project/'),
+            $entry,
+            '/guide/current/',
+            navigationPager: [
+                'previous' => null,
+                'next' => ['title' => 'Custom Page', 'url' => '/guide/custom/'],
+            ],
+        );
+
+        assertStringContainsString('href="../../guide/custom/" rel="next"', $html);
+    }
+
     public function testRendersLastUpdatedWhenEnabled(): void
     {
         $entryFile = $this->contentDir . '/blog/post.md';
@@ -582,12 +602,50 @@ PHP);
         $entry = $this->createEntry(filePath: $entryFile, title: 'Cached Post', layout: 'spaced');
         $html = $renderer->render($this->createSiteConfig(theme: 'custom'), $entry, '/blog/cached-post/');
 
-        $cacheFiles = array_values(array_filter(scandir($cacheDir), static fn (string $file): bool => $file !== '.' && $file !== '..'));
+        $cacheFiles = array_values(array_filter(scandir($cacheDir), static fn(string $file): bool => $file !== '.' && $file !== '..'));
 
         $this->assertCount(1, $cacheFiles);
         assertSame($html, file_get_contents($cacheDir . '/' . $cacheFiles[0]));
         assertStringContainsString('<html><body><main> Cached body. </main></body></html>', $html);
         assertStringNotContainsString("\n", (string) file_get_contents($cacheDir . '/' . $cacheFiles[0]));
+    }
+
+    public function testResolvedPagerDataChangesCacheSignature(): void
+    {
+        $entryFile = $this->contentDir . '/blog/post.md';
+        file_put_contents($entryFile, "---\ntitle: Cached Pager\n---\n\nBody.\n");
+
+        $templateResolver = $this->createTemplateResolver();
+        $cacheDir = $this->contentDir . '/cache';
+        $renderer = new EntryRenderer(
+            $this->createPipeline(),
+            $templateResolver,
+            cache: new BuildCache($cacheDir, $templateResolver->templateDirs()),
+            contentDir: $this->contentDir,
+        );
+        $entry = $this->createEntry(filePath: $entryFile, title: 'Cached Pager');
+
+        $first = $renderer->render(
+            $this->createSiteConfig(),
+            $entry,
+            '/guide/current/',
+            navigationPager: ['previous' => null, 'next' => ['title' => 'First', 'url' => '/first/']],
+        );
+        $second = $renderer->render(
+            $this->createSiteConfig(),
+            $entry,
+            '/guide/current/',
+            navigationPager: ['previous' => null, 'next' => ['title' => 'Second', 'url' => '/second/']],
+        );
+
+        $cacheFiles = array_values(array_filter(
+            scandir($cacheDir),
+            static fn(string $file): bool => $file !== '.' && $file !== '..',
+        ));
+
+        $this->assertCount(2, $cacheFiles);
+        assertStringContainsString('First', $first);
+        assertStringContainsString('Second', $second);
     }
 
     private function createPipeline(): ContentProcessorPipeline
@@ -615,12 +673,12 @@ PHP);
         bool $authorPages = false,
         bool $minify = true,
         array $data = [],
-    ): SiteConfig
-    {
+        string $baseUrl = 'https://example.com',
+    ): SiteConfig {
         return new SiteConfig(
             title: 'Test Site',
             description: '',
-            baseUrl: 'https://example.com',
+            baseUrl: $baseUrl,
             defaultLanguage: 'en',
             charset: 'UTF-8',
             defaultAuthor: '',

--- a/tests/Unit/Build/NavigationPagerTest.php
+++ b/tests/Unit/Build/NavigationPagerTest.php
@@ -50,6 +50,48 @@ final class NavigationPagerTest extends TestCase
         assertNull(NavigationPager::forUrl($this->createNavigation(), 'sidebar', '/missing/'));
     }
 
+    public function testAppliesOverridesIndependently(): void
+    {
+        $inherited = NavigationPager::forUrl($this->createNavigation(), 'sidebar', '/content/');
+
+        $pager = NavigationPager::withOverrides(
+            $inherited,
+            false,
+            ['text' => 'Custom next', 'link' => '/custom/next/'],
+        );
+
+        assertSame(
+            [
+                'previous' => null,
+                'next' => ['title' => 'Custom next', 'url' => '/custom/next/'],
+            ],
+            $pager,
+        );
+    }
+
+    public function testCustomOverrideCreatesPagerWithoutNavigationData(): void
+    {
+        assertSame(
+            [
+                'previous' => ['title' => 'External guide', 'url' => 'https://example.com/guide'],
+                'next' => null,
+            ],
+            NavigationPager::withOverrides(
+                null,
+                ['text' => 'External guide', 'link' => 'https://example.com/guide'],
+                null,
+            ),
+        );
+    }
+
+    public function testOmittedOverridesPreserveInheritedPager(): void
+    {
+        $inherited = NavigationPager::forUrl($this->createNavigation(), 'sidebar', '/content/');
+
+        assertSame($inherited, NavigationPager::withOverrides($inherited, null, null));
+        assertNull(NavigationPager::withOverrides(null, null, null));
+    }
+
     private function createNavigation(): Navigation
     {
         return new Navigation([

--- a/tests/Unit/Content/Parser/EntryParserTest.php
+++ b/tests/Unit/Content/Parser/EntryParserTest.php
@@ -8,6 +8,7 @@ use YiiPress\Content\Parser\EntryParser;
 use YiiPress\Content\Parser\FilenameParser;
 use YiiPress\Content\Parser\FrontMatterParser;
 use YiiPress\Content\Parser\InvalidContentConfigException;
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 
 use function file_put_contents;
@@ -75,6 +76,51 @@ final class EntryParserTest extends TestCase
         }
     }
 
+    public function testParsesPagerOverrides(): void
+    {
+        $file = tempnam(sys_get_temp_dir(), 'yiipress-entry-pager-') . '.md';
+        file_put_contents(
+            $file,
+            "---\ntitle: Pager\nprevious: false\nnext:\n  text: Continue\n  link: /guide/continue/\n---\n\nBody.\n",
+        );
+
+        try {
+            $entry = $this->parser->parse($file, 'docs');
+
+            assertFalse($entry->previous);
+            assertSame(['text' => 'Continue', 'link' => '/guide/continue/'], $entry->next);
+        } finally {
+            unlink($file);
+        }
+    }
+
+    #[DataProvider('invalidPagerOverrideProvider')]
+    public function testRejectsInvalidPagerOverrides(string $yaml, string $message): void
+    {
+        $file = tempnam(sys_get_temp_dir(), 'yiipress-entry-pager-invalid-') . '.md';
+        file_put_contents($file, "---\ntitle: Pager\n$yaml\n---\n\nBody.\n");
+
+        try {
+            $this->parser->parse($file, 'docs');
+            self::fail('Expected invalid pager override to throw.');
+        } catch (InvalidContentConfigException $e) {
+            assertStringContainsString($message, $e->getMessage());
+            assertSame($file, $e->filePath());
+        } finally {
+            unlink($file);
+        }
+    }
+
+    /** @return iterable<string, array{string, string}> */
+    public static function invalidPagerOverrideProvider(): iterable
+    {
+        yield 'scalar' => ['previous: Previous page', 'Invalid "previous" pager override'];
+        yield 'missing text' => ["next:\n  link: /next/", 'Invalid "next" pager override'];
+        yield 'extra field' => ["next:\n  text: Next\n  link: /next/\n  target: _blank", 'Invalid "next" pager override'];
+        yield 'unsafe scheme' => ["previous:\n  text: Bad\n  link: 'javascript:alert(1)'", 'Unsafe URL'];
+        yield 'protocol relative' => ["next:\n  text: Bad\n  link: //evil.example/page", 'Unsafe URL'];
+    }
+
     public function testEntryBodyIsLoadedLazily(): void
     {
         $entry = $this->parser->parse($this->dataDir . '/blog/2024-03-15-test-post.md', 'blog');
@@ -124,7 +170,7 @@ final class EntryParserTest extends TestCase
         assertSame(['php', 'inline', 'shit', 'yii', 'multi-part-tag', 'two-words'], $tagLowercases);
 
         // Verify 'php' appears only once (not duplicated as 'php' and 'PHP')
-        $phpCount = count(array_filter($entry->tags, static fn ($tag) => strtolower($tag) === 'php'));
+        $phpCount = count(array_filter($entry->tags, static fn($tag) => strtolower($tag) === 'php'));
         assertSame(1, $phpCount);
     }
 


### PR DESCRIPTION
## Summary

- parse independent `previous` and `next` entry overrides with inherit, disabled, and custom-link states
- validate override structures and reject unsafe pager URLs with actionable diagnostics
- merge overrides with navigation-derived pager data and preserve subdirectory-safe internal links
- include resolved pager data in cache signatures, with parser/resolver/renderer coverage
- document syntax and precedence, update the roadmap, and add a phpbench benchmark

Closes #113

## Verification

- `make test CLI_ARGS='tests/Unit/Content/Parser/EntryParserTest.php tests/Unit/Build/NavigationPagerTest.php tests/Unit/Build/EntryRendererTest.php'` — 51 tests, 151 assertions, passing
- `make psalm` — no errors
- `make bench BENCH_FILTER=NavigationPagerBench` — passing, 25.711 μs mean
- `git diff --check` — passing
- `make test` — issue-related tests pass; the suite retains one unrelated existing failure in `MarkdownRendererTest::testRendersTaskList` because its CRLF expected fixture is compared with LF renderer output