### PR TITLE
Fix #112: Add per-entry edit-link visibility override

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -142,6 +142,18 @@ Supported placeholders are:
 - `{permalink}` — root-relative permalink, URL-encoded with `/` preserved
 - `{url}` — absolute page URL resolved from `base_url`, URL-encoded
 
+An individual entry can suppress only its edit action while leaving the report-issue action
+available:
+
+```yaml
+---
+title: Generated API reference
+editLink: false
+---
+```
+
+Omitting `editLink` (or setting it to `true`) preserves the site-wide `edit_page` behavior.
+
 ### Multilingual support
 
 Declare site languages in `content/config.yaml`. The first language is the default:

--- a/docs/content.md
+++ b/docs/content.md
@@ -145,6 +145,7 @@ extra:
 - **language** — language code for multilingual content (e.g., `en`, `ru`)
 - **redirect_to** — URL to redirect to; generates a redirect HTML page (with `<meta http-equiv="refresh">`, JS `window.location.replace()`, and `<link rel="canonical">`) instead of rendering content. Redirect entries are excluded from feeds, sitemaps, listings, archives, and taxonomy pages. Root-relative targets such as `/new-url/` are YiiPress site-root paths; when `base_url` includes a deployment path, YiiPress prefixes that path in the generated redirect target. Absolute URLs are emitted unchanged
 - **previous**, **next** — per-entry pager overrides. Omit a direction to inherit its link from sidebar navigation when `navigation_pager` is enabled for the collection, set it to `false` to hide that direction, or provide both `text` and `link` for a custom link. Custom links also work when collection navigation paging is disabled. Relative and root-relative internal links and absolute HTTP(S) links are accepted; unsafe URL schemes fail the build. Root-relative links are rendered relative to the output page, so they work when `base_url` contains a deployment subdirectory
+- **editLink** — set to `false` to hide the edit-page action for this entry. When omitted or `true`, the entry inherits the site-wide `edit_page` configuration. This does not affect the report-issue action
 - **extra** — arbitrary key-value pairs accessible in templates
 
 Pager precedence is resolved independently for each direction: an entry override wins, an omitted

--- a/docs/templates.md
+++ b/docs/templates.md
@@ -177,7 +177,7 @@ Built-in templates and partials expect `$ui` to be passed by the renderer; `Page
 | `$translations` | `list<Translation>` | Alternate-language versions of the current entry           |
 | `$navigationPager` | `?array{previous: ?array, next: ?array}` | Final previous/next links after per-entry overrides are applied to sidebar-derived navigation |
 | `$lastUpdated` | `?array{iso: string, text: string}` | Source file modification time when `last_updated` is enabled |
-| `$editPageUrl` | `string` | Resolved edit-page URL when `edit_page` is configured, otherwise empty |
+| `$editPageUrl` | `string` | Resolved edit-page URL when `edit_page` is configured and the entry does not set `editLink: false`, otherwise empty |
 | `$reportIssueUrl` | `string` | Resolved issue-report URL when `report_issue` is configured, otherwise empty |
 
 Example:

--- a/roadmap.md
+++ b/roadmap.md
@@ -108,6 +108,7 @@
 - [x] oEmbed support (auto-expanding URLs to embeds) as a plugin
 - [x] [Code block language labels](https://github.com/yiipress/engine/issues/105)
 - [x] [Per-entry previous/next pager overrides](https://github.com/yiipress/engine/issues/113)
+- [x] [Per-entry edit-link visibility override](https://github.com/yiipress/engine/issues/112)
 
 ## Priority 8: Advanced features
 

--- a/src/Build/EntryRenderer.php
+++ b/src/Build/EntryRenderer.php
@@ -180,7 +180,7 @@ final class EntryRenderer
         $rootPath = UrlResolver::rootPath($permalink);
         $navigationPager = $this->relativizeNavigationPager($navigationPager, $rootPath);
         $lastUpdated = $this->lastUpdated($siteConfig, $entry);
-        $editPageUrl = $siteConfig->editPageUrl === null
+        $editPageUrl = $siteConfig->editPageUrl === null || $entry->editLink === false
             ? ''
             : PageActionUrlFormatter::format($siteConfig->editPageUrl, $siteConfig, $entry, $permalink, $this->contentDir);
         $reportIssueUrl = $siteConfig->reportIssueUrl === null

--- a/src/Content/Model/Entry.php
+++ b/src/Content/Model/Entry.php
@@ -45,6 +45,7 @@ final class Entry
         public array $aliases = [],
         public array|false|null $previous = null,
         public array|false|null $next = null,
+        public ?bool $editLink = null,
     ) {}
 
     private ?string $bodyCache = null;
@@ -84,6 +85,7 @@ final class Entry
             aliases: $this->aliases,
             previous: $this->previous,
             next: $this->next,
+            editLink: $this->editLink,
         );
     }
 

--- a/src/Content/Parser/EntryParser.php
+++ b/src/Content/Parser/EntryParser.php
@@ -9,6 +9,7 @@ use DateMalformedStringException;
 use DateTimeImmutable;
 
 use function is_array;
+use function is_bool;
 use function is_string;
 
 final readonly class EntryParser
@@ -109,7 +110,27 @@ final readonly class EntryParser
                 : [],
             previous: $this->parsePagerOverride($fields, 'previous', $filePath),
             next: $this->parsePagerOverride($fields, 'next', $filePath),
+            editLink: $this->parseEditLink($fields, $filePath),
         );
+    }
+
+    /**
+     * @param array<string, mixed> $fields
+     */
+    private function parseEditLink(array $fields, string $filePath): ?bool
+    {
+        if (!array_key_exists('editLink', $fields) || $fields['editLink'] === null) {
+            return null;
+        }
+        if (!is_bool($fields['editLink'])) {
+            throw new InvalidContentConfigException(
+                "Invalid \"editLink\" visibility override in front matter: $filePath",
+                $filePath,
+                'Omit "editLink" to inherit it, or set it to true or false.',
+            );
+        }
+
+        return $fields['editLink'];
     }
 
     /**

--- a/tests/Unit/Build/EntryRendererTest.php
+++ b/tests/Unit/Build/EntryRendererTest.php
@@ -256,6 +256,57 @@ final class EntryRendererTest extends TestCase
         assertStringNotContainsString('data-ui-key="edit_this_page"', $html);
     }
 
+    public function testEntryCanHideEditPageLinkWithoutHidingReportIssueLink(): void
+    {
+        $entryFile = $this->contentDir . '/blog/post.md';
+        file_put_contents($entryFile, "---\ntitle: Current\n---\n\nBody.\n");
+
+        $entry = $this->createEntry(filePath: $entryFile, title: 'Current', editLink: false);
+        $renderer = new EntryRenderer($this->createPipeline(), $this->createTemplateResolver(), contentDir: $this->contentDir);
+        $html = $renderer->render(
+            $this->createSiteConfig(
+                editPageUrl: 'https://github.com/example/site/edit/main/{path}',
+                reportIssueUrl: 'https://github.com/example/site/issues/new?title={title}',
+            ),
+            $entry,
+            '/blog/current/',
+        );
+
+        assertStringNotContainsString('data-ui-key="edit_this_page"', $html);
+        assertStringContainsString('data-ui-key="report_an_issue">Report an issue', $html);
+    }
+
+    public function testHiddenEditPageUrlIsEmptyForCustomTheme(): void
+    {
+        $entryFile = $this->contentDir . '/blog/post.md';
+        file_put_contents($entryFile, "---\ntitle: Current\n---\n\nBody.\n");
+        $themePath = $this->contentDir . '/custom-theme';
+        mkdir($themePath);
+        file_put_contents(
+            $themePath . '/entry.php',
+            '<?= $editPageUrl === "" ? "edit-hidden" : "edit-visible" ?>|<?= $reportIssueUrl ?>',
+        );
+
+        $entry = $this->createEntry(filePath: $entryFile, title: 'Current', editLink: false);
+        $renderer = new EntryRenderer(
+            $this->createPipeline(),
+            $this->createTemplateResolver($themePath),
+            contentDir: $this->contentDir,
+        );
+        $html = $renderer->render(
+            $this->createSiteConfig(
+                theme: 'custom',
+                editPageUrl: 'https://example.com/edit/{path}',
+                reportIssueUrl: 'https://example.com/report/{path}',
+                minify: false,
+            ),
+            $entry,
+            '/blog/current/',
+        );
+
+        assertSame('edit-hidden|https://example.com/report/blog/post.md', $html);
+    }
+
     public function testRendersReportIssueLinkWhenConfigured(): void
     {
         $entryFile = $this->contentDir . '/blog/post.md';
@@ -713,6 +764,7 @@ PHP);
         string $language = '',
         array $extra = [],
         bool $showTitle = true,
+        ?bool $editLink = null,
     ): Entry {
         $content = file_get_contents($filePath);
         $bodyMarker = "---\n\n";
@@ -746,6 +798,7 @@ PHP);
             bodyLength: $bodyLength,
             inlineTags: $inlineTags,
             showTitle: $showTitle,
+            editLink: $editLink,
         );
     }
 

--- a/tests/Unit/Content/Parser/EntryParserTest.php
+++ b/tests/Unit/Content/Parser/EntryParserTest.php
@@ -96,7 +96,7 @@ final class EntryParserTest extends TestCase
 
     public function testParsesEditLinkVisibilityOverride(): void
     {
-        $file = tempnam(sys_get_temp_dir(), 'yiipress-entry-edit-link-') . '.md';
+        $file = tempnam(sys_get_temp_dir(), 'yiipress-entry-edit-link-');
         file_put_contents($file, "---\ntitle: Generated\neditLink: false\n---\n\nBody.\n");
 
         try {
@@ -110,7 +110,7 @@ final class EntryParserTest extends TestCase
 
     public function testEditLinkVisibilityIsInheritedWhenOmitted(): void
     {
-        $file = tempnam(sys_get_temp_dir(), 'yiipress-entry-edit-link-') . '.md';
+        $file = tempnam(sys_get_temp_dir(), 'yiipress-entry-edit-link-');
         file_put_contents($file, "---\ntitle: Editable\n---\n\nBody.\n");
 
         try {
@@ -124,7 +124,7 @@ final class EntryParserTest extends TestCase
 
     public function testRejectsInvalidEditLinkVisibilityOverride(): void
     {
-        $file = tempnam(sys_get_temp_dir(), 'yiipress-entry-edit-link-invalid-') . '.md';
+        $file = tempnam(sys_get_temp_dir(), 'yiipress-entry-edit-link-invalid-');
         file_put_contents($file, "---\ntitle: Editable\neditLink: hidden\n---\n\nBody.\n");
 
         try {

--- a/tests/Unit/Content/Parser/EntryParserTest.php
+++ b/tests/Unit/Content/Parser/EntryParserTest.php
@@ -94,6 +94,50 @@ final class EntryParserTest extends TestCase
         }
     }
 
+    public function testParsesEditLinkVisibilityOverride(): void
+    {
+        $file = tempnam(sys_get_temp_dir(), 'yiipress-entry-edit-link-') . '.md';
+        file_put_contents($file, "---\ntitle: Generated\neditLink: false\n---\n\nBody.\n");
+
+        try {
+            $entry = $this->parser->parse($file, 'docs');
+
+            assertFalse($entry->editLink);
+        } finally {
+            unlink($file);
+        }
+    }
+
+    public function testEditLinkVisibilityIsInheritedWhenOmitted(): void
+    {
+        $file = tempnam(sys_get_temp_dir(), 'yiipress-entry-edit-link-') . '.md';
+        file_put_contents($file, "---\ntitle: Editable\n---\n\nBody.\n");
+
+        try {
+            $entry = $this->parser->parse($file, 'docs');
+
+            assertNull($entry->editLink);
+        } finally {
+            unlink($file);
+        }
+    }
+
+    public function testRejectsInvalidEditLinkVisibilityOverride(): void
+    {
+        $file = tempnam(sys_get_temp_dir(), 'yiipress-entry-edit-link-invalid-') . '.md';
+        file_put_contents($file, "---\ntitle: Editable\neditLink: hidden\n---\n\nBody.\n");
+
+        try {
+            $this->parser->parse($file, 'docs');
+            self::fail('Expected invalid edit-link visibility override to throw.');
+        } catch (InvalidContentConfigException $e) {
+            assertStringContainsString('Invalid "editLink" visibility override', $e->getMessage());
+            assertSame($file, $e->filePath());
+        } finally {
+            unlink($file);
+        }
+    }
+
     #[DataProvider('invalidPagerOverrideProvider')]
     public function testRejectsInvalidPagerOverrides(string $yaml, string $message): void
     {


### PR DESCRIPTION
Closes #112.

## Summary

- parse a nullable boolean `editLink` entry front-matter field
- suppress the resolved edit-page URL when `editLink: false` while keeping report-issue independent
- expose the same resolved action data to built-in and custom themes
- document the override and mark the roadmap item complete

## Verification

- `make test CLI_ARGS='tests/Unit/Content/Parser/EntryParserTest.php tests/Unit/Build/EntryRendererTest.php'` (49 tests, 141 assertions)
- `make psalm`
- `git diff --check`

The full test run passed 836/837 tests; the unrelated existing `MarkdownRendererTest::testRendersTaskList` line-ending assertion failed.