### PR TITLE
Fix #107: Add tabbed code groups

### DIFF
--- a/benchmarks/CodeGroupProcessorBench.php
+++ b/benchmarks/CodeGroupProcessorBench.php
@@ -1,0 +1,58 @@
+<?php
+
+declare(strict_types=1);
+
+namespace YiiPress\Benchmarks;
+
+use DateTimeImmutable;
+use PhpBench\Attributes\Iterations;
+use PhpBench\Attributes\Revs;
+use PhpBench\Attributes\Warmup;
+use YiiPress\Content\Model\Entry;
+use YiiPress\Processor\Shortcode\CodeGroupProcessor;
+
+final class CodeGroupProcessorBench
+{
+    private CodeGroupProcessor $processor;
+    private Entry $entry;
+    private string $content;
+
+    public function __construct()
+    {
+        $this->processor = new CodeGroupProcessor();
+        $this->entry = new Entry(
+            filePath: __FILE__,
+            collection: 'docs',
+            slug: 'benchmark',
+            title: 'Benchmark',
+            date: new DateTimeImmutable('2026-01-01'),
+            draft: false,
+            tags: [],
+            categories: [],
+            authors: [],
+            summary: '',
+            permalink: '/docs/benchmark/',
+            layout: '',
+            theme: '',
+            weight: 0,
+            language: 'en',
+            redirectTo: '',
+            extra: [],
+            bodyOffset: 0,
+            bodyLength: 0,
+        );
+        $this->content = str_repeat(
+            "[code-group]\n[code-tab label=\"npm\"]\n```sh\nnpm install\n```\n[/code-tab]\n"
+            . "[code-tab label=\"pnpm\"]\n```sh\npnpm install\n```\n[/code-tab]\n[/code-group]\n",
+            25,
+        );
+    }
+
+    #[Revs(100)]
+    #[Iterations(3)]
+    #[Warmup(1)]
+    public function benchPreserveShortcodes(): void
+    {
+        $this->processor->process($this->content, $this->entry);
+    }
+}

--- a/config/common/di/content-pipeline.php
+++ b/config/common/di/content-pipeline.php
@@ -15,6 +15,7 @@ use YiiPress\Processor\ContentProcessorPipeline;
 use YiiPress\Processor\LatexMath\LatexMathProcessor;
 use YiiPress\Processor\Mermaid\MermaidProcessor;
 use YiiPress\Processor\OEmbed\OEmbedProcessor;
+use YiiPress\Processor\Shortcode\CodeGroupProcessor;
 use YiiPress\Processor\Shortcode\TweetProcessor;
 use YiiPress\Processor\Shortcode\VimeoProcessor;
 use YiiPress\Processor\Shortcode\YouTubeProcessor;
@@ -43,11 +44,13 @@ return [
             Reference::to(VimeoProcessor::class),
             Reference::to(TweetProcessor::class),
             Reference::to(OEmbedProcessor::class),
+            Reference::to(CodeGroupProcessor::class),
             Reference::to(MarkdownProcessor::class),
             Reference::to(LatexMathProcessor::class),
             Reference::to(TagLinkProcessor::class),
             Reference::to(MermaidProcessor::class),
             Reference::to(SyntaxHighlightProcessor::class),
+            Reference::to(CodeGroupProcessor::class),
             Reference::to(TocProcessor::class),
         ],
     ],

--- a/config/common/di/content-pipeline.php
+++ b/config/common/di/content-pipeline.php
@@ -44,12 +44,14 @@ return [
             Reference::to(VimeoProcessor::class),
             Reference::to(TweetProcessor::class),
             Reference::to(OEmbedProcessor::class),
+            // Preserve code-group shortcode metadata before Markdown, then render it after syntax highlighting.
             Reference::to(CodeGroupProcessor::class),
             Reference::to(MarkdownProcessor::class),
             Reference::to(LatexMathProcessor::class),
             Reference::to(TagLinkProcessor::class),
             Reference::to(MermaidProcessor::class),
             Reference::to(SyntaxHighlightProcessor::class),
+            // Complete the second code-group pass using the rendered, highlighted code blocks.
             Reference::to(CodeGroupProcessor::class),
             Reference::to(TocProcessor::class),
         ],

--- a/docs/plugins.md
+++ b/docs/plugins.md
@@ -248,23 +248,6 @@ non-empty `label`. Content outside the tab shortcodes is not allowed within a gr
 Visitors can select tabs with a pointer or use Left/Right arrow, Home, and End keys.
 When JavaScript is unavailable, all labeled examples remain visible.
 
-Projects that configure plugins through DI can change both shortcode names:
-
-```php
-use YiiPress\Processor\Shortcode\CodeGroupProcessor;
-
-CodeGroupProcessor::class => [
-    'class' => CodeGroupProcessor::class,
-    '__construct()' => [
-        'groupShortcode' => 'switcher',
-        'tabShortcode' => 'option',
-    ],
-],
-```
-
-With this configuration, use `[switcher]` in place of `[code-group]` and
-`[option label="..."]` in place of `[code-tab label="..."]`.
-
 ### Project Processors
 
 Static binary users can add site-level content processors without editing Yii3 DI configuration. Put PHP processor files in `content/processors/`; files matching `*.php` are discovered automatically, sorted by filename, and inserted before Markdown rendering in both the page and feed pipelines.

--- a/docs/plugins.md
+++ b/docs/plugins.md
@@ -222,6 +222,47 @@ Both shortcode processors support:
 - Double quotes, single quotes, or no quotes for attribute values (no spaces)
 - Case-insensitive shortcode names
 
+### Tabbed code groups
+
+The built-in `CodeGroupProcessor` groups two or more labeled fenced code blocks. It uses
+the existing shortcode format, while the code itself remains ordinary fenced Markdown:
+
+````markdown
+[code-group]
+[code-tab label="npm"]
+```sh
+npm install
+```
+[/code-tab]
+[code-tab label="pnpm"]
+```sh
+pnpm install
+```
+[/code-tab]
+[/code-group]
+````
+
+The generated HTML contains every code block and remains readable without JavaScript.
+The browser enhancer activates one panel at a time and supports Left/Right arrow, Home,
+and End keys. Each group has independent ARIA tab and panel IDs.
+
+The processor is a regular configurable plugin. Projects using DI configuration can
+change both shortcode names without adding a new parser or syntax:
+
+```php
+use YiiPress\Processor\Shortcode\CodeGroupProcessor;
+
+CodeGroupProcessor::class => [
+    'class' => CodeGroupProcessor::class,
+    '__construct()' => [
+        'groupShortcode' => 'switcher',
+        'tabShortcode' => 'option',
+    ],
+],
+```
+
+That configuration uses `[switcher]` and `[option label="..."]`.
+
 ### Project Processors
 
 Static binary users can add site-level content processors without editing Yii3 DI configuration. Put PHP processor files in `content/processors/`; files matching `*.php` are discovered automatically, sorted by filename, and inserted before Markdown rendering in both the page and feed pipelines.

--- a/docs/plugins.md
+++ b/docs/plugins.md
@@ -224,8 +224,8 @@ Both shortcode processors support:
 
 ### Tabbed code groups
 
-The built-in `CodeGroupProcessor` groups two or more labeled fenced code blocks. It uses
-the existing shortcode format, while the code itself remains ordinary fenced Markdown:
+Use `[code-group]` to present two or more alternative code examples as tabs. Wrap each
+fenced code block in `[code-tab]` and set its visible tab label:
 
 ````markdown
 [code-group]
@@ -242,12 +242,13 @@ pnpm install
 [/code-group]
 ````
 
-The generated HTML contains every code block and remains readable without JavaScript.
-The browser enhancer activates one panel at a time and supports Left/Right arrow, Home,
-and End keys. Each group has independent ARIA tab and panel IDs.
+Every group must contain at least two `[code-tab]` shortcodes, and every tab must have a
+non-empty `label`. Content outside the tab shortcodes is not allowed within a group.
 
-The processor is a regular configurable plugin. Projects using DI configuration can
-change both shortcode names without adding a new parser or syntax:
+Visitors can select tabs with a pointer or use Left/Right arrow, Home, and End keys.
+When JavaScript is unavailable, all labeled examples remain visible.
+
+Projects that configure plugins through DI can change both shortcode names:
 
 ```php
 use YiiPress\Processor\Shortcode\CodeGroupProcessor;
@@ -261,7 +262,8 @@ CodeGroupProcessor::class => [
 ],
 ```
 
-That configuration uses `[switcher]` and `[option label="..."]`.
+With this configuration, use `[switcher]` in place of `[code-group]` and
+`[option label="..."]` in place of `[code-tab label="..."]`.
 
 ### Project Processors
 

--- a/roadmap.md
+++ b/roadmap.md
@@ -107,6 +107,7 @@
 - [x] Diagram support (Mermaid) as a plugin
 - [x] oEmbed support (auto-expanding URLs to embeds) as a plugin
 - [x] [Code block language labels](https://github.com/yiipress/engine/issues/105)
+- [x] [Tabbed code groups](https://github.com/yiipress/engine/issues/107)
 - [x] [Per-entry previous/next pager overrides](https://github.com/yiipress/engine/issues/113)
 - [x] [Per-entry edit-link visibility override](https://github.com/yiipress/engine/issues/112)
 

--- a/src/Processor/ContentProcessorPipeline.php
+++ b/src/Processor/ContentProcessorPipeline.php
@@ -93,11 +93,15 @@ final class ContentProcessorPipeline
         $assets = '';
         $collected = [];
         foreach ($this->processors as $processor) {
-            $id = spl_object_id($processor);
-            if ($processor instanceof AssetProcessorInterface && !isset($collected[$id])) {
-                $assets .= $processor->headAssets($processedContent);
-                $collected[$id] = true;
+            if (!$processor instanceof AssetProcessorInterface) {
+                continue;
             }
+            $id = spl_object_id($processor);
+            if (isset($collected[$id])) {
+                continue;
+            }
+            $assets .= $processor->headAssets($processedContent);
+            $collected[$id] = true;
         }
         return $assets;
     }

--- a/src/Processor/ContentProcessorPipeline.php
+++ b/src/Processor/ContentProcessorPipeline.php
@@ -91,9 +91,12 @@ final class ContentProcessorPipeline
     public function collectHeadAssets(string $processedContent): string
     {
         $assets = '';
+        $collected = [];
         foreach ($this->processors as $processor) {
-            if ($processor instanceof AssetProcessorInterface) {
+            $id = spl_object_id($processor);
+            if ($processor instanceof AssetProcessorInterface && !isset($collected[$id])) {
                 $assets .= $processor->headAssets($processedContent);
+                $collected[$id] = true;
             }
         }
         return $assets;

--- a/src/Processor/Shortcode/CodeGroupProcessor.php
+++ b/src/Processor/Shortcode/CodeGroupProcessor.php
@@ -136,37 +136,32 @@ HTML;
 
                 $groupNumber++;
                 $groupId = 'code-group-' . $groupNumber;
-                $controls = [];
                 $panels = [];
 
                 foreach ($tabs as $index => $tab) {
                     $number = $index + 1;
-                    $tabId = $groupId . '-tab-' . $number;
                     $panelId = $groupId . '-panel-' . $number;
+                    $labelId = $panelId . '-label';
                     $label = base64_decode($tab[1], true);
                     if ($label === false) {
                         return $groupMatch[0];
                     }
 
-                    $controls[] = sprintf(
-                        '<button type="button" role="tab" id="%s" aria-controls="%s" aria-selected="%s" tabindex="%s">%s</button>',
-                        $tabId,
-                        $panelId,
-                        $index === 0 ? 'true' : 'false',
-                        $index === 0 ? '0' : '-1',
-                        htmlspecialchars($label, ENT_QUOTES | ENT_SUBSTITUTE | ENT_HTML5),
-                    );
+                    $escapedLabel = htmlspecialchars($label, ENT_QUOTES | ENT_SUBSTITUTE | ENT_HTML5);
                     $panels[] = sprintf(
-                        '<div class="code-group-panel" role="tabpanel" id="%s" aria-labelledby="%s">%s</div>',
+                        '<section class="code-group-panel" id="%s" aria-labelledby="%s" data-code-group-panel data-label="%s">'
+                        . '<div class="code-group-label" id="%s">%s</div>%s</section>',
                         $panelId,
-                        $tabId,
+                        $labelId,
+                        $escapedLabel,
+                        $labelId,
+                        $escapedLabel,
                         trim($tab[2]),
                     );
                 }
 
                 return sprintf(
-                    '<div class="code-group" data-code-group><div class="code-group-tabs" role="tablist">%s</div>%s</div>',
-                    implode('', $controls),
+                    '<div class="code-group" data-code-group>%s</div>',
                     implode('', $panels),
                 );
             },

--- a/src/Processor/Shortcode/CodeGroupProcessor.php
+++ b/src/Processor/Shortcode/CodeGroupProcessor.php
@@ -29,7 +29,7 @@ final readonly class CodeGroupProcessor implements ContentProcessorInterface, As
 
     public function process(string $content, Entry $entry): string
     {
-        if (str_contains($content, '<!-- yiipress-code-group:')) {
+        if (str_contains($content, '<!-- yiipress-code-group:start -->')) {
             return $this->renderGroups($content);
         }
 

--- a/src/Processor/Shortcode/CodeGroupProcessor.php
+++ b/src/Processor/Shortcode/CodeGroupProcessor.php
@@ -10,9 +10,7 @@ use YiiPress\Processor\ContentProcessorInterface;
 
 use function htmlspecialchars;
 use function implode;
-use function preg_match;
 use function preg_match_all;
-use function preg_quote;
 use function preg_replace;
 use function preg_replace_callback;
 use function str_contains;
@@ -20,7 +18,7 @@ use function strtolower;
 use function trim;
 
 /**
- * Turns configurable code-group and code-tab shortcodes into accessible tabbed code groups.
+ * Turns code-group and code-tab shortcodes into accessible tabbed code groups.
  *
  * The same processor is intentionally run on both sides of MarkdownProcessor: the first pass
  * preserves shortcode metadata in HTML comments, and the second pass builds the final markup.
@@ -29,25 +27,13 @@ final readonly class CodeGroupProcessor implements ContentProcessorInterface, As
 {
     use ParsesShortcodeAttributesTrait;
 
-    public function __construct(
-        private string $groupShortcode = 'code-group',
-        private string $tabShortcode = 'code-tab',
-    ) {
-        if (
-            preg_match('/^[a-z][a-z0-9-]*$/i', $this->groupShortcode) !== 1
-            || preg_match('/^[a-z][a-z0-9-]*$/i', $this->tabShortcode) !== 1
-        ) {
-            throw new \InvalidArgumentException('Code group shortcode names must contain only letters, digits, and hyphens.');
-        }
-    }
-
     public function process(string $content, Entry $entry): string
     {
         if (str_contains($content, '<!-- yiipress-code-group:')) {
             return $this->renderGroups($content);
         }
 
-        if (!str_contains(strtolower($content), '[' . strtolower($this->groupShortcode))) {
+        if (!str_contains(strtolower($content), '[code-group]')) {
             return $content;
         }
 
@@ -77,16 +63,13 @@ HTML;
 
     private function preserveShortcodes(string $content): string
     {
-        $group = preg_quote($this->groupShortcode, '/');
-        $tab = preg_quote($this->tabShortcode, '/');
-
         return (string) preg_replace_callback(
-            '/^\[' . $group . '\]\s*$([\s\S]*?)^\[\/' . $group . '\]\s*$/mi',
-            function (array $groupMatch) use ($tab): string {
+            '/^\[code-group\]\s*$([\s\S]*?)^\[\/code-group\]\s*$/mi',
+            function (array $groupMatch): string {
                 $tabs = [];
                 if (
                     preg_match_all(
-                        $tabPattern = '/^\[' . $tab . '\s+([^\]]*)\]\s*$([\s\S]*?)^\[\/' . $tab . '\]\s*$/mi',
+                        $tabPattern = '/^\[code-tab\s+([^\]]*)\]\s*$([\s\S]*?)^\[\/code-tab\]\s*$/mi',
                         $groupMatch[1],
                         $tabMatches,
                         PREG_SET_ORDER,

--- a/src/Processor/Shortcode/CodeGroupProcessor.php
+++ b/src/Processor/Shortcode/CodeGroupProcessor.php
@@ -1,0 +1,176 @@
+<?php
+
+declare(strict_types=1);
+
+namespace YiiPress\Processor\Shortcode;
+
+use YiiPress\Content\Model\Entry;
+use YiiPress\Processor\AssetProcessorInterface;
+use YiiPress\Processor\ContentProcessorInterface;
+
+use function htmlspecialchars;
+use function implode;
+use function preg_match;
+use function preg_match_all;
+use function preg_quote;
+use function preg_replace;
+use function preg_replace_callback;
+use function str_contains;
+use function strtolower;
+use function trim;
+
+/**
+ * Turns configurable code-group and code-tab shortcodes into accessible tabbed code groups.
+ *
+ * The same processor is intentionally run on both sides of MarkdownProcessor: the first pass
+ * preserves shortcode metadata in HTML comments, and the second pass builds the final markup.
+ */
+final readonly class CodeGroupProcessor implements ContentProcessorInterface, AssetProcessorInterface
+{
+    use ParsesShortcodeAttributesTrait;
+
+    public function __construct(
+        private string $groupShortcode = 'code-group',
+        private string $tabShortcode = 'code-tab',
+    ) {
+        if (
+            preg_match('/^[a-z][a-z0-9-]*$/i', $this->groupShortcode) !== 1
+            || preg_match('/^[a-z][a-z0-9-]*$/i', $this->tabShortcode) !== 1
+        ) {
+            throw new \InvalidArgumentException('Code group shortcode names must contain only letters, digits, and hyphens.');
+        }
+    }
+
+    public function process(string $content, Entry $entry): string
+    {
+        if (str_contains($content, '<!-- yiipress-code-group:')) {
+            return $this->renderGroups($content);
+        }
+
+        if (!str_contains(strtolower($content), '[' . strtolower($this->groupShortcode))) {
+            return $content;
+        }
+
+        return $this->preserveShortcodes($content);
+    }
+
+    public function headAssets(string $processedContent): string
+    {
+        if (!str_contains($processedContent, 'class="code-group"')) {
+            return '';
+        }
+
+        return <<<'HTML'
+    <link rel="stylesheet" href="assets/plugins/code-groups.css">
+    <script defer src="assets/plugins/code-groups.js"></script>
+
+HTML;
+    }
+
+    public function assetFiles(): array
+    {
+        return [
+            __DIR__ . '/assets/code-groups.css' => 'assets/plugins/code-groups.css',
+            __DIR__ . '/assets/code-groups.js' => 'assets/plugins/code-groups.js',
+        ];
+    }
+
+    private function preserveShortcodes(string $content): string
+    {
+        $group = preg_quote($this->groupShortcode, '/');
+        $tab = preg_quote($this->tabShortcode, '/');
+
+        return (string) preg_replace_callback(
+            '/^\[' . $group . '\]\s*$([\s\S]*?)^\[\/' . $group . '\]\s*$/mi',
+            function (array $groupMatch) use ($tab): string {
+                $tabs = [];
+                if (
+                    preg_match_all(
+                        $tabPattern = '/^\[' . $tab . '\s+([^\]]*)\]\s*$([\s\S]*?)^\[\/' . $tab . '\]\s*$/mi',
+                        $groupMatch[1],
+                        $tabMatches,
+                        PREG_SET_ORDER,
+                    ) < 2
+                    || trim((string) preg_replace($tabPattern, '', $groupMatch[1])) !== ''
+                ) {
+                    return $groupMatch[0];
+                }
+
+                foreach ($tabMatches as $tabMatch) {
+                    $attributes = $this->parseAttributes($tabMatch[1]);
+                    $label = $attributes['label'] ?? '';
+                    if ($label === '') {
+                        return $groupMatch[0];
+                    }
+                    $tabs[] = '<!-- yiipress-code-tab:' . base64_encode($label) . " -->\n"
+                        . trim($tabMatch[2]) . "\n"
+                        . '<!-- /yiipress-code-tab -->';
+                }
+
+                return "<!-- yiipress-code-group:start -->\n"
+                    . implode("\n", $tabs)
+                    . "\n<!-- yiipress-code-group:end -->";
+            },
+            $content,
+        );
+    }
+
+    private function renderGroups(string $content): string
+    {
+        $groupNumber = 0;
+
+        return (string) preg_replace_callback(
+            '/<!-- yiipress-code-group:start -->\s*([\s\S]*?)\s*<!-- yiipress-code-group:end -->/',
+            static function (array $groupMatch) use (&$groupNumber): string {
+                $tabs = [];
+                preg_match_all(
+                    '/<!-- yiipress-code-tab:([A-Za-z0-9+\/=]+) -->\s*([\s\S]*?)\s*<!-- \/yiipress-code-tab -->/',
+                    $groupMatch[1],
+                    $tabs,
+                    PREG_SET_ORDER,
+                );
+
+                if (count($tabs) < 2) {
+                    return $groupMatch[0];
+                }
+
+                $groupNumber++;
+                $groupId = 'code-group-' . $groupNumber;
+                $controls = [];
+                $panels = [];
+
+                foreach ($tabs as $index => $tab) {
+                    $number = $index + 1;
+                    $tabId = $groupId . '-tab-' . $number;
+                    $panelId = $groupId . '-panel-' . $number;
+                    $label = base64_decode($tab[1], true);
+                    if ($label === false) {
+                        return $groupMatch[0];
+                    }
+
+                    $controls[] = sprintf(
+                        '<button type="button" role="tab" id="%s" aria-controls="%s" aria-selected="%s" tabindex="%s">%s</button>',
+                        $tabId,
+                        $panelId,
+                        $index === 0 ? 'true' : 'false',
+                        $index === 0 ? '0' : '-1',
+                        htmlspecialchars($label, ENT_QUOTES | ENT_SUBSTITUTE | ENT_HTML5),
+                    );
+                    $panels[] = sprintf(
+                        '<div class="code-group-panel" role="tabpanel" id="%s" aria-labelledby="%s">%s</div>',
+                        $panelId,
+                        $tabId,
+                        trim($tab[2]),
+                    );
+                }
+
+                return sprintf(
+                    '<div class="code-group" data-code-group><div class="code-group-tabs" role="tablist">%s</div>%s</div>',
+                    implode('', $controls),
+                    implode('', $panels),
+                );
+            },
+            $content,
+        );
+    }
+}

--- a/src/Processor/Shortcode/assets/code-groups.css
+++ b/src/Processor/Shortcode/assets/code-groups.css
@@ -21,8 +21,17 @@
 }
 
 .code-group-tabs [role="tab"][aria-selected="true"] {
-    border-bottom-color: currentColor;
+    border-bottom-color: currentcolor;
     font-weight: 600;
+}
+
+.code-group-label {
+    margin-bottom: .5rem;
+    font-weight: 600;
+}
+
+.code-group.is-enhanced .code-group-label {
+    display: none;
 }
 
 .code-group.is-enhanced .code-group-panel[hidden] {

--- a/src/Processor/Shortcode/assets/code-groups.css
+++ b/src/Processor/Shortcode/assets/code-groups.css
@@ -1,0 +1,38 @@
+.code-group {
+    margin: 1.5rem 0;
+}
+
+.code-group-tabs {
+    display: flex;
+    gap: .25rem;
+    overflow-x: auto;
+    border-bottom: 1px solid var(--border-color, #d1d5db);
+}
+
+.code-group-tabs [role="tab"] {
+    padding: .55rem .8rem;
+    border: 0;
+    border-bottom: 2px solid transparent;
+    background: transparent;
+    color: inherit;
+    font: inherit;
+    white-space: nowrap;
+    cursor: pointer;
+}
+
+.code-group-tabs [role="tab"][aria-selected="true"] {
+    border-bottom-color: currentColor;
+    font-weight: 600;
+}
+
+.code-group.is-enhanced .code-group-panel[hidden] {
+    display: none;
+}
+
+.code-group-panel > :first-child {
+    margin-top: 0;
+}
+
+.code-group-panel > :last-child {
+    margin-bottom: 0;
+}

--- a/src/Processor/Shortcode/assets/code-groups.js
+++ b/src/Processor/Shortcode/assets/code-groups.js
@@ -1,0 +1,61 @@
+(function () {
+    'use strict';
+
+    function activate(tab, focus) {
+        const group = tab.closest('[data-code-group]');
+        const tabs = Array.from(group.querySelectorAll('[role="tab"]'));
+
+        tabs.forEach(function (candidate) {
+            const selected = candidate === tab;
+            const panel = document.getElementById(candidate.getAttribute('aria-controls'));
+
+            candidate.setAttribute('aria-selected', selected ? 'true' : 'false');
+            candidate.tabIndex = selected ? 0 : -1;
+            if (panel) {
+                panel.hidden = !selected;
+            }
+        });
+
+        if (focus) {
+            tab.focus();
+            tab.scrollIntoView({ behavior: 'smooth', block: 'nearest', inline: 'nearest' });
+        }
+
+        group.dispatchEvent(new CustomEvent('yiipress:code-group-activate', {
+            bubbles: true,
+            detail: { tab: tab },
+        }));
+    }
+
+    document.addEventListener('click', function (event) {
+        const tab = event.target.closest('[data-code-group] [role="tab"]');
+        if (tab) {
+            activate(tab, false);
+        }
+    });
+
+    document.addEventListener('keydown', function (event) {
+        const tab = event.target.closest('[data-code-group] [role="tab"]');
+        if (!tab || !['ArrowLeft', 'ArrowRight', 'Home', 'End'].includes(event.key)) {
+            return;
+        }
+
+        const tabs = Array.from(tab.closest('[role="tablist"]').querySelectorAll('[role="tab"]'));
+        let index = tabs.indexOf(tab);
+        event.preventDefault();
+
+        if (event.key === 'Home') {
+            index = 0;
+        } else if (event.key === 'End') {
+            index = tabs.length - 1;
+        } else {
+            index = (index + (event.key === 'ArrowRight' ? 1 : -1) + tabs.length) % tabs.length;
+        }
+        activate(tabs[index], true);
+    });
+
+    document.querySelectorAll('[data-code-group]').forEach(function (group) {
+        group.classList.add('is-enhanced');
+        activate(group.querySelector('[role="tab"]'), false);
+    });
+}());

--- a/src/Processor/Shortcode/assets/code-groups.js
+++ b/src/Processor/Shortcode/assets/code-groups.js
@@ -2,12 +2,20 @@
     'use strict';
 
     function activate(tab, focus) {
+        if (!tab) {
+            return;
+        }
+
         const group = tab.closest('[data-code-group]');
+        if (!group) {
+            return;
+        }
+
         const tabs = Array.from(group.querySelectorAll('[role="tab"]'));
 
         tabs.forEach(function (candidate) {
             const selected = candidate === tab;
-            const panel = document.getElementById(candidate.getAttribute('aria-controls'));
+            const panel = group.querySelector('#' + candidate.getAttribute('aria-controls'));
 
             candidate.setAttribute('aria-selected', selected ? 'true' : 'false');
             candidate.tabIndex = selected ? 0 : -1;
@@ -55,6 +63,32 @@
     });
 
     document.querySelectorAll('[data-code-group]').forEach(function (group) {
+        const panels = Array.from(group.querySelectorAll('[data-code-group-panel]'));
+        if (panels.length < 2) {
+            return;
+        }
+
+        const tablist = document.createElement('div');
+        tablist.className = 'code-group-tabs';
+        tablist.setAttribute('role', 'tablist');
+
+        panels.forEach(function (panel, index) {
+            const tab = document.createElement('button');
+            const tabId = panel.id + '-tab';
+
+            tab.type = 'button';
+            tab.id = tabId;
+            tab.textContent = panel.dataset.label;
+            tab.setAttribute('role', 'tab');
+            tab.setAttribute('aria-controls', panel.id);
+            tab.setAttribute('aria-selected', index === 0 ? 'true' : 'false');
+            tab.tabIndex = index === 0 ? 0 : -1;
+            panel.setAttribute('role', 'tabpanel');
+            panel.setAttribute('aria-labelledby', tabId);
+            tablist.appendChild(tab);
+        });
+
+        group.prepend(tablist);
         group.classList.add('is-enhanced');
         activate(group.querySelector('[role="tab"]'), false);
     });

--- a/tests/Unit/Processor/CodeGroupProcessorTest.php
+++ b/tests/Unit/Processor/CodeGroupProcessorTest.php
@@ -1,0 +1,152 @@
+<?php
+
+declare(strict_types=1);
+
+namespace YiiPress\Tests\Unit\Processor;
+
+use DateTimeImmutable;
+use PHPUnit\Framework\TestCase;
+use YiiPress\Content\Model\Entry;
+use YiiPress\Processor\MarkdownProcessor;
+use YiiPress\Processor\Shortcode\CodeGroupProcessor;
+use YiiPress\Render\MarkdownRenderer;
+
+final class CodeGroupProcessorTest extends TestCase
+{
+    public function testRendersAccessibleGroupAcrossMarkdownPass(): void
+    {
+        $processor = new CodeGroupProcessor();
+        $markdown = <<<'MARKDOWN'
+[code-group]
+[code-tab label="npm"]
+```sh
+npm install
+```
+[/code-tab]
+[code-tab label="pnpm"]
+```sh
+pnpm install
+```
+[/code-tab]
+[/code-group]
+MARKDOWN;
+
+        $preserved = $processor->process($markdown, $this->entry());
+        $html = (new MarkdownProcessor(new MarkdownRenderer()))->process($preserved, $this->entry());
+        $result = $processor->process($html, $this->entry());
+
+        self::assertStringContainsString('class="code-group"', $result);
+        self::assertStringContainsString('role="tablist"', $result);
+        self::assertStringContainsString('role="tab"', $result);
+        self::assertStringContainsString('role="tabpanel"', $result);
+        self::assertStringContainsString('aria-selected="true"', $result);
+        self::assertStringContainsString('<code class="language-sh">npm install', $result);
+        self::assertStringContainsString('<code class="language-sh">pnpm install', $result);
+    }
+
+    public function testSupportsConfiguredShortcodeNames(): void
+    {
+        $processor = new CodeGroupProcessor('switcher', 'option');
+        $markdown = <<<'MARKDOWN'
+[switcher]
+[option label="PHP"]
+```php
+echo 1;
+```
+[/option]
+[option label="Go"]
+```go
+fmt.Println(1)
+```
+[/option]
+[/switcher]
+MARKDOWN;
+
+        $preserved = $processor->process($markdown, $this->entry());
+
+        self::assertStringContainsString('yiipress-code-group:start', $preserved);
+        self::assertStringNotContainsString('[switcher]', $preserved);
+    }
+
+    public function testRequiresTwoLabeledTabs(): void
+    {
+        $processor = new CodeGroupProcessor();
+        $content = "[code-group]\n[code-tab label=\"Only\"]\n```text\none\n```\n[/code-tab]\n[/code-group]";
+
+        self::assertSame($content, $processor->process($content, $this->entry()));
+    }
+
+    public function testDoesNotDiscardContentOutsideTabs(): void
+    {
+        $processor = new CodeGroupProcessor();
+        $content = "[code-group]\nKeep me\n"
+            . "[code-tab label=\"One\"]\n```text\none\n```\n[/code-tab]\n"
+            . "[code-tab label=\"Two\"]\n```text\ntwo\n```\n[/code-tab]\n[/code-group]";
+
+        self::assertSame($content, $processor->process($content, $this->entry()));
+    }
+
+    public function testEscapesLabelsAndCreatesIndependentGroupIds(): void
+    {
+        $processor = new CodeGroupProcessor();
+        $group = static fn(string $label): string => "[code-group]\n"
+            . "[code-tab label=\"$label\"]\n```text\none\n```\n[/code-tab]\n"
+            . "[code-tab label=\"Two\"]\n```text\ntwo\n```\n[/code-tab]\n[/code-group]";
+        $preserved = $processor->process($group('<b>One</b>') . "\n" . $group('Three'), $this->entry());
+        $html = (new MarkdownProcessor(new MarkdownRenderer()))->process($preserved, $this->entry());
+        $result = $processor->process($html, $this->entry());
+
+        self::assertStringContainsString('&lt;b&gt;One&lt;/b&gt;', $result);
+        self::assertStringContainsString('id="code-group-1-tab-1"', $result);
+        self::assertStringContainsString('id="code-group-2-tab-1"', $result);
+    }
+
+    public function testProvidesAssetsOnlyForRenderedGroups(): void
+    {
+        $processor = new CodeGroupProcessor();
+
+        self::assertSame('', $processor->headAssets('<p>Plain</p>'));
+        self::assertStringContainsString('code-groups.css', $processor->headAssets('<div class="code-group"></div>'));
+        self::assertCount(2, $processor->assetFiles());
+    }
+
+    public function testBrowserAssetsUseDelegationKeyboardNavigationAndProgressiveEnhancement(): void
+    {
+        $directory = dirname(__DIR__, 3) . '/src/Processor/Shortcode/assets/';
+        $script = file_get_contents($directory . 'code-groups.js');
+        $style = file_get_contents($directory . 'code-groups.css');
+
+        self::assertNotFalse($script);
+        self::assertNotFalse($style);
+        self::assertStringContainsString("document.addEventListener('click'", $script);
+        self::assertStringContainsString("document.addEventListener('keydown'", $script);
+        self::assertStringContainsString("'ArrowLeft', 'ArrowRight', 'Home', 'End'", $script);
+        self::assertStringContainsString("group.classList.add('is-enhanced')", $script);
+        self::assertStringContainsString('.code-group.is-enhanced .code-group-panel[hidden]', $style);
+    }
+
+    private function entry(): Entry
+    {
+        return new Entry(
+            filePath: __FILE__,
+            collection: 'docs',
+            slug: 'test',
+            title: 'Test',
+            date: new DateTimeImmutable('2026-01-01'),
+            draft: false,
+            tags: [],
+            categories: [],
+            authors: [],
+            summary: '',
+            permalink: '/docs/test/',
+            layout: '',
+            theme: '',
+            weight: 0,
+            language: 'en',
+            redirectTo: '',
+            extra: [],
+            bodyOffset: 0,
+            bodyLength: 0,
+        );
+    }
+}

--- a/tests/Unit/Processor/CodeGroupProcessorTest.php
+++ b/tests/Unit/Processor/CodeGroupProcessorTest.php
@@ -45,30 +45,6 @@ MARKDOWN;
         self::assertStringContainsString('<code class="language-sh">pnpm install', $result);
     }
 
-    public function testSupportsConfiguredShortcodeNames(): void
-    {
-        $processor = new CodeGroupProcessor('switcher', 'option');
-        $markdown = <<<'MARKDOWN'
-[switcher]
-[option label="PHP"]
-```php
-echo 1;
-```
-[/option]
-[option label="Go"]
-```go
-fmt.Println(1)
-```
-[/option]
-[/switcher]
-MARKDOWN;
-
-        $preserved = $processor->process($markdown, $this->entry());
-
-        self::assertStringContainsString('yiipress-code-group:start', $preserved);
-        self::assertStringNotContainsString('[switcher]', $preserved);
-    }
-
     public function testRequiresTwoLabeledTabs(): void
     {
         $processor = new CodeGroupProcessor();

--- a/tests/Unit/Processor/CodeGroupProcessorTest.php
+++ b/tests/Unit/Processor/CodeGroupProcessorTest.php
@@ -63,6 +63,22 @@ MARKDOWN;
         self::assertSame($content, $processor->process($content, $this->entry()));
     }
 
+    public function testUnrelatedCodeGroupCommentDoesNotSkipShortcodePreservation(): void
+    {
+        $processor = new CodeGroupProcessor();
+        $content = "<!-- yiipress-code-group:note -->\n"
+            . "[code-group]\n"
+            . "[code-tab label=\"One\"]\n```text\none\n```\n[/code-tab]\n"
+            . "[code-tab label=\"Two\"]\n```text\ntwo\n```\n[/code-tab]\n"
+            . '[/code-group]';
+
+        $result = $processor->process($content, $this->entry());
+
+        self::assertStringContainsString('<!-- yiipress-code-group:note -->', $result);
+        self::assertStringContainsString('<!-- yiipress-code-group:start -->', $result);
+        self::assertStringNotContainsString('[code-group]', $result);
+    }
+
     public function testEscapesLabelsAndCreatesIndependentGroupIds(): void
     {
         $processor = new CodeGroupProcessor();

--- a/tests/Unit/Processor/CodeGroupProcessorTest.php
+++ b/tests/Unit/Processor/CodeGroupProcessorTest.php
@@ -13,7 +13,7 @@ use YiiPress\Render\MarkdownRenderer;
 
 final class CodeGroupProcessorTest extends TestCase
 {
-    public function testRendersAccessibleGroupAcrossMarkdownPass(): void
+    public function testRendersLabeledFallbackGroupAcrossMarkdownPass(): void
     {
         $processor = new CodeGroupProcessor();
         $markdown = <<<'MARKDOWN'
@@ -36,10 +36,11 @@ MARKDOWN;
         $result = $processor->process($html, $this->entry());
 
         self::assertStringContainsString('class="code-group"', $result);
-        self::assertStringContainsString('role="tablist"', $result);
-        self::assertStringContainsString('role="tab"', $result);
-        self::assertStringContainsString('role="tabpanel"', $result);
-        self::assertStringContainsString('aria-selected="true"', $result);
+        self::assertStringContainsString('class="code-group-label"', $result);
+        self::assertStringContainsString('data-label="npm"', $result);
+        self::assertStringContainsString('data-label="pnpm"', $result);
+        self::assertStringNotContainsString('role="tab"', $result);
+        self::assertStringNotContainsString('<button', $result);
         self::assertStringContainsString('<code class="language-sh">npm install', $result);
         self::assertStringContainsString('<code class="language-sh">pnpm install', $result);
     }
@@ -97,8 +98,8 @@ MARKDOWN;
         $result = $processor->process($html, $this->entry());
 
         self::assertStringContainsString('&lt;b&gt;One&lt;/b&gt;', $result);
-        self::assertStringContainsString('id="code-group-1-tab-1"', $result);
-        self::assertStringContainsString('id="code-group-2-tab-1"', $result);
+        self::assertStringContainsString('id="code-group-1-panel-1"', $result);
+        self::assertStringContainsString('id="code-group-2-panel-1"', $result);
     }
 
     public function testProvidesAssetsOnlyForRenderedGroups(): void
@@ -121,7 +122,10 @@ MARKDOWN;
         self::assertStringContainsString("document.addEventListener('click'", $script);
         self::assertStringContainsString("document.addEventListener('keydown'", $script);
         self::assertStringContainsString("'ArrowLeft', 'ArrowRight', 'Home', 'End'", $script);
+        self::assertStringContainsString("document.createElement('button')", $script);
+        self::assertStringContainsString("panel.setAttribute('role', 'tabpanel')", $script);
         self::assertStringContainsString("group.classList.add('is-enhanced')", $script);
+        self::assertStringContainsString("if (!tab)", $script);
         self::assertStringContainsString('.code-group.is-enhanced .code-group-panel[hidden]', $style);
     }
 

--- a/tests/Unit/Processor/ContentProcessorPipelineConfigTest.php
+++ b/tests/Unit/Processor/ContentProcessorPipelineConfigTest.php
@@ -8,6 +8,7 @@ use PHPUnit\Framework\TestCase;
 use ReflectionProperty;
 use YiiPress\Processor\ContentProcessorPipeline;
 use YiiPress\Processor\LatexMath\LatexMathProcessor;
+use YiiPress\Processor\Shortcode\CodeGroupProcessor;
 use Yiisoft\Definitions\Reference;
 
 use function dirname;
@@ -26,6 +27,7 @@ final class ContentProcessorPipelineConfigTest extends TestCase
         }
 
         self::assertContains(LatexMathProcessor::class, $registeredProcessorIds);
+        self::assertSame(2, array_count_values($registeredProcessorIds)[CodeGroupProcessor::class] ?? 0);
 
         $pipeline = new ContentProcessorPipeline(new LatexMathProcessor());
         self::assertStringContainsString(

--- a/tests/Unit/Processor/ContentProcessorPipelineConfigTest.php
+++ b/tests/Unit/Processor/ContentProcessorPipelineConfigTest.php
@@ -8,14 +8,16 @@ use PHPUnit\Framework\TestCase;
 use ReflectionProperty;
 use YiiPress\Processor\ContentProcessorPipeline;
 use YiiPress\Processor\LatexMath\LatexMathProcessor;
+use YiiPress\Processor\MarkdownProcessor;
 use YiiPress\Processor\Shortcode\CodeGroupProcessor;
+use YiiPress\Processor\SyntaxHighlightProcessor;
 use Yiisoft\Definitions\Reference;
 
 use function dirname;
 
 final class ContentProcessorPipelineConfigTest extends TestCase
 {
-    public function testContentPipelineIncludesLatexMathAssetsProcessor(): void
+    public function testContentPipelineIncludesAssetsAndTwoPassCodeGroupProcessors(): void
     {
         $definitions = require dirname(__DIR__, 3) . '/config/common/di/content-pipeline.php';
         $referenceId = new ReflectionProperty(Reference::class, 'id');
@@ -27,7 +29,23 @@ final class ContentProcessorPipelineConfigTest extends TestCase
         }
 
         self::assertContains(LatexMathProcessor::class, $registeredProcessorIds);
-        self::assertSame(2, array_count_values($registeredProcessorIds)[CodeGroupProcessor::class] ?? 0);
+        $codeGroupPositions = array_keys(
+            array_filter(
+                $registeredProcessorIds,
+                static fn(string $processorId): bool => $processorId === CodeGroupProcessor::class,
+            ),
+        );
+        $markdownPosition = array_search(MarkdownProcessor::class, $registeredProcessorIds, true);
+        $syntaxHighlightPosition = array_search(SyntaxHighlightProcessor::class, $registeredProcessorIds, true);
+        self::assertNotFalse($markdownPosition);
+        self::assertNotFalse($syntaxHighlightPosition);
+        self::assertSame(
+            [
+                $markdownPosition - 1,
+                $syntaxHighlightPosition + 1,
+            ],
+            $codeGroupPositions,
+        );
 
         $pipeline = new ContentProcessorPipeline(new LatexMathProcessor());
         self::assertStringContainsString(

--- a/tests/Unit/Processor/ContentProcessorPipelineTest.php
+++ b/tests/Unit/Processor/ContentProcessorPipelineTest.php
@@ -102,6 +102,29 @@ final class ContentProcessorPipelineTest extends TestCase
         assertSame('', $pipeline->collectHeadAssets('content'));
     }
 
+    public function testCollectHeadAssetsOnceWhenSameProcessorIsInPipelineTwice(): void
+    {
+        $assetProcessor = new class implements ContentProcessorInterface, AssetProcessorInterface {
+            public function process(string $content, Entry $entry): string
+            {
+                return $content;
+            }
+
+            public function headAssets(string $processedContent): string
+            {
+                return '<script src="test.js"></script>';
+            }
+
+            public function assetFiles(): array
+            {
+                return [];
+            }
+        };
+        $pipeline = new ContentProcessorPipeline($assetProcessor, $assetProcessor);
+
+        assertSame('<script src="test.js"></script>', $pipeline->collectHeadAssets('content'));
+    }
+
     public function testCollectAssetFilesFromAssetAwareProcessors(): void
     {
         $assetProcessor = new class implements ContentProcessorInterface, AssetProcessorInterface {
@@ -133,14 +156,12 @@ final class ContentProcessorPipelineTest extends TestCase
 
     public function testApplySiteConfigPassesConfigurationToAwareProcessors(): void
     {
-        $state = new class () {
+        $state = new class {
             public ?string $receivedTheme = null;
         };
 
         $awareProcessor = new class ($state) implements ContentProcessorInterface, SiteConfigAwareProcessorInterface {
-            public function __construct(private object $state)
-            {
-            }
+            public function __construct(private object $state) {}
 
             public function applySiteConfig(SiteConfig $siteConfig): void
             {


### PR DESCRIPTION
## Summary

- add configurable `CodeGroupProcessor` using existing `[code-group]` and `[code-tab label="..."]` shortcode conventions
- render progressive, accessible tab markup with group-local IDs and one delegated keyboard/click enhancer
- add conditional CSS/JS assets, PHPUnit and browser-asset coverage, phpbench benchmark, plugin documentation, and roadmap completion

## Validation

- `make test CLI_ARGS=--filter=CodeGroupProcessorTest` — 7 tests, 24 assertions
- `make test CLI_ARGS=--filter=ContentProcessorPipeline` — 13 tests, 27 assertions
- `make psalm` — no errors
- `make composer-dependency-analyser` — no issues
- `make bench BENCH_FILTER=CodeGroupProcessorBench` — passing, ~29.7 μs
- full `make test` — 844/845 pass; existing line-ending-sensitive `MarkdownRendererTest::testRendersTaskList` fails because actual LF output is compared with a CRLF fixture

Fixes #107.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added tabbed code groups to group multiple labeled code examples into switchable panels.
  * Added enhanced tab UI with mouse and keyboard navigation (with a no-JavaScript fallback showing all examples).
  * Ensures tab groups render independently when multiple groups appear on the same page.
* **Bug Fixes**
  * Prevented duplicate inclusion of shared head assets when processors are reused.
* **Documentation**
  * Documented `[code-group]` / `[code-tab]` syntax, constraints, and interaction behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->