### PR TITLE
Fix #110: Add per-entry documentation aside visibility

### DIFF
--- a/docs/content.md
+++ b/docs/content.md
@@ -330,7 +330,7 @@ sidebar:
 
 You can define any number of menus. Each item has a `title`, an optional `url`, and supports nested `children` for sub-navigation. Items without `url` render as section labels, which is useful for grouped sidebars.
 
-In the bundled `minimal` theme, a menu named `sidebar` enables a documentation layout for entries whose permalink appears in that sidebar. Those pages render the sidebar navigation on the left and the generated table of contents on the right. Blog entries and other pages that are not listed in `sidebar` keep the regular article layout.
+In the bundled `minimal` theme, a menu named `sidebar` enables a documentation layout for entries whose permalink appears in that sidebar. Those pages render the sidebar navigation on the left and the generated table of contents on the right. Set `aside: false` in an entry's front matter to hide only its right-hand documentation aside; heading IDs and table-of-contents data remain available to custom templates. Omitting `aside` (or setting it to `true`) keeps the default documentation layout. Blog entries and other pages that are not listed in `sidebar` keep the regular article layout.
 
 To localize menu labels, make `title` a language map instead of a scalar:
 

--- a/docs/templates.md
+++ b/docs/templates.md
@@ -172,6 +172,7 @@ Built-in templates and partials expect `$ui` to be passed by the renderer; `Page
 | `$permalink`  | `string`      | Current entry permalink                                          |
 | `$nav`        | `?Navigation` | Navigation object or `null`                                      |
 | `$toc`        | `list<array>` | Table of contents entries (`{id, text, level}`) or empty list    |
+| `$aside`      | `bool`        | Whether the documentation aside is enabled for this entry        |
 | `$related`    | `list<RelatedEntry>` | Related entries ordered by relevance or empty list        |
 | `$language`   | `string`      | Effective language code for the current entry                    |
 | `$translations` | `list<Translation>` | Alternate-language versions of the current entry           |

--- a/roadmap.md
+++ b/roadmap.md
@@ -113,6 +113,7 @@
 - [x] [FAQ question blocks with configurable section grouping](https://github.com/yiipress/engine/issues/114)
 - [x] [Per-entry table-of-contents depth and visibility](https://github.com/yiipress/engine/issues/109)
 - [x] [Per-entry last-updated visibility override](https://github.com/yiipress/engine/issues/111)
+- [x] [Per-entry documentation aside visibility](https://github.com/yiipress/engine/issues/110)
 
 ## Priority 8: Advanced features
 

--- a/src/Build/EntryRenderer.php
+++ b/src/Build/EntryRenderer.php
@@ -228,7 +228,7 @@ final class EntryRenderer
             'entryAuthors' => $this->entryAuthors($siteConfig, $entry, $rootPath),
             'tags' => array_values(array_filter(
                 $entry->tags,
-                static fn (string $tag) => !in_array(mb_strtolower($tag), $entry->inlineTags, true),
+                static fn(string $tag) => !in_array(mb_strtolower($tag), $entry->inlineTags, true),
             )),
             'categories' => $entry->categories,
             'collection' => $entry->collection,
@@ -238,6 +238,7 @@ final class EntryRenderer
             'nav' => $navigation,
             'headAssets' => $headAssets,
             'toc' => $toc,
+            'aside' => $entry->aside ?? true,
             'related' => $related,
             'translations' => $translations,
             'navigationPager' => $navigationPager,
@@ -250,7 +251,7 @@ final class EntryRenderer
             'rootPath' => $rootPath,
             'assetManifest' => $this->assetManifest,
             'themeName' => $themeName,
-            'themeAsset' => fn (string $path): string => Asset::themeUrl(
+            'themeAsset' => fn(string $path): string => Asset::themeUrl(
                 $path,
                 $this->templateResolver->resolveResourceThemeName('assets/' . ltrim($path, '/'), $themeName),
                 $rootPath,
@@ -270,7 +271,7 @@ final class EntryRenderer
     private function authorText(Entry $entry): string
     {
         return implode(', ', array_map(
-            fn (string $authorSlug) => $this->authors[$authorSlug]->title ?? $authorSlug,
+            fn(string $authorSlug) => $this->authors[$authorSlug]->title ?? $authorSlug,
             $entry->authors,
         ));
     }

--- a/src/Content/Model/Entry.php
+++ b/src/Content/Model/Entry.php
@@ -50,6 +50,7 @@ final class Entry
         public int|false|null $faqLevel = null,
         public array|false|null $toc = null,
         public ?bool $lastUpdated = null,
+        public ?bool $aside = null,
     ) {}
 
     private ?string $bodyCache = null;
@@ -93,6 +94,7 @@ final class Entry
             faqLevel: $this->faqLevel,
             toc: $this->toc,
             lastUpdated: $this->lastUpdated,
+            aside: $this->aside,
         );
     }
 

--- a/src/Content/Parser/EntryParser.php
+++ b/src/Content/Parser/EntryParser.php
@@ -114,6 +114,7 @@ final readonly class EntryParser
             faqLevel: $this->parseFaqLevel($fields, $filePath),
             toc: $this->parseToc($fields, $filePath),
             lastUpdated: $this->parseBooleanOverride($fields, 'last_updated', $filePath),
+            aside: $this->parseBooleanOverride($fields, 'aside', $filePath),
         );
     }
 

--- a/tests/Unit/Build/EntryRendererTest.php
+++ b/tests/Unit/Build/EntryRendererTest.php
@@ -13,6 +13,8 @@ use YiiPress\Build\TemplateResolver;
 use YiiPress\Content\Model\Author;
 use YiiPress\Content\Model\Entry;
 use YiiPress\Content\Model\I18nConfig;
+use YiiPress\Content\Model\Navigation;
+use YiiPress\Content\Model\NavigationItem;
 use YiiPress\Content\Model\SearchConfig;
 use YiiPress\Content\Model\SiteConfig;
 use YiiPress\Hook\RenderFinishedEvent;
@@ -213,6 +215,48 @@ final class EntryRendererTest extends TestCase
             static fn (string $file): bool => $file !== '.' && $file !== '..',
         ));
         $this->assertCount(2, $cacheFiles);
+    }
+
+    public function testCanHideDocumentationAsideWithoutDiscardingTocData(): void
+    {
+        $entryFile = $this->contentDir . '/blog/post.md';
+        file_put_contents($entryFile, "---\ntitle: Focused\n---\n\n<h2>Details</h2>\n");
+        $themePath = $this->contentDir . '/custom-theme';
+        mkdir($themePath);
+        file_put_contents($themePath . '/entry.php', '<?= $aside ? "aside-visible" : "aside-hidden" ?>|<?= count($toc) ?>');
+
+        $entry = $this->createEntry(filePath: $entryFile, title: 'Focused', aside: false);
+        $renderer = new EntryRenderer(
+            new ContentProcessorPipeline(new TocProcessor()),
+            $this->createTemplateResolver($themePath),
+            contentDir: $this->contentDir,
+        );
+        $html = $renderer->render($this->createSiteConfig(theme: 'custom', minify: false), $entry, '/docs/focused/');
+
+        assertSame('aside-hidden|1', $html);
+    }
+
+    public function testHiddenDocumentationAsideDoesNotReserveThemeGridColumn(): void
+    {
+        $entryFile = $this->contentDir . '/blog/post.md';
+        file_put_contents($entryFile, "---\ntitle: Focused\n---\n\n<h2>Details</h2>\n");
+
+        $entry = $this->createEntry(filePath: $entryFile, title: 'Focused', aside: false);
+        $renderer = new EntryRenderer(
+            new ContentProcessorPipeline(new TocProcessor()),
+            $this->createTemplateResolver(),
+            contentDir: $this->contentDir,
+        );
+        $navigation = new Navigation([
+            'sidebar' => [new NavigationItem('Focused', '/docs/focused/', [])],
+        ]);
+        $html = $renderer->render($this->createSiteConfig(minify: false), $entry, '/docs/focused/', $navigation);
+
+        assertStringContainsString('class="docs-layout"', $html);
+        assertStringContainsString('class="docs-sidebar"', $html);
+        assertStringNotContainsString('docs-layout-with-toc', $html);
+        assertStringNotContainsString('toc-sidebar-right', $html);
+        assertStringContainsString('id="details"', $html);
     }
 
     public function testRendersInternalCustomPagerUrlRelativeToDeploymentPage(): void
@@ -927,6 +971,7 @@ PHP);
         ?bool $editLink = null,
         array|false|null $toc = null,
         ?bool $lastUpdated = null,
+        ?bool $aside = null,
     ): Entry {
         $content = file_get_contents($filePath);
         $bodyMarker = "---\n\n";
@@ -963,6 +1008,7 @@ PHP);
             editLink: $editLink,
             toc: $toc,
             lastUpdated: $lastUpdated,
+            aside: $aside,
         );
     }
 

--- a/tests/Unit/Content/Parser/EntryParserTest.php
+++ b/tests/Unit/Content/Parser/EntryParserTest.php
@@ -161,6 +161,20 @@ final class EntryParserTest extends TestCase
         }
     }
 
+    public function testAsideVisibilityIsInheritedWhenExplicitlyNull(): void
+    {
+        $file = tempnam(sys_get_temp_dir(), 'yiipress-entry-aside-');
+        file_put_contents($file, "---\ntitle: Default\naside: null\n---\n\nBody.\n");
+
+        try {
+            $entry = $this->parser->parse($file, 'docs');
+
+            assertNull($entry->aside);
+        } finally {
+            unlink($file);
+        }
+    }
+
     public function testRejectsInvalidAsideVisibilityOverride(): void
     {
         $file = tempnam(sys_get_temp_dir(), 'yiipress-entry-aside-invalid-');

--- a/tests/Unit/Content/Parser/EntryParserTest.php
+++ b/tests/Unit/Content/Parser/EntryParserTest.php
@@ -122,6 +122,61 @@ final class EntryParserTest extends TestCase
         }
     }
 
+    public function testParsesAsideVisibilityOverride(): void
+    {
+        $file = tempnam(sys_get_temp_dir(), 'yiipress-entry-aside-');
+        file_put_contents($file, "---\ntitle: Focused\naside: false\n---\n\nBody.\n");
+
+        try {
+            $entry = $this->parser->parse($file, 'docs');
+            assertFalse($entry->aside);
+        } finally {
+            unlink($file);
+        }
+    }
+
+    public function testParsesEnabledAsideVisibilityOverride(): void
+    {
+        $file = tempnam(sys_get_temp_dir(), 'yiipress-entry-aside-');
+        file_put_contents($file, "---\ntitle: Full layout\naside: true\n---\n\nBody.\n");
+
+        try {
+            $entry = $this->parser->parse($file, 'docs');
+            assertTrue($entry->aside);
+        } finally {
+            unlink($file);
+        }
+    }
+
+    public function testAsideVisibilityIsInheritedWhenOmitted(): void
+    {
+        $file = tempnam(sys_get_temp_dir(), 'yiipress-entry-aside-');
+        file_put_contents($file, "---\ntitle: Default\n---\n\nBody.\n");
+
+        try {
+            $entry = $this->parser->parse($file, 'docs');
+            assertNull($entry->aside);
+        } finally {
+            unlink($file);
+        }
+    }
+
+    public function testRejectsInvalidAsideVisibilityOverride(): void
+    {
+        $file = tempnam(sys_get_temp_dir(), 'yiipress-entry-aside-invalid-');
+        file_put_contents($file, "---\ntitle: Invalid\naside: right\n---\n\nBody.\n");
+
+        try {
+            $this->parser->parse($file, 'docs');
+            self::fail('Expected invalid aside visibility override to throw.');
+        } catch (InvalidContentConfigException $e) {
+            assertStringContainsString('Invalid "aside" visibility override', $e->getMessage());
+            assertSame($file, $e->filePath());
+        } finally {
+            unlink($file);
+        }
+    }
+
     #[DataProvider('faqLevelProvider')]
     public function testParsesFaqLevel(string $yaml, int|false|null $expected): void
     {

--- a/tests/Unit/Theme/MinimalThemeAssetsTest.php
+++ b/tests/Unit/Theme/MinimalThemeAssetsTest.php
@@ -54,8 +54,10 @@ final class MinimalThemeAssetsTest extends TestCase
 
         self::assertNotFalse($css);
         assertStringContainsString('.docs-layout {', $css);
+        assertStringContainsString('grid-template-columns: 16rem minmax(0, var(--max-width));', $css);
+        assertStringContainsString('.docs-layout.docs-layout-with-toc {', $css);
         assertStringContainsString('grid-template-columns: 16rem minmax(0, var(--max-width)) 14rem;', $css);
-        assertStringNotContainsString('.docs-layout:not(.docs-layout-with-toc)', $css);
+        assertStringContainsString('.container:has(.docs-layout-with-toc) {', $css);
         assertStringContainsString('.docs-sidebar-nav .is-current > a {', $css);
         assertStringContainsString('.toc-sidebar .is-current > a {', $css);
         assertStringContainsString('.toc-sidebar .is-current::before {', $css);

--- a/themes/minimal/assets/style.css
+++ b/themes/minimal/assets/style.css
@@ -686,13 +686,19 @@ a.tag-link:hover {
 }
 
 .container:has(.docs-layout) {
+    max-width: calc(var(--max-width) + 16rem + 2.5rem);
+}
+.container:has(.docs-layout-with-toc) {
     max-width: calc(var(--max-width) + 16rem + 14rem + 5rem);
 }
 .docs-layout {
     display: grid;
-    grid-template-columns: 16rem minmax(0, var(--max-width)) 14rem;
+    grid-template-columns: 16rem minmax(0, var(--max-width));
     gap: 2.5rem;
     align-items: start;
+}
+.docs-layout.docs-layout-with-toc {
+    grid-template-columns: 16rem minmax(0, var(--max-width)) 14rem;
 }
 .docs-content {
     min-width: 0;

--- a/themes/minimal/entry.php
+++ b/themes/minimal/entry.php
@@ -18,6 +18,7 @@ declare(strict_types=1);
  * @var bool $showTitle
  * @var string $headAssets
  * @var list<array{id: string, text: string, level: int}> $toc
+ * @var bool $aside
  * @var list<YiiPress\Content\Model\RelatedEntry> $related
  * @var list<YiiPress\Content\Model\Translation> $translations
  * @var array{previous: array{title: string, url: string}|null, next: array{title: string, url: string}|null}|null $navigationPager
@@ -48,9 +49,11 @@ $uiLanguage ??= 'en';
 $translations ??= [];
 $entryAuthors ??= [];
 $permalink ??= '';
+$aside ??= true;
 $hasToc = $toc !== [];
 $hasDocsSidebar = $nav !== null && NavigationRenderer::menuContainsUrl($nav, 'sidebar', $permalink);
 $useDocsLayout = $hasDocsSidebar;
+$hasDocsAside = $useDocsLayout && $aside && $hasToc;
 $useLegacyTocSidebar = !$useDocsLayout && $hasToc;
 ?>
 <!DOCTYPE html>
@@ -65,7 +68,7 @@ $useLegacyTocSidebar = !$useDocsLayout && $hasToc;
 <main>
     <div class="container">
 <?php if ($useDocsLayout): ?>
-        <div class="docs-layout<?= $hasToc ? ' docs-layout-with-toc' : '' ?>">
+        <div class="docs-layout<?= $hasDocsAside ? ' docs-layout-with-toc' : '' ?>">
             <aside class="docs-sidebar" aria-label="<?= $h($t('sidebar_navigation')) ?>" data-ui-attr-aria-label="sidebar_navigation">
                 <?= NavigationRenderer::render($nav, 'sidebar', $rootPath, $uiLanguage, $uiLanguage, 'docs-sidebar-nav', $permalink) ?>
             </aside>
@@ -200,7 +203,7 @@ $useLegacyTocSidebar = !$useDocsLayout && $hasToc;
                 </nav>
 <?php endif; ?>
             </article>
-<?php if ($useDocsLayout && $hasToc): ?>
+<?php if ($hasDocsAside): ?>
             <aside class="toc-sidebar toc-sidebar-right" aria-label="<?= $h($t('table_of_contents')) ?>" data-ui-attr-aria-label="table_of_contents">
                 <nav>
                     <ol>


### PR DESCRIPTION
Closes #110.

## Summary
- parse a strict nullable `aside` entry front-matter override
- expose the resolved `$aside` boolean to custom templates while retaining `$toc`
- omit the minimal theme right documentation aside and its grid column when disabled
- document the user-facing option and template contract
- add parser, renderer, and bundled-theme PHPUnit coverage

## Validation
- `make test tests/Unit/Content/Parser/EntryParserTest.php tests/Unit/Build/EntryRendererTest.php`
- `make psalm`
- `make composer-dependency-analyser`
- `make cs-fix`
- full `make test`: 851/852 tests passed; the existing task-list assertion is line-ending-sensitive in this CRLF worktree (`MarkdownRendererTest::testRendersTaskList`) and passes in Linux CI checkouts

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added per-entry control for showing or hiding the documentation table-of-contents aside.
  * Added support for the `aside` front-matter option, with validation for boolean values.
  * Hiding the aside preserves heading IDs and table-of-contents data without reserving aside layout space.

* **Documentation**
  * Documented the new `aside` setting and template variable.
  * Updated navigation guidance and roadmap information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->