### PR TITLE
Fix #124: Hide internal worker command

### DIFF
--- a/config/console/commands.php
+++ b/config/console/commands.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 use YiiPress\Console;
 
 return [
-    '_worker' => Console\WorkerCommand::class,
+    '|worker' => Console\WorkerCommand::class,
     'build' => Console\BuildCommand::class,
     'check:links' => Console\CheckCommand::class,
     'clean|clear' => Console\CleanCommand::class,

--- a/docs/engine.md
+++ b/docs/engine.md
@@ -162,7 +162,7 @@ Performance is handled by doing less work, keeping expensive work native, and le
 - OPCache can reuse compiled PHP templates when the runtime enables it.
 - JIT and preloading remain available to source installs where the PHP runtime is managed directly.
 
-Parallel builds use `pcntl_fork()` where it is available. On Windows, YiiPress starts portable child processes through the packaged executable and passes each one an isolated typed rendering job. Each worker receives the indexed site, renders its assigned pages, and writes independent files. Secondary outputs stay sequential or are parallelized only when the page count is high enough to justify worker overhead.
+Parallel builds use `pcntl_fork()` where it is available. On Windows, YiiPress starts portable child processes through the packaged executable and passes each one an isolated typed rendering job. The internal `worker` command used for these child processes remains executable but is hidden from the user-facing command list. Each worker receives the indexed site, renders its assigned pages, and writes independent files. Secondary outputs stay sequential or are parallelized only when the page count is high enough to justify worker overhead.
 
 This approach avoids shared memory and synchronization. Feed generation can split work per collection when workers are enabled because feeds may render every entry body again. Sitemap and robots output remain serial.
 

--- a/roadmap.md
+++ b/roadmap.md
@@ -67,6 +67,7 @@
 - [x] Dry run mode for build — show what would be generated without writing files
 - [x] No-write build mode for render-vs-filesystem performance diagnostics
 - [x] `serve` overlay button to open the current markdown source in a configured editor
+- [x] [Hide the internal worker command from the user-facing command list](https://github.com/yiipress/engine/issues/124)
 
 ## Priority 4: Templates and theming
 

--- a/src/Build/PortableWorkerPool.php
+++ b/src/Build/PortableWorkerPool.php
@@ -67,7 +67,7 @@ final class PortableWorkerPool
                     throw new RuntimeException(sprintf('Unable to write worker job "%s".', $jobFile));
                 }
 
-                $command = [...$this->executableCommand(), '_worker', $jobFile, $resultFile];
+                $command = [...$this->executableCommand(), 'worker', $jobFile, $resultFile];
                 $pipes = [];
                 $process = proc_open($command, [
                     0 => ['pipe', 'r'],

--- a/src/Console/WorkerCommand.php
+++ b/src/Console/WorkerCommand.php
@@ -27,7 +27,7 @@ use function file_put_contents;
 use function is_dir;
 use function unserialize;
 
-#[AsCommand(name: '_worker', description: 'Runs an internal portable worker job', hidden: true)]
+#[AsCommand(name: 'worker', description: 'Runs an internal portable worker job', hidden: true)]
 final class WorkerCommand extends Command
 {
     public function __construct(

--- a/tests/Console/ConsoleRunnerTest.php
+++ b/tests/Console/ConsoleRunnerTest.php
@@ -8,6 +8,7 @@ use PHPUnit\Framework\TestCase;
 
 use function PHPUnit\Framework\assertSame;
 use function PHPUnit\Framework\assertStringContainsString;
+use function PHPUnit\Framework\assertStringNotContainsString;
 
 final class ConsoleRunnerTest extends TestCase
 {
@@ -20,5 +21,6 @@ final class ConsoleRunnerTest extends TestCase
         assertSame(0, $exitCode);
         assertStringContainsString('YiiPress 1.0.0', implode("\n", $output));
         self::assertStringNotContainsString('Yii Console', implode("\n", $output));
+        assertStringNotContainsString('Runs an internal portable worker job', implode("\n", $output));
     }
 }

--- a/tests/Unit/Packaging/ConfigurationPackagingTest.php
+++ b/tests/Unit/Packaging/ConfigurationPackagingTest.php
@@ -11,6 +11,7 @@ use YiiPress\Console\ImportCommand;
 use YiiPress\Console\NewCommand;
 use YiiPress\Console\ServeCommand;
 use YiiPress\Console\ThemeInitCommand;
+use YiiPress\Console\WorkerCommand;
 use YiiPress\Build\PharArchiveFilter;
 use YiiPress\Build\PhpDocStripper;
 use PHPUnit\Framework\Attributes\Test;
@@ -75,6 +76,7 @@ final class ConfigurationPackagingTest extends TestCase
         assertSame(ServeCommand::class, $commands['serve']);
         assertSame(InitCommand::class, $commands['init']);
         assertSame(ThemeInitCommand::class, $commands['theme:init']);
+        assertSame(WorkerCommand::class, $commands['|worker']);
     }
 
     #[Test]


### PR DESCRIPTION
Closes #124.

## Summary
- register the internal worker through Yii Console's hidden-command map syntax
- rename `_worker` to `worker` now that it is not user-facing
- update portable worker invocation, regression coverage, architecture docs, and roadmap

## Verification
- `make test CLI_ARGS='tests/Console/ConsoleRunnerTest.php tests/Unit/Packaging/ConfigurationPackagingTest.php tests/Unit/Build/PortableWorkerPoolTest.php'` — 33 tests, 469 assertions
- `make yii` — worker command absent from the command list
- `make psalm` — no errors
- `make test` — 903/904 pass; existing `MarkdownRendererTest::testRendersTaskList` line-ending assertion fails (LF actual versus CRLF expected)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated the internal worker command while keeping it hidden from user-facing command listings.
  * Preserved worker execution, timeout, failure handling, and cleanup behavior.
  * Prevented internal worker activity from appearing in console output.
* **Documentation**
  * Clarified the worker command’s executable but hidden status.
  * Added the completed change to the project roadmap.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->