### PR TITLE
Fix #126: Fix console error verbosity

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -72,7 +72,7 @@
         "yiisoft/yii-console": "^2.4.2",
         "yiisoft/yii-event": "^2.2",
         "yiisoft/yii-http": "^1.1.1",
-        "yiisoft/yii-runner-console": "^2.2.1",
+        "yiisoft/yii-runner": "^2.2.1",
         "yiisoft/yii-runner-http": "^3.2.1"
     },
     "require-dev": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "26447d6116aec376ef2d17385e7ed35b",
+    "content-hash": "78267b02298cb5573fc1a5565f4357a9",
     "packages": [
         {
             "name": "alexkart/curl-builder",
@@ -3558,82 +3558,6 @@
                 }
             ],
             "time": "2025-12-19T12:23:49+00:00"
-        },
-        {
-            "name": "yiisoft/yii-runner-console",
-            "version": "2.2.1",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/yiisoft/yii-runner-console.git",
-                "reference": "16ca4daa1c02ef4c9e2d0db4cf30a194467c6a34"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/yiisoft/yii-runner-console/zipball/16ca4daa1c02ef4c9e2d0db4cf30a194467c6a34",
-                "reference": "16ca4daa1c02ef4c9e2d0db4cf30a194467c6a34",
-                "shasum": ""
-            },
-            "require": {
-                "php": "8.0 - 8.5",
-                "symfony/console": "^5.4 || ^6.0 || ^7.0 || ^8.0",
-                "yiisoft/config": "^1.1",
-                "yiisoft/definitions": "^1.0 || ^2.0 || ^3.0",
-                "yiisoft/di": "^1.0",
-                "yiisoft/yii-console": "^2.0",
-                "yiisoft/yii-runner": "^2.2"
-            },
-            "require-dev": {
-                "bamarni/composer-bin-plugin": "^1.8.3",
-                "codeception/codeception": "^5.1.2",
-                "codeception/module-cli": "^2.0.1",
-                "rector/rector": "^2.0.11"
-            },
-            "type": "library",
-            "extra": {
-                "bamarni-bin": {
-                    "bin-links": true,
-                    "forward-command": true,
-                    "target-directory": "tools"
-                },
-                "config-plugin-options": {
-                    "build-merge-plan": false
-                }
-            },
-            "autoload": {
-                "psr-4": {
-                    "Yiisoft\\Yii\\Runner\\Console\\": "src"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "BSD-3-Clause"
-            ],
-            "description": "Console application runner",
-            "homepage": "https://www.yiiframework.com/",
-            "keywords": [
-                "console",
-                "runner",
-                "yii"
-            ],
-            "support": {
-                "chat": "https://t.me/yii3en",
-                "forum": "https://www.yiiframework.com/forum/",
-                "irc": "ircs://irc.libera.chat:6697/yii",
-                "issues": "https://github.com/yiisoft/yii-runner-console/issues?state=open",
-                "source": "https://github.com/yiisoft/yii-runner-console",
-                "wiki": "https://www.yiiframework.com/wiki/"
-            },
-            "funding": [
-                {
-                    "url": "https://github.com/sponsors/yiisoft",
-                    "type": "github"
-                },
-                {
-                    "url": "https://opencollective.com/yiisoft",
-                    "type": "opencollective"
-                }
-            ],
-            "time": "2025-12-20T07:01:24+00:00"
         },
         {
             "name": "yiisoft/yii-runner-http",

--- a/config/common/di/logger.php
+++ b/config/common/di/logger.php
@@ -13,6 +13,9 @@ return [
         '__construct()' => [
             'stream' => 'php://stderr',
         ],
+        'setEnabled()' => [
+            static fn(): bool => PHP_SAPI !== 'cli',
+        ],
     ],
     LoggerInterface::class => [
         'class' => Logger::class,

--- a/config/common/di/logger.php
+++ b/config/common/di/logger.php
@@ -14,7 +14,7 @@ return [
             'stream' => 'php://stderr',
         ],
         'setEnabled()' => [
-            static fn(): bool => PHP_SAPI !== 'cli',
+            static fn(): bool => PHP_SAPI !== 'cli' && PHP_SAPI !== 'phpdbg',
         ],
     ],
     LoggerInterface::class => [

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -2,6 +2,8 @@
 
 The examples below assume the static binary is in your project directory and use `./yiipress` so they work without changing `PATH`. Source checkouts expose the same commands through `./yii`; engine contributors should run them through the repository `make` targets.
 
+All commands support Symfony's standard verbosity options. By default, errors contain only information useful to an end user. Use `-v` to include the exception type, `-vv` to include its source location, or `-vvv` to include the debugging stack trace.
+
 ## `build`
 
 Generates static HTML content from source files.

--- a/roadmap.md
+++ b/roadmap.md
@@ -67,6 +67,7 @@
 - [x] Dry run mode for build — show what would be generated without writing files
 - [x] No-write build mode for render-vs-filesystem performance diagnostics
 - [x] `serve` overlay button to open the current markdown source in a configured editor
+- [x] [Respect console verbosity when rendering errors](https://github.com/yiipress/engine/issues/126)
 
 ## Priority 4: Templates and theming
 

--- a/src/Console/ApplicationRunner.php
+++ b/src/Console/ApplicationRunner.php
@@ -1,0 +1,84 @@
+<?php
+
+declare(strict_types=1);
+
+namespace YiiPress\Console;
+
+use Symfony\Component\Console\Input\ArgvInput;
+use Throwable;
+use Yiisoft\Yii\Console\Application;
+use Yiisoft\Yii\Console\ExitCode;
+use Yiisoft\Yii\Console\Output\ConsoleBufferedOutput;
+use Yiisoft\Yii\Runner\ApplicationRunner as BaseApplicationRunner;
+
+final class ApplicationRunner extends BaseApplicationRunner
+{
+    /**
+     * @param list<string> $nestedParamsGroups
+     * @param list<string> $nestedEventsGroups
+     * @param list<object> $configModifiers
+     */
+    public function __construct(
+        string $rootPath,
+        bool $debug = false,
+        bool $checkEvents = false,
+        ?string $environment = null,
+        string $bootstrapGroup = 'bootstrap-console',
+        string $eventsGroup = 'events-console',
+        string $diGroup = 'di-console',
+        string $diProvidersGroup = 'di-providers-console',
+        string $diDelegatesGroup = 'di-delegates-console',
+        string $diTagsGroup = 'di-tags-console',
+        string $paramsGroup = 'params-console',
+        array $nestedParamsGroups = ['params'],
+        array $nestedEventsGroups = ['events'],
+        array $configModifiers = [],
+        string $configDirectory = 'config',
+        string $vendorDirectory = 'vendor',
+        string $configMergePlanFile = '.merge-plan.php',
+    ) {
+        parent::__construct(
+            $rootPath,
+            $debug,
+            $checkEvents,
+            $environment,
+            $bootstrapGroup,
+            $eventsGroup,
+            $diGroup,
+            $diProvidersGroup,
+            $diDelegatesGroup,
+            $diTagsGroup,
+            $paramsGroup,
+            $nestedParamsGroups,
+            $nestedEventsGroups,
+            $configModifiers,
+            $configDirectory,
+            $vendorDirectory,
+            $configMergePlanFile,
+        );
+    }
+
+    public function run(): void
+    {
+        $this->runBootstrap();
+        $this->checkEvents();
+
+        /** @var Application $application */
+        $application = $this->getContainer()->get(Application::class);
+        $application->setCatchExceptions(false);
+
+        $exitCode = ExitCode::UNSPECIFIED_ERROR;
+        $input = new ArgvInput();
+        $output = new ConsoleBufferedOutput();
+
+        try {
+            $application->start($input);
+            $exitCode = $application->run($input, $output);
+        } catch (Throwable $throwable) {
+            (new ExceptionRenderer())->render($throwable, $output);
+        } finally {
+            $application->shutdown($exitCode);
+            exit($exitCode);
+        }
+    }
+}

--- a/src/Console/ApplicationRunner.php
+++ b/src/Console/ApplicationRunner.php
@@ -70,11 +70,13 @@ final class ApplicationRunner extends BaseApplicationRunner
         $exitCode = ExitCode::UNSPECIFIED_ERROR;
         $input = new ArgvInput();
         $output = new ConsoleBufferedOutput();
+        (new ConsoleOutputConfigurator())->configure($input, $output);
 
         try {
             $application->start($input);
             $exitCode = $application->run($input, $output);
         } catch (Throwable $throwable) {
+            $exitCode = (new ExceptionExitCode())->resolve($throwable);
             (new ExceptionRenderer())->render($throwable, $output);
         } finally {
             $application->shutdown($exitCode);

--- a/src/Console/ConsoleOutputConfigurator.php
+++ b/src/Console/ConsoleOutputConfigurator.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+namespace YiiPress\Console;
+
+use Symfony\Component\Console\Input\ArgvInput;
+use Symfony\Component\Console\Output\OutputInterface;
+
+final class ConsoleOutputConfigurator
+{
+    public function configure(ArgvInput $input, OutputInterface $output): void
+    {
+        $output->setVerbosity(match (true) {
+            $input->hasParameterOption('--silent', true) => OutputInterface::VERBOSITY_SILENT,
+            $input->hasParameterOption(['--quiet', '-q'], true) => OutputInterface::VERBOSITY_QUIET,
+            $input->hasParameterOption(['-vvv', '--verbose=3'], true) => OutputInterface::VERBOSITY_DEBUG,
+            $input->hasParameterOption(['-vv', '--verbose=2'], true) => OutputInterface::VERBOSITY_VERY_VERBOSE,
+            $input->hasParameterOption(['-v', '--verbose', '--verbose=1'], true) => OutputInterface::VERBOSITY_VERBOSE,
+            default => $output->getVerbosity(),
+        });
+    }
+}

--- a/src/Console/ExceptionExitCode.php
+++ b/src/Console/ExceptionExitCode.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+namespace YiiPress\Console;
+
+use Throwable;
+use Yiisoft\Yii\Console\ExitCode;
+
+use function is_int;
+
+final class ExceptionExitCode
+{
+    public function resolve(Throwable $throwable): int
+    {
+        $code = $throwable->getCode();
+
+        return is_int($code) && $code > ExitCode::OK ? $code : ExitCode::UNSPECIFIED_ERROR;
+    }
+}

--- a/src/Console/ExceptionExitCode.php
+++ b/src/Console/ExceptionExitCode.php
@@ -11,10 +11,14 @@ use function is_int;
 
 final class ExceptionExitCode
 {
+    private const MAX_EXIT_CODE = 254;
+
     public function resolve(Throwable $throwable): int
     {
         $code = $throwable->getCode();
 
-        return is_int($code) && $code > ExitCode::OK ? $code : ExitCode::UNSPECIFIED_ERROR;
+        return is_int($code) && $code > ExitCode::OK && $code <= self::MAX_EXIT_CODE
+            ? $code
+            : ExitCode::UNSPECIFIED_ERROR;
     }
 }

--- a/src/Console/ExceptionRenderer.php
+++ b/src/Console/ExceptionRenderer.php
@@ -5,9 +5,12 @@ declare(strict_types=1);
 namespace YiiPress\Console;
 
 use Symfony\Component\Console\Application;
+use Symfony\Component\Console\Exception\RuntimeException;
 use Symfony\Component\Console\Formatter\OutputFormatter;
 use Symfony\Component\Console\Output\OutputInterface;
 use Throwable;
+
+use function is_int;
 
 final class ExceptionRenderer
 {
@@ -17,7 +20,11 @@ final class ExceptionRenderer
         $output->setVerbosity(OutputInterface::VERBOSITY_NORMAL);
 
         try {
-            (new Application())->renderThrowable($throwable, $output);
+            $code = $throwable->getCode();
+            (new Application())->renderThrowable(
+                new RuntimeException($throwable->getMessage(), is_int($code) ? $code : 0),
+                $output,
+            );
         } finally {
             $output->setVerbosity($verbosity);
         }

--- a/src/Console/ExceptionRenderer.php
+++ b/src/Console/ExceptionRenderer.php
@@ -16,9 +16,11 @@ final class ExceptionRenderer
         $verbosity = $output->getVerbosity();
         $output->setVerbosity(OutputInterface::VERBOSITY_NORMAL);
 
-        (new Application())->renderThrowable($throwable, $output);
-
-        $output->setVerbosity($verbosity);
+        try {
+            (new Application())->renderThrowable($throwable, $output);
+        } finally {
+            $output->setVerbosity($verbosity);
+        }
 
         $output->writeln(
             '<comment>Exception:</comment> ' . OutputFormatter::escape($throwable::class),
@@ -33,6 +35,9 @@ final class ExceptionRenderer
             OutputInterface::VERBOSITY_VERY_VERBOSE,
         );
         $output->writeln('<comment>Stack trace:</comment>', OutputInterface::VERBOSITY_DEBUG);
-        $output->writeln($throwable->getTraceAsString(), OutputInterface::VERBOSITY_DEBUG);
+        $output->writeln(
+            $throwable->getTraceAsString(),
+            OutputInterface::VERBOSITY_DEBUG | OutputInterface::OUTPUT_RAW,
+        );
     }
 }

--- a/src/Console/ExceptionRenderer.php
+++ b/src/Console/ExceptionRenderer.php
@@ -1,0 +1,38 @@
+<?php
+
+declare(strict_types=1);
+
+namespace YiiPress\Console;
+
+use Symfony\Component\Console\Application;
+use Symfony\Component\Console\Formatter\OutputFormatter;
+use Symfony\Component\Console\Output\OutputInterface;
+use Throwable;
+
+final class ExceptionRenderer
+{
+    public function render(Throwable $throwable, OutputInterface $output): void
+    {
+        $verbosity = $output->getVerbosity();
+        $output->setVerbosity(OutputInterface::VERBOSITY_NORMAL);
+
+        (new Application())->renderThrowable($throwable, $output);
+
+        $output->setVerbosity($verbosity);
+
+        $output->writeln(
+            '<comment>Exception:</comment> ' . OutputFormatter::escape($throwable::class),
+            OutputInterface::VERBOSITY_VERBOSE,
+        );
+        $output->writeln(
+            sprintf(
+                '<comment>Location:</comment> %s:%d',
+                OutputFormatter::escape($throwable->getFile()),
+                $throwable->getLine(),
+            ),
+            OutputInterface::VERBOSITY_VERY_VERBOSE,
+        );
+        $output->writeln('<comment>Stack trace:</comment>', OutputInterface::VERBOSITY_DEBUG);
+        $output->writeln($throwable->getTraceAsString(), OutputInterface::VERBOSITY_DEBUG);
+    }
+}

--- a/tests/Console/ConsoleRunnerTest.php
+++ b/tests/Console/ConsoleRunnerTest.php
@@ -21,4 +21,22 @@ final class ConsoleRunnerTest extends TestCase
         assertStringContainsString('YiiPress 1.0.0', implode("\n", $output));
         self::assertStringNotContainsString('Yii Console', implode("\n", $output));
     }
+
+    public function testCommandErrorRespectsVerbosity(): void
+    {
+        $yii = dirname(__DIR__, 2) . '/yii';
+
+        exec($yii . ' new 2>&1', $defaultOutput, $defaultExitCode);
+        exec($yii . ' new -vvv 2>&1', $debugOutput, $debugExitCode);
+
+        $defaultOutput = implode("\n", $defaultOutput);
+        $debugOutput = implode("\n", $debugOutput);
+
+        self::assertSame(1, $defaultExitCode);
+        self::assertSame(1, $debugExitCode);
+        self::assertStringContainsString('Not enough arguments', $defaultOutput);
+        self::assertStringNotContainsString('Message context:', $defaultOutput);
+        self::assertStringNotContainsString('Stack trace:', $defaultOutput);
+        self::assertStringContainsString('Stack trace:', $debugOutput);
+    }
 }

--- a/tests/Console/ConsoleRunnerTest.php
+++ b/tests/Console/ConsoleRunnerTest.php
@@ -6,6 +6,7 @@ namespace YiiPress\Tests\Console;
 
 use PHPUnit\Framework\TestCase;
 
+use function escapeshellarg;
 use function PHPUnit\Framework\assertSame;
 use function PHPUnit\Framework\assertStringContainsString;
 use function PHPUnit\Framework\assertStringNotContainsString;
@@ -26,7 +27,7 @@ final class ConsoleRunnerTest extends TestCase
 
     public function testCommandErrorRespectsVerbosity(): void
     {
-        $yii = dirname(__DIR__, 2) . '/yii';
+        $yii = escapeshellarg(dirname(__DIR__, 2) . '/yii');
 
         exec($yii . ' new 2>&1', $defaultOutput, $defaultExitCode);
         exec($yii . ' new -vvv 2>&1', $debugOutput, $debugExitCode);

--- a/tests/Unit/Console/ConsoleOutputConfiguratorTest.php
+++ b/tests/Unit/Console/ConsoleOutputConfiguratorTest.php
@@ -18,9 +18,14 @@ final class ConsoleOutputConfiguratorTest extends TestCase
      */
     public static function verbosityProvider(): iterable
     {
+        yield 'silent' => ['--silent', OutputInterface::VERBOSITY_SILENT];
         yield 'quiet' => ['-q', OutputInterface::VERBOSITY_QUIET];
+        yield 'long quiet' => ['--quiet', OutputInterface::VERBOSITY_QUIET];
         yield 'verbose' => ['-v', OutputInterface::VERBOSITY_VERBOSE];
+        yield 'long verbose' => ['--verbose', OutputInterface::VERBOSITY_VERBOSE];
+        yield 'long verbose 1' => ['--verbose=1', OutputInterface::VERBOSITY_VERBOSE];
         yield 'very verbose' => ['-vv', OutputInterface::VERBOSITY_VERY_VERBOSE];
+        yield 'long verbose 2' => ['--verbose=2', OutputInterface::VERBOSITY_VERY_VERBOSE];
         yield 'debug' => ['-vvv', OutputInterface::VERBOSITY_DEBUG];
         yield 'long debug' => ['--verbose=3', OutputInterface::VERBOSITY_DEBUG];
     }
@@ -34,5 +39,15 @@ final class ConsoleOutputConfiguratorTest extends TestCase
         (new ConsoleOutputConfigurator())->configure($input, $output);
 
         self::assertSame($verbosity, $output->getVerbosity());
+    }
+
+    public function testPreservesExistingVerbosityWithoutOption(): void
+    {
+        $input = new ArgvInput(['yii', 'build']);
+        $output = new BufferedOutput(OutputInterface::VERBOSITY_VERY_VERBOSE);
+
+        (new ConsoleOutputConfigurator())->configure($input, $output);
+
+        self::assertSame(OutputInterface::VERBOSITY_VERY_VERBOSE, $output->getVerbosity());
     }
 }

--- a/tests/Unit/Console/ConsoleOutputConfiguratorTest.php
+++ b/tests/Unit/Console/ConsoleOutputConfiguratorTest.php
@@ -1,0 +1,38 @@
+<?php
+
+declare(strict_types=1);
+
+namespace YiiPress\Tests\Unit\Console;
+
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Console\Input\ArgvInput;
+use Symfony\Component\Console\Output\BufferedOutput;
+use Symfony\Component\Console\Output\OutputInterface;
+use YiiPress\Console\ConsoleOutputConfigurator;
+
+final class ConsoleOutputConfiguratorTest extends TestCase
+{
+    /**
+     * @return iterable<string, array{string, int}>
+     */
+    public static function verbosityProvider(): iterable
+    {
+        yield 'quiet' => ['-q', OutputInterface::VERBOSITY_QUIET];
+        yield 'verbose' => ['-v', OutputInterface::VERBOSITY_VERBOSE];
+        yield 'very verbose' => ['-vv', OutputInterface::VERBOSITY_VERY_VERBOSE];
+        yield 'debug' => ['-vvv', OutputInterface::VERBOSITY_DEBUG];
+        yield 'long debug' => ['--verbose=3', OutputInterface::VERBOSITY_DEBUG];
+    }
+
+    #[DataProvider('verbosityProvider')]
+    public function testConfiguresVerbosityBeforeApplicationStarts(string $option, int $verbosity): void
+    {
+        $input = new ArgvInput(['yii', 'build', $option]);
+        $output = new BufferedOutput();
+
+        (new ConsoleOutputConfigurator())->configure($input, $output);
+
+        self::assertSame($verbosity, $output->getVerbosity());
+    }
+}

--- a/tests/Unit/Console/ExceptionExitCodeTest.php
+++ b/tests/Unit/Console/ExceptionExitCodeTest.php
@@ -18,6 +18,9 @@ final class ExceptionExitCodeTest extends TestCase
     public static function codeProvider(): iterable
     {
         yield 'positive' => [ExitCode::USAGE, ExitCode::USAGE];
+        yield 'maximum' => [254, 254];
+        yield 'reserved' => [255, ExitCode::UNSPECIFIED_ERROR];
+        yield 'too large' => [256, ExitCode::UNSPECIFIED_ERROR];
         yield 'zero' => [ExitCode::OK, ExitCode::UNSPECIFIED_ERROR];
         yield 'negative' => [-1, ExitCode::UNSPECIFIED_ERROR];
     }

--- a/tests/Unit/Console/ExceptionExitCodeTest.php
+++ b/tests/Unit/Console/ExceptionExitCodeTest.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+namespace YiiPress\Tests\Unit\Console;
+
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\TestCase;
+use RuntimeException;
+use YiiPress\Console\ExceptionExitCode;
+use Yiisoft\Yii\Console\ExitCode;
+
+final class ExceptionExitCodeTest extends TestCase
+{
+    /**
+     * @return iterable<string, array{int, int}>
+     */
+    public static function codeProvider(): iterable
+    {
+        yield 'positive' => [ExitCode::USAGE, ExitCode::USAGE];
+        yield 'zero' => [ExitCode::OK, ExitCode::UNSPECIFIED_ERROR];
+        yield 'negative' => [-1, ExitCode::UNSPECIFIED_ERROR];
+    }
+
+    #[DataProvider('codeProvider')]
+    public function testResolvesExceptionExitCode(int $code, int $expected): void
+    {
+        self::assertSame($expected, (new ExceptionExitCode())->resolve(new RuntimeException('Failure.', $code)));
+    }
+}

--- a/tests/Unit/Console/ExceptionRendererTest.php
+++ b/tests/Unit/Console/ExceptionRendererTest.php
@@ -40,6 +40,7 @@ final class ExceptionRendererTest extends TestCase
         self::assertSame($hasExceptionClass, str_contains($rendered, 'Exception: RuntimeException'));
         self::assertSame($hasLocation, str_contains($rendered, 'Location:'));
         self::assertSame($hasStackTrace, str_contains($rendered, 'Stack trace:'));
+        self::assertStringNotContainsString('In ExceptionRendererTest.php line', $rendered);
         self::assertSame($verbosity, $output->getVerbosity());
     }
 }

--- a/tests/Unit/Console/ExceptionRendererTest.php
+++ b/tests/Unit/Console/ExceptionRendererTest.php
@@ -40,5 +40,6 @@ final class ExceptionRendererTest extends TestCase
         self::assertSame($hasExceptionClass, str_contains($rendered, 'Exception: RuntimeException'));
         self::assertSame($hasLocation, str_contains($rendered, 'Location:'));
         self::assertSame($hasStackTrace, str_contains($rendered, 'Stack trace:'));
+        self::assertSame($verbosity, $output->getVerbosity());
     }
 }

--- a/tests/Unit/Console/ExceptionRendererTest.php
+++ b/tests/Unit/Console/ExceptionRendererTest.php
@@ -1,0 +1,44 @@
+<?php
+
+declare(strict_types=1);
+
+namespace YiiPress\Tests\Unit\Console;
+
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\TestCase;
+use RuntimeException;
+use Symfony\Component\Console\Output\BufferedOutput;
+use Symfony\Component\Console\Output\OutputInterface;
+use YiiPress\Console\ExceptionRenderer;
+
+final class ExceptionRendererTest extends TestCase
+{
+    /**
+     * @return iterable<string, array{int, bool, bool, bool}>
+     */
+    public static function verbosityProvider(): iterable
+    {
+        yield 'default' => [OutputInterface::VERBOSITY_NORMAL, false, false, false];
+        yield 'verbose' => [OutputInterface::VERBOSITY_VERBOSE, true, false, false];
+        yield 'very verbose' => [OutputInterface::VERBOSITY_VERY_VERBOSE, true, true, false];
+        yield 'debug' => [OutputInterface::VERBOSITY_DEBUG, true, true, true];
+    }
+
+    #[DataProvider('verbosityProvider')]
+    public function testRendersDetailsAccordingToVerbosity(
+        int $verbosity,
+        bool $hasExceptionClass,
+        bool $hasLocation,
+        bool $hasStackTrace,
+    ): void {
+        $output = new BufferedOutput($verbosity, false);
+
+        (new ExceptionRenderer())->render(new RuntimeException('Something went wrong.'), $output);
+
+        $rendered = $output->fetch();
+        self::assertStringContainsString('Something went wrong.', $rendered);
+        self::assertSame($hasExceptionClass, str_contains($rendered, 'Exception: RuntimeException'));
+        self::assertSame($hasLocation, str_contains($rendered, 'Location:'));
+        self::assertSame($hasStackTrace, str_contains($rendered, 'Stack trace:'));
+    }
+}

--- a/yii
+++ b/yii
@@ -4,12 +4,12 @@
 declare(strict_types=1);
 
 use YiiPress\Environment;
-use Yiisoft\Yii\Runner\Console\ConsoleApplicationRunner;
+use YiiPress\Console\ApplicationRunner;
 
 require_once __DIR__ . '/src/autoload.php';
 
 // Run console application runner
-$runner = new ConsoleApplicationRunner(
+$runner = new ApplicationRunner(
     rootPath: __DIR__,
     debug: Environment::appDebug(),
     checkEvents: Environment::appDebug(),


### PR DESCRIPTION
Closes #126.

## Summary
- render concise, end-user-oriented console errors by default
- add exception type at `-v`, source location at `-vv`, and stack traces only at `-vvv`
- prevent duplicate console exception logging while preserving non-CLI stream logging
- document the verbosity levels and mark the roadmap item complete

## Tests
- `make test tests/Unit/Console/ExceptionRendererTest.php tests/Console/ConsoleRunnerTest.php`
- `make psalm`
- `make test` (909 tests run; one unrelated existing failure in `MarkdownRendererTest::testRendersTaskList` due to CRLF/LF expectation mismatch)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added configurable console error details based on verbosity levels.
  * Standard output shows concise errors, while higher verbosity reveals exception types, source locations, and stack traces.
  * Added support for quiet, verbose, and debug console output options.
  * Improved console application startup, shutdown, and error exit-code handling.

* **Documentation**
  * Documented console verbosity flags and their error-output behavior.
  * Updated the roadmap to reflect completed verbosity support.

* **Bug Fixes**
  * Prevented stream logging from being enabled during CLI execution.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->