### PR TITLE
Fix #129: Add one-command cross-platform installers

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+*.sh text eol=lf
+*.ps1 text eol=crlf

--- a/README.md
+++ b/README.md
@@ -22,13 +22,13 @@ and assets without a database or any runtime.
 Linux (x86-64) and macOS (Apple silicon):
 
 ```shell
-curl -fsSL https://raw.githubusercontent.com/yiipress/engine/9ec820b7c9d62160c183d3a6c1497b01afb4b133/install.sh | sh
+curl -fsSL https://raw.githubusercontent.com/yiipress/engine/master/install.sh | sh
 ```
 
 Windows (x86-64, PowerShell):
 
 ```powershell
-irm https://raw.githubusercontent.com/yiipress/engine/9ec820b7c9d62160c183d3a6c1497b01afb4b133/install.ps1 | iex
+irm https://raw.githubusercontent.com/yiipress/engine/master/install.ps1 | iex
 ```
 
 Both installers verify the latest release checksum and put `yiipress` on `PATH`. Run the same command again to update it.

--- a/README.md
+++ b/README.md
@@ -22,13 +22,13 @@ and assets without a database or any runtime.
 Linux (x86-64) and macOS (Apple silicon):
 
 ```shell
-curl -fsSL https://raw.githubusercontent.com/yiipress/engine/master/install.sh | sh
+curl -fsSL https://raw.githubusercontent.com/yiipress/engine/9ec820b7c9d62160c183d3a6c1497b01afb4b133/install.sh | sh
 ```
 
 Windows (x86-64, PowerShell):
 
 ```powershell
-irm https://raw.githubusercontent.com/yiipress/engine/master/install.ps1 | iex
+irm https://raw.githubusercontent.com/yiipress/engine/9ec820b7c9d62160c183d3a6c1497b01afb4b133/install.ps1 | iex
 ```
 
 Both installers verify the latest release checksum and put `yiipress` on `PATH`. Run the same command again to update it.

--- a/README.md
+++ b/README.md
@@ -17,6 +17,23 @@ YiiPress is a fast, file-based static website engine powered by [Yii3](https://w
 Write Markdown, build static HTML, and ship blogs, documentation, feeds, sitemaps, taxonomy pages, authors, search, redirects,
 and assets without a database or any runtime.
 
+## Install or update
+
+Linux (x86-64) and macOS (Apple silicon):
+
+```shell
+curl -fsSL https://raw.githubusercontent.com/yiipress/engine/master/install.sh | sh
+```
+
+Windows (x86-64, PowerShell):
+
+```powershell
+irm https://raw.githubusercontent.com/yiipress/engine/master/install.ps1 | iex
+```
+
+Both installers verify the latest release checksum and put `yiipress` on `PATH`. Run the same command again to update it.
+Set `YIIPRESS_INSTALL_DIR` to install into another directory.
+
 Use the static binary for normal projects: it includes the runtime and native extensions, so you do not need Docker, PHP, Composer,
 or a database on the machine that builds or previews the site.
 
@@ -46,28 +63,26 @@ Source installs require PHP 8.5 and native extensions. Prefer the binary unless 
 
 ## Installation
 
-Download the static binary from the latest GitHub release or workflow artifact, then put it in your site repository as
-`yiipress` (`yiipress.exe` on Windows).
+Use the installer for your platform at the beginning of this README. For unsupported architectures, download the static binary
+from the latest GitHub release and put it in a directory included in `PATH` (`yiipress.exe` on Windows).
 
 Create a content project:
 
 ```shell
 mkdir mysite
 cd mysite
-cp /path/to/yiipress ./yiipress
-chmod +x ./yiipress
 ```
 
 Initialize content:
 
 ```shell
-./yiipress init
+yiipress init
 ```
 
 Start the development server:
 
 ```shell
-./yiipress serve
+yiipress serve
 ```
 
 The preview server prints the URL it is listening on.
@@ -113,7 +128,7 @@ Welcome to my site.
 Build the static site:
 
 ```shell
-./yiipress build
+yiipress build
 ```
 
 Generated files are written to `output/`.
@@ -121,10 +136,10 @@ Generated files are written to `output/`.
 Common commands:
 
 ```shell
-./yiipress new "My First Post" --collection=blog
-./yiipress build --workers=4
-./yiipress build --drafts --future
-./yiipress clean
+yiipress new "My First Post" --collection=blog
+yiipress build --workers=4
+yiipress build --drafts --future
+yiipress clean
 ```
 
 Engine packaging commands, used by maintainers:

--- a/build/PharArchiveFilter.php
+++ b/build/PharArchiveFilter.php
@@ -27,6 +27,10 @@ final class PharArchiveFilter
             return true;
         }
 
+        if (in_array($path, ['install.sh', 'install.ps1'], true)) {
+            return true;
+        }
+
         if (!str_starts_with($path, 'vendor/')) {
             return false;
         }

--- a/docs/README.md
+++ b/docs/README.md
@@ -10,6 +10,23 @@ show_title: false
 
 [YiiPress](https://github.com/yiipress/engine) turns Markdown files into a fast static website. Use the static binary for day-to-day work: no PHP, Composer, database, or application server is needed for building or serving a preview.
 
+## Install or update
+
+Linux (x86-64) and macOS (Apple silicon):
+
+```shell
+curl -fsSL https://raw.githubusercontent.com/yiipress/engine/master/install.sh | sh
+```
+
+Windows (x86-64, PowerShell):
+
+```powershell
+irm https://raw.githubusercontent.com/yiipress/engine/master/install.ps1 | iex
+```
+
+Both installers verify the latest release checksum and put `yiipress` on `PATH`. Run the same command again to update it.
+Set `YIIPRESS_INSTALL_DIR` to install into another directory.
+
 ## Why YiiPress
 
 - **Static binary first** — download `yiipress`, put it in your project, and run it.

--- a/docs/README.md
+++ b/docs/README.md
@@ -15,13 +15,13 @@ show_title: false
 Linux (x86-64) and macOS (Apple silicon):
 
 ```shell
-curl -fsSL https://raw.githubusercontent.com/yiipress/engine/9ec820b7c9d62160c183d3a6c1497b01afb4b133/install.sh | sh
+curl -fsSL https://raw.githubusercontent.com/yiipress/engine/master/install.sh | sh
 ```
 
 Windows (x86-64, PowerShell):
 
 ```powershell
-irm https://raw.githubusercontent.com/yiipress/engine/9ec820b7c9d62160c183d3a6c1497b01afb4b133/install.ps1 | iex
+irm https://raw.githubusercontent.com/yiipress/engine/master/install.ps1 | iex
 ```
 
 Both installers verify the latest release checksum and put `yiipress` on `PATH`. Run the same command again to update it.

--- a/docs/README.md
+++ b/docs/README.md
@@ -15,13 +15,13 @@ show_title: false
 Linux (x86-64) and macOS (Apple silicon):
 
 ```shell
-curl -fsSL https://raw.githubusercontent.com/yiipress/engine/master/install.sh | sh
+curl -fsSL https://raw.githubusercontent.com/yiipress/engine/9ec820b7c9d62160c183d3a6c1497b01afb4b133/install.sh | sh
 ```
 
 Windows (x86-64, PowerShell):
 
 ```powershell
-irm https://raw.githubusercontent.com/yiipress/engine/master/install.ps1 | iex
+irm https://raw.githubusercontent.com/yiipress/engine/9ec820b7c9d62160c183d3a6c1497b01afb4b133/install.ps1 | iex
 ```
 
 Both installers verify the latest release checksum and put `yiipress` on `PATH`. Run the same command again to update it.

--- a/docs/binaries-phar-docker.md
+++ b/docs/binaries-phar-docker.md
@@ -5,13 +5,13 @@
 Install the latest stable binary on 64-bit x86 Linux or Apple silicon macOS with:
 
 ```shell
-curl -fsSL https://raw.githubusercontent.com/yiipress/engine/master/install.sh | sh
+curl -fsSL https://raw.githubusercontent.com/yiipress/engine/9ec820b7c9d62160c183d3a6c1497b01afb4b133/install.sh | sh
 ```
 
 On 64-bit x86 Windows, run in PowerShell:
 
 ```powershell
-irm https://raw.githubusercontent.com/yiipress/engine/master/install.ps1 | iex
+irm https://raw.githubusercontent.com/yiipress/engine/9ec820b7c9d62160c183d3a6c1497b01afb4b133/install.ps1 | iex
 ```
 
 The installers download the latest release archive and `SHA256SUMS`, verify the archive, and atomically install the executable.
@@ -20,8 +20,8 @@ and adds it to the user `PATH`. Re-run the same command to update an existing in
 release, set environment variables before invoking the installer. For example, with the shell installer:
 
 ```shell
-curl -fsSL https://raw.githubusercontent.com/yiipress/engine/master/install.sh | YIIPRESS_INSTALL_DIR="$HOME/.local/bin" sh
-curl -fsSL https://raw.githubusercontent.com/yiipress/engine/master/install.sh | YIIPRESS_VERSION=X.Y.Z sh
+curl -fsSL https://raw.githubusercontent.com/yiipress/engine/9ec820b7c9d62160c183d3a6c1497b01afb4b133/install.sh | YIIPRESS_INSTALL_DIR="$HOME/.local/bin" sh
+curl -fsSL https://raw.githubusercontent.com/yiipress/engine/9ec820b7c9d62160c183d3a6c1497b01afb4b133/install.sh | YIIPRESS_VERSION=X.Y.Z sh
 ```
 
 YiiPress can be packaged as reproducible artifacts:

--- a/docs/binaries-phar-docker.md
+++ b/docs/binaries-phar-docker.md
@@ -5,13 +5,13 @@
 Install the latest stable binary on 64-bit x86 Linux or Apple silicon macOS with:
 
 ```shell
-curl -fsSL https://raw.githubusercontent.com/yiipress/engine/9ec820b7c9d62160c183d3a6c1497b01afb4b133/install.sh | sh
+curl -fsSL https://raw.githubusercontent.com/yiipress/engine/master/install.sh | sh
 ```
 
 On 64-bit x86 Windows, run in PowerShell:
 
 ```powershell
-irm https://raw.githubusercontent.com/yiipress/engine/9ec820b7c9d62160c183d3a6c1497b01afb4b133/install.ps1 | iex
+irm https://raw.githubusercontent.com/yiipress/engine/master/install.ps1 | iex
 ```
 
 The installers download the latest release archive and `SHA256SUMS`, verify the archive, and atomically install the executable.
@@ -20,8 +20,8 @@ and adds it to the user `PATH`. Re-run the same command to update an existing in
 release, set environment variables before invoking the installer. For example, with the shell installer:
 
 ```shell
-curl -fsSL https://raw.githubusercontent.com/yiipress/engine/9ec820b7c9d62160c183d3a6c1497b01afb4b133/install.sh | YIIPRESS_INSTALL_DIR="$HOME/.local/bin" sh
-curl -fsSL https://raw.githubusercontent.com/yiipress/engine/9ec820b7c9d62160c183d3a6c1497b01afb4b133/install.sh | YIIPRESS_VERSION=X.Y.Z sh
+curl -fsSL https://raw.githubusercontent.com/yiipress/engine/master/install.sh | YIIPRESS_INSTALL_DIR="$HOME/.local/bin" sh
+curl -fsSL https://raw.githubusercontent.com/yiipress/engine/master/install.sh | YIIPRESS_VERSION=X.Y.Z sh
 ```
 
 YiiPress can be packaged as reproducible artifacts:

--- a/docs/binaries-phar-docker.md
+++ b/docs/binaries-phar-docker.md
@@ -1,5 +1,29 @@
 # Binaries, PHAR, Docker
 
+## Installation
+
+Install the latest stable binary on 64-bit x86 Linux or Apple silicon macOS with:
+
+```shell
+curl -fsSL https://raw.githubusercontent.com/yiipress/engine/master/install.sh | sh
+```
+
+On 64-bit x86 Windows, run in PowerShell:
+
+```powershell
+irm https://raw.githubusercontent.com/yiipress/engine/master/install.ps1 | iex
+```
+
+The installers download the latest release archive and `SHA256SUMS`, verify the archive, and atomically install the executable.
+The shell installer uses `/usr/local/bin/yiipress`; the PowerShell installer uses the current user's local application directory
+and adds it to the user `PATH`. Re-run the same command to update an existing installation. To use another directory or a fixed
+release, set environment variables before invoking the installer. For example, with the shell installer:
+
+```shell
+curl -fsSL https://raw.githubusercontent.com/yiipress/engine/master/install.sh | YIIPRESS_INSTALL_DIR="$HOME/.local/bin" sh
+curl -fsSL https://raw.githubusercontent.com/yiipress/engine/master/install.sh | YIIPRESS_VERSION=X.Y.Z sh
+```
+
 YiiPress can be packaged as reproducible artifacts:
 
 ```bash

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -9,21 +9,19 @@ mkdir myblog
 cd myblog
 ```
 
-Download the YiiPress binary from the latest GitHub release or workflow artifact and place it in this directory as `yiipress` (`yiipress.exe` on Windows):
+Install YiiPress for your platform using the command on the [documentation home page](README.md#install-or-update).
+The installer puts the executable on `PATH`, so the same commands work on Linux, macOS, and Windows.
 
 ```bash
-cp /path/to/yiipress ./yiipress
-chmod +x ./yiipress
+yiipress --version
 ```
-
-On Windows, use `yiipress.exe` in the examples below.
 
 ## 2. Create the initial files
 
 Run:
 
 ```bash
-./yiipress init
+yiipress init
 ```
 
 This creates `content/config.yaml`, `content/navigation.yaml`, and two starter collections. Edit `content/config.yaml`:
@@ -61,7 +59,7 @@ content/
 Create the post with the scaffold command:
 
 ```bash
-./yiipress new "Hello World" --collection=blog
+yiipress new "Hello World" --collection=blog
 ```
 
 Then edit the generated file in `content/blog/`. A typical post looks like this:
@@ -89,7 +87,7 @@ YiiPress is a static blog engine built on [Yii3](https://yiisoft.github.io/docs/
 Use the same command without `--collection` for a root-level page:
 
 ```bash
-./yiipress new "About"
+yiipress new "About"
 ```
 
 A simple `content/about.md` page looks like this:
@@ -119,7 +117,7 @@ main:
 ## 7. Build the site
 
 ```bash
-./yiipress build
+yiipress build
 ```
 
 This generates static HTML in the `output/` directory:
@@ -147,7 +145,7 @@ output/
 Start the dev server:
 
 ```bash
-./yiipress serve
+yiipress serve
 ```
 
 Open the URL printed by the command. The preview server rebuilds after content changes and refreshes the browser.
@@ -157,13 +155,13 @@ Open the URL printed by the command. The preview server rebuilds after content c
 Include drafts and future-dated posts during development:
 
 ```bash
-./yiipress build --drafts --future
+yiipress build --drafts --future
 ```
 
 Use multiple workers for faster builds:
 
 ```bash
-./yiipress build --workers=4
+yiipress build --workers=4
 ```
 
 By default, YiiPress uses `--workers=auto`, which detects available CPU capacity and uses up to 4 workers automatically.
@@ -171,7 +169,7 @@ By default, YiiPress uses `--workers=auto`, which detects available CPU capacity
 Disable cache for a clean build:
 
 ```bash
-./yiipress build --no-cache
+yiipress build --no-cache
 ```
 
 ## Next steps

--- a/install.ps1
+++ b/install.ps1
@@ -54,7 +54,11 @@ try {
     $Target = Join-Path $InstallDirectory "yiipress.exe"
     $TemporaryTarget = Join-Path $InstallDirectory (".yiipress-" + [Guid]::NewGuid() + ".exe")
     Copy-Item -Path $Binary -Destination $TemporaryTarget
-    [IO.File]::Move($TemporaryTarget, $Target, $true)
+    if (Test-Path -PathType Leaf $Target) {
+        [IO.File]::Replace($TemporaryTarget, $Target, $null)
+    } else {
+        [IO.File]::Move($TemporaryTarget, $Target)
+    }
 
     $UserPath = [Environment]::GetEnvironmentVariable("Path", "User")
     $PathEntries = if ($UserPath) { $UserPath -split ";" } else { @() }

--- a/install.ps1
+++ b/install.ps1
@@ -1,0 +1,72 @@
+$ErrorActionPreference = "Stop"
+
+$Repository = if ($env:YIIPRESS_REPOSITORY) { $env:YIIPRESS_REPOSITORY } else { "yiipress/engine" }
+$InstallDirectory = if ($env:YIIPRESS_INSTALL_DIR) {
+    $env:YIIPRESS_INSTALL_DIR
+} else {
+    Join-Path ([Environment]::GetFolderPath("LocalApplicationData")) "Programs\YiiPress"
+}
+$Version = if ($env:YIIPRESS_VERSION) { $env:YIIPRESS_VERSION } else { "latest" }
+
+if (-not [Runtime.InteropServices.RuntimeInformation]::IsOSPlatform([Runtime.InteropServices.OSPlatform]::Windows)) {
+    throw "This installer supports Windows only. Use install.sh on Linux or macOS."
+}
+if ([Runtime.InteropServices.RuntimeInformation]::OSArchitecture -ne [Runtime.InteropServices.Architecture]::X64) {
+    throw "The YiiPress Windows installer currently supports x64 Windows only."
+}
+
+$Asset = "yiipress-windows-amd64.zip"
+$ReleaseUrl = if ($Version -eq "latest") {
+    "https://github.com/$Repository/releases/latest/download"
+} else {
+    "https://github.com/$Repository/releases/download/$Version"
+}
+$WorkDirectory = Join-Path ([IO.Path]::GetTempPath()) ("yiipress-installer-" + [Guid]::NewGuid())
+
+try {
+    New-Item -ItemType Directory -Path $WorkDirectory | Out-Null
+    $Archive = Join-Path $WorkDirectory $Asset
+    $Checksums = Join-Path $WorkDirectory "SHA256SUMS"
+
+    Write-Host "Downloading YiiPress $Version for windows/amd64..."
+    Invoke-WebRequest -Uri "$ReleaseUrl/$Asset" -OutFile $Archive
+    Invoke-WebRequest -Uri "$ReleaseUrl/SHA256SUMS" -OutFile $Checksums
+
+    $ChecksumLine = Get-Content $Checksums | Where-Object {
+        $_ -match "^[0-9a-fA-F]{64}\s+(?:\*|assets/)?$([Regex]::Escape($Asset))$"
+    } | Select-Object -First 1
+    if (-not $ChecksumLine) {
+        throw "SHA256SUMS does not contain $Asset."
+    }
+    $ExpectedChecksum = ($ChecksumLine -split "\s+")[0]
+    $ActualChecksum = (Get-FileHash -Algorithm SHA256 -Path $Archive).Hash
+    if ($ActualChecksum -ne $ExpectedChecksum) {
+        throw "Checksum verification failed for $Asset."
+    }
+
+    Expand-Archive -Path $Archive -DestinationPath $WorkDirectory -Force
+    $Binary = Join-Path $WorkDirectory "yiipress.exe"
+    if (-not (Test-Path -PathType Leaf $Binary)) {
+        throw "The release archive does not contain yiipress.exe."
+    }
+
+    New-Item -ItemType Directory -Path $InstallDirectory -Force | Out-Null
+    $Target = Join-Path $InstallDirectory "yiipress.exe"
+    $TemporaryTarget = Join-Path $InstallDirectory (".yiipress-" + [Guid]::NewGuid() + ".exe")
+    Copy-Item -Path $Binary -Destination $TemporaryTarget
+    [IO.File]::Move($TemporaryTarget, $Target, $true)
+
+    $UserPath = [Environment]::GetEnvironmentVariable("Path", "User")
+    $PathEntries = if ($UserPath) { $UserPath -split ";" } else { @() }
+    if ($InstallDirectory -notin $PathEntries) {
+        $UpdatedPath = (@($PathEntries) + $InstallDirectory | Where-Object { $_ }) -join ";"
+        [Environment]::SetEnvironmentVariable("Path", $UpdatedPath, "User")
+        Write-Host "Added $InstallDirectory to your user PATH. Open a new terminal to use yiipress."
+    }
+
+    Write-Host "YiiPress was installed to $Target."
+} finally {
+    if (Test-Path $WorkDirectory) {
+        Remove-Item -Path $WorkDirectory -Recurse -Force
+    }
+}

--- a/install.sh
+++ b/install.sh
@@ -1,0 +1,103 @@
+#!/bin/sh
+
+set -eu
+
+repository="${YIIPRESS_REPOSITORY:-yiipress/engine}"
+install_dir="${YIIPRESS_INSTALL_DIR:-/usr/local/bin}"
+version="${YIIPRESS_VERSION:-latest}"
+
+for command in curl tar awk mktemp install mv rm uname; do
+    if ! command -v "$command" >/dev/null 2>&1; then
+        echo "YiiPress installer requires $command." >&2
+        exit 1
+    fi
+done
+
+system="$(uname -s)"
+machine="$(uname -m)"
+case "$system" in
+    Linux)
+        platform="linux"
+        checksum_command="sha256sum"
+        case "$machine" in
+            x86_64|amd64) architecture="amd64" ;;
+            *)
+                echo "Unsupported Linux architecture: ${machine}." >&2
+                exit 1
+                ;;
+        esac
+        ;;
+    Darwin)
+        platform="macos"
+        checksum_command="shasum"
+        case "$machine" in
+            arm64|aarch64) architecture="arm64" ;;
+            *)
+                echo "Unsupported macOS architecture: ${machine}." >&2
+                exit 1
+                ;;
+        esac
+        ;;
+    *)
+        echo "Unsupported operating system: ${system}. Use install.ps1 on Windows." >&2
+        exit 1
+        ;;
+esac
+
+if ! command -v "$checksum_command" >/dev/null 2>&1; then
+    echo "YiiPress installer requires $checksum_command." >&2
+    exit 1
+fi
+
+asset="yiipress-${platform}-${architecture}.tar.gz"
+if [ "$version" = "latest" ]; then
+    release_url="https://github.com/${repository}/releases/latest/download"
+else
+    release_url="https://github.com/${repository}/releases/download/${version}"
+fi
+
+work_dir="$(mktemp -d)"
+trap 'rm -rf "$work_dir"' EXIT HUP INT TERM
+
+echo "Downloading YiiPress ${version} for ${platform}/${architecture}..."
+curl -fsSL --retry 3 --retry-delay 2 "${release_url}/${asset}" -o "${work_dir}/${asset}"
+curl -fsSL --retry 3 --retry-delay 2 "${release_url}/SHA256SUMS" -o "${work_dir}/SHA256SUMS"
+
+expected_checksum="$(awk -v asset="$asset" '$2 == asset || $2 == "*" asset || $2 == "assets/" asset { print $1; exit }' "${work_dir}/SHA256SUMS")"
+if [ -z "$expected_checksum" ]; then
+    echo "SHA256SUMS does not contain ${asset}." >&2
+    exit 1
+fi
+
+if [ "$checksum_command" = "shasum" ]; then
+    actual_checksum="$(shasum -a 256 "${work_dir}/${asset}" | awk '{ print $1 }')"
+else
+    actual_checksum="$(sha256sum "${work_dir}/${asset}" | awk '{ print $1 }')"
+fi
+if [ "$actual_checksum" != "$expected_checksum" ]; then
+    echo "Checksum verification failed for ${asset}." >&2
+    exit 1
+fi
+
+tar -xzf "${work_dir}/${asset}" -C "$work_dir" yiipress
+if [ ! -f "${work_dir}/yiipress" ]; then
+    echo "The release archive does not contain the yiipress binary." >&2
+    exit 1
+fi
+
+elevate=""
+if { [ ! -d "$install_dir" ] && ! mkdir -p "$install_dir" 2>/dev/null; } || [ ! -w "$install_dir" ]; then
+    if command -v sudo >/dev/null 2>&1; then
+        elevate="sudo"
+    else
+        echo "Cannot write to ${install_dir}. Run as root or set YIIPRESS_INSTALL_DIR." >&2
+        exit 1
+    fi
+fi
+
+$elevate install -d "$install_dir"
+temporary_target="${install_dir}/.yiipress.$$"
+$elevate install -m 0755 "${work_dir}/yiipress" "$temporary_target"
+$elevate mv -f "$temporary_target" "${install_dir}/yiipress"
+
+echo "YiiPress was installed to ${install_dir}/yiipress."

--- a/install.sh
+++ b/install.sh
@@ -80,7 +80,7 @@ if [ "$actual_checksum" != "$expected_checksum" ]; then
 fi
 
 tar -xzf "${work_dir}/${asset}" -C "$work_dir" yiipress
-if [ ! -f "${work_dir}/yiipress" ]; then
+if [ ! -f "${work_dir}/yiipress" ] || [ -L "${work_dir}/yiipress" ]; then
     echo "The release archive does not contain the yiipress binary." >&2
     exit 1
 fi

--- a/roadmap.md
+++ b/roadmap.md
@@ -69,6 +69,7 @@
 - [x] `serve` overlay button to open the current markdown source in a configured editor
 - [x] [Respect console verbosity when rendering errors](https://github.com/yiipress/engine/issues/126)
 - [x] [Hide the internal worker command from the user-facing command list](https://github.com/yiipress/engine/issues/124)
+- [x] [Add one-command Linux, macOS, and Windows installers and updaters](https://github.com/yiipress/engine/issues/129)
 
 ## Priority 4: Templates and theming
 

--- a/tests/Unit/Packaging/ConfigurationPackagingTest.php
+++ b/tests/Unit/Packaging/ConfigurationPackagingTest.php
@@ -789,6 +789,8 @@ PHP;
     {
         foreach ([
             'config/.gitignore',
+            'install.sh',
+            'install.ps1',
             'runtime/cache/build-manifest.json',
             'vendor/composer/installed.json',
             'vendor\\composer\\installed.json',

--- a/tests/Unit/Packaging/InstallerTest.php
+++ b/tests/Unit/Packaging/InstallerTest.php
@@ -22,6 +22,7 @@ use function readdir;
 use function rmdir;
 use function stream_get_contents;
 use function str_replace;
+use function symlink;
 use function sys_get_temp_dir;
 use function uniqid;
 use function unlink;
@@ -106,6 +107,18 @@ SH);
     }
 
     #[Test]
+    public function refusesASymbolicLinkBinaryFromTheArchive(): void
+    {
+        $this->createRelease('unused', symbolicLink: true);
+
+        [$exitCode, $output] = $this->runInstaller();
+
+        self::assertSame(1, $exitCode);
+        self::assertStringContainsString('does not contain the yiipress binary', $output);
+        self::assertFileDoesNotExist($this->root . '/install/yiipress');
+    }
+
+    #[Test]
     public function installsTheLatestMacOsArmBinary(): void
     {
         $this->createRelease('macos-version', 'yiipress-macos-arm64.tar.gz');
@@ -158,19 +171,29 @@ SH);
         self::assertStringContainsString('OSPlatform]::Windows', $script);
         self::assertStringContainsString('releases/latest/download', $script);
         self::assertStringContainsString('Get-FileHash -Algorithm SHA256', $script);
-        self::assertStringContainsString('[IO.File]::Move($TemporaryTarget, $Target, $true)', $script);
+        self::assertStringContainsString('[IO.File]::Replace($TemporaryTarget, $Target, $null)', $script);
+        self::assertStringContainsString('[IO.File]::Move($TemporaryTarget, $Target)', $script);
+        self::assertStringNotContainsString('[IO.File]::Move($TemporaryTarget, $Target, $true)', $script);
         self::assertStringContainsString('[Environment]::SetEnvironmentVariable("Path", $UpdatedPath, "User")', $script);
         self::assertStringContainsString('YIIPRESS_INSTALL_DIR', $script);
         self::assertStringContainsString('YIIPRESS_VERSION', $script);
     }
 
-    private function createRelease(string $contents, string $asset = 'yiipress-linux-amd64.tar.gz'): void
+    private function createRelease(
+        string $contents,
+        string $asset = 'yiipress-linux-amd64.tar.gz',
+        bool $symbolicLink = false,
+    ): void
     {
         $archiveRoot = $this->root . '/archive';
         if (!is_dir($archiveRoot)) {
             mkdir($archiveRoot);
         }
-        file_put_contents($archiveRoot . '/yiipress', $contents);
+        if ($symbolicLink) {
+            symlink('/etc/passwd', $archiveRoot . '/yiipress');
+        } else {
+            file_put_contents($archiveRoot . '/yiipress', $contents);
+        }
 
         $archive = $this->root . '/release/' . $asset;
         $pipes = [];

--- a/tests/Unit/Packaging/InstallerTest.php
+++ b/tests/Unit/Packaging/InstallerTest.php
@@ -179,6 +179,20 @@ SH);
         self::assertStringContainsString('YIIPRESS_VERSION', $script);
     }
 
+    #[Test]
+    public function documentationUsesTheSameImmutableInstallerRevision(): void
+    {
+        $root = dirname(__DIR__, 3);
+        $revision = '9ec820b7c9d62160c183d3a6c1497b01afb4b133';
+        foreach (['README.md', 'docs/README.md', 'docs/binaries-phar-docker.md'] as $path) {
+            $documentation = file_get_contents($root . '/' . $path);
+            self::assertIsString($documentation);
+            self::assertStringContainsString("yiipress/engine/$revision/install.sh", $documentation);
+            self::assertStringContainsString("yiipress/engine/$revision/install.ps1", $documentation);
+            self::assertStringNotContainsString('yiipress/engine/master/install.', $documentation);
+        }
+    }
+
     private function createRelease(
         string $contents,
         string $asset = 'yiipress-linux-amd64.tar.gz',

--- a/tests/Unit/Packaging/InstallerTest.php
+++ b/tests/Unit/Packaging/InstallerTest.php
@@ -1,0 +1,198 @@
+<?php
+
+declare(strict_types=1);
+
+namespace YiiPress\Tests\Unit\Packaging;
+
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+
+use function chmod;
+use function dirname;
+use function file_get_contents;
+use function file_put_contents;
+use function getenv;
+use function hash_file;
+use function is_dir;
+use function mkdir;
+use function proc_close;
+use function proc_open;
+use function readdir;
+use function rmdir;
+use function stream_get_contents;
+use function str_replace;
+use function sys_get_temp_dir;
+use function uniqid;
+use function unlink;
+
+final class InstallerTest extends TestCase
+{
+    private string $root;
+
+    protected function setUp(): void
+    {
+        $this->root = sys_get_temp_dir() . '/yiipress-installer-' . uniqid('', true);
+        mkdir($this->root . '/bin', recursive: true);
+        mkdir($this->root . '/release', recursive: true);
+        mkdir($this->root . '/install', recursive: true);
+
+        $curl = str_replace("\r\n", "\n", <<<'SH'
+#!/bin/sh
+set -eu
+url=""
+output=""
+while [ "$#" -gt 0 ]; do
+    case "$1" in
+        -o) output="$2"; shift 2 ;;
+        http*) url="$1"; shift ;;
+        *) shift ;;
+    esac
+done
+cp "${YIIPRESS_TEST_RELEASE_DIR}/${url##*/}" "$output"
+SH);
+        file_put_contents($this->root . '/bin/curl', $curl);
+        chmod($this->root . '/bin/curl', 0755);
+
+        $uname = "#!/bin/sh\nif [ \"\$1\" = \"-s\" ]; then printf '%s\\n' \"\$YIIPRESS_TEST_SYSTEM\"; else printf '%s\\n' \"\$YIIPRESS_TEST_MACHINE\"; fi\n";
+        file_put_contents($this->root . '/bin/uname', $uname);
+        chmod($this->root . '/bin/uname', 0755);
+
+        $shasum = "#!/bin/sh\nshift 2\nexec sha256sum \"\$@\"\n";
+        file_put_contents($this->root . '/bin/shasum', $shasum);
+        chmod($this->root . '/bin/shasum', 0755);
+    }
+
+    protected function tearDown(): void
+    {
+        $this->removeDirectory($this->root);
+    }
+
+    #[Test]
+    public function installsAndUpdatesTheLatestLinuxBinary(): void
+    {
+        $this->createRelease('version-one');
+
+        [$exitCode, $output] = $this->runInstaller();
+
+        self::assertSame(0, $exitCode, $output);
+        self::assertSame('version-one', file_get_contents($this->root . '/install/yiipress'));
+        self::assertSame(0755, fileperms($this->root . '/install/yiipress') & 0777);
+
+        $this->createRelease('version-two');
+        [$exitCode, $output] = $this->runInstaller();
+
+        self::assertSame(0, $exitCode, $output);
+        self::assertSame('version-two', file_get_contents($this->root . '/install/yiipress'));
+        self::assertSame([], glob($this->root . '/install/.yiipress.*'));
+    }
+
+    #[Test]
+    public function refusesAnArchiveWithAnInvalidChecksum(): void
+    {
+        $this->createRelease('untrusted');
+        file_put_contents($this->root . '/release/SHA256SUMS', sprintf("%064d  yiipress-linux-amd64.tar.gz\n", 0));
+
+        [$exitCode, $output] = $this->runInstaller();
+
+        self::assertSame(1, $exitCode);
+        self::assertStringContainsString('Checksum verification failed', $output);
+        self::assertFileDoesNotExist($this->root . '/install/yiipress');
+    }
+
+    #[Test]
+    public function installsTheLatestMacOsArmBinary(): void
+    {
+        $this->createRelease('macos-version', 'yiipress-macos-arm64.tar.gz');
+
+        [$exitCode, $output] = $this->runInstaller('Darwin', 'arm64');
+
+        self::assertSame(0, $exitCode, $output);
+        self::assertStringContainsString('macos/arm64', $output);
+        self::assertSame('macos-version', file_get_contents($this->root . '/install/yiipress'));
+    }
+
+    #[Test]
+    public function windowsInstallerDownloadsVerifiesAndAtomicallyReplacesTheExecutable(): void
+    {
+        $script = file_get_contents(dirname(__DIR__, 3) . '/install.ps1');
+        self::assertIsString($script);
+
+        self::assertStringContainsString('yiipress-windows-amd64.zip', $script);
+        self::assertStringContainsString('OSPlatform]::Windows', $script);
+        self::assertStringContainsString('releases/latest/download', $script);
+        self::assertStringContainsString('Get-FileHash -Algorithm SHA256', $script);
+        self::assertStringContainsString('[IO.File]::Move($TemporaryTarget, $Target, $true)', $script);
+        self::assertStringContainsString('[Environment]::SetEnvironmentVariable("Path", $UpdatedPath, "User")', $script);
+        self::assertStringContainsString('YIIPRESS_INSTALL_DIR', $script);
+        self::assertStringContainsString('YIIPRESS_VERSION', $script);
+    }
+
+    private function createRelease(string $contents, string $asset = 'yiipress-linux-amd64.tar.gz'): void
+    {
+        $archiveRoot = $this->root . '/archive';
+        if (!is_dir($archiveRoot)) {
+            mkdir($archiveRoot);
+        }
+        file_put_contents($archiveRoot . '/yiipress', $contents);
+
+        $archive = $this->root . '/release/' . $asset;
+        $pipes = [];
+        $process = proc_open(
+            ['tar', '-C', $archiveRoot, '-czf', $archive, 'yiipress'],
+            [1 => ['pipe', 'w'], 2 => ['pipe', 'w']],
+            $pipes,
+        );
+        self::assertIsResource($process);
+        $output = stream_get_contents($pipes[1]) . stream_get_contents($pipes[2]);
+        self::assertSame(0, proc_close($process), $output);
+
+        $checksum = hash_file('sha256', $archive);
+        self::assertIsString($checksum);
+        file_put_contents($this->root . '/release/SHA256SUMS', "$checksum  assets/$asset\n");
+    }
+
+    /** @return array{int, string} */
+    private function runInstaller(string $system = 'Linux', string $machine = 'x86_64'): array
+    {
+        $systemPath = getenv('PATH');
+        self::assertIsString($systemPath);
+        $environment = [
+            'PATH' => $this->root . '/bin:' . $systemPath,
+            'YIIPRESS_INSTALL_DIR' => $this->root . '/install',
+            'YIIPRESS_REPOSITORY' => 'test/engine',
+            'YIIPRESS_TEST_RELEASE_DIR' => $this->root . '/release',
+            'YIIPRESS_TEST_SYSTEM' => $system,
+            'YIIPRESS_TEST_MACHINE' => $machine,
+        ];
+        $pipes = [];
+        $process = proc_open(
+            ['sh', dirname(__DIR__, 3) . '/install.sh'],
+            [1 => ['pipe', 'w'], 2 => ['pipe', 'w']],
+            $pipes,
+            null,
+            $environment,
+        );
+        self::assertIsResource($process);
+        $output = stream_get_contents($pipes[1]) . stream_get_contents($pipes[2]);
+
+        return [proc_close($process), $output];
+    }
+
+    private function removeDirectory(string $directory): void
+    {
+        if (!is_dir($directory)) {
+            return;
+        }
+        $handle = opendir($directory);
+        self::assertIsResource($handle);
+        while (($name = readdir($handle)) !== false) {
+            if ($name === '.' || $name === '..') {
+                continue;
+            }
+            $path = $directory . '/' . $name;
+            is_dir($path) ? $this->removeDirectory($path) : unlink($path);
+        }
+        closedir($handle);
+        rmdir($directory);
+    }
+}

--- a/tests/Unit/Packaging/InstallerTest.php
+++ b/tests/Unit/Packaging/InstallerTest.php
@@ -179,20 +179,6 @@ SH);
         self::assertStringContainsString('YIIPRESS_VERSION', $script);
     }
 
-    #[Test]
-    public function documentationUsesTheSameImmutableInstallerRevision(): void
-    {
-        $root = dirname(__DIR__, 3);
-        $revision = '9ec820b7c9d62160c183d3a6c1497b01afb4b133';
-        foreach (['README.md', 'docs/README.md', 'docs/binaries-phar-docker.md'] as $path) {
-            $documentation = file_get_contents($root . '/' . $path);
-            self::assertIsString($documentation);
-            self::assertStringContainsString("yiipress/engine/$revision/install.sh", $documentation);
-            self::assertStringContainsString("yiipress/engine/$revision/install.ps1", $documentation);
-            self::assertStringNotContainsString('yiipress/engine/master/install.', $documentation);
-        }
-    }
-
     private function createRelease(
         string $contents,
         string $asset = 'yiipress-linux-amd64.tar.gz',

--- a/tests/Unit/Packaging/InstallerTest.php
+++ b/tests/Unit/Packaging/InstallerTest.php
@@ -11,6 +11,7 @@ use function chmod;
 use function dirname;
 use function file_get_contents;
 use function file_put_contents;
+use function fclose;
 use function getenv;
 use function hash_file;
 use function is_dir;
@@ -49,6 +50,7 @@ while [ "$#" -gt 0 ]; do
     esac
 done
 cp "${YIIPRESS_TEST_RELEASE_DIR}/${url##*/}" "$output"
+printf '%s\n' "$url" >> "${YIIPRESS_TEST_CURL_LOG}"
 SH);
         file_put_contents($this->root . '/bin/curl', $curl);
         chmod($this->root . '/bin/curl', 0755);
@@ -60,6 +62,10 @@ SH);
         $shasum = "#!/bin/sh\nshift 2\nexec sha256sum \"\$@\"\n";
         file_put_contents($this->root . '/bin/shasum', $shasum);
         chmod($this->root . '/bin/shasum', 0755);
+
+        $sudo = "#!/bin/sh\nprintf '%s\\n' \"\$*\" >> \"\$YIIPRESS_TEST_SUDO_LOG\"\n";
+        file_put_contents($this->root . '/bin/sudo', $sudo);
+        chmod($this->root . '/bin/sudo', 0755);
     }
 
     protected function tearDown(): void
@@ -112,6 +118,37 @@ SH);
     }
 
     #[Test]
+    public function installsAPinnedReleaseIntoTheConfiguredDirectory(): void
+    {
+        $this->createRelease('pinned-version');
+        $installDirectory = $this->root . '/custom-install';
+
+        [$exitCode, $output] = $this->runInstaller(installDirectory: $installDirectory, version: '0.1.8');
+
+        self::assertSame(0, $exitCode, $output);
+        self::assertSame('pinned-version', file_get_contents($installDirectory . '/yiipress'));
+        $curlLog = file_get_contents($this->root . '/curl.log');
+        self::assertIsString($curlLog);
+        self::assertStringContainsString('/releases/download/0.1.8/yiipress-linux-amd64.tar.gz', $curlLog);
+        self::assertStringNotContainsString('/releases/latest/download', $curlLog);
+    }
+
+    #[Test]
+    public function usesSudoWhenTheInstallDirectoryCannotBeCreated(): void
+    {
+        $this->createRelease('sudo-version');
+
+        [$exitCode, $output] = $this->runInstaller(installDirectory: '/proc/yiipress-installer-test');
+
+        self::assertSame(0, $exitCode, $output);
+        $sudoLog = file_get_contents($this->root . '/sudo.log');
+        self::assertIsString($sudoLog);
+        self::assertStringContainsString('install -d /proc/yiipress-installer-test', $sudoLog);
+        self::assertStringContainsString('install -m 0755', $sudoLog);
+        self::assertStringContainsString('mv -f /proc/yiipress-installer-test/.yiipress.', $sudoLog);
+    }
+
+    #[Test]
     public function windowsInstallerDownloadsVerifiesAndAtomicallyReplacesTheExecutable(): void
     {
         $script = file_get_contents(dirname(__DIR__, 3) . '/install.ps1');
@@ -144,6 +181,8 @@ SH);
         );
         self::assertIsResource($process);
         $output = stream_get_contents($pipes[1]) . stream_get_contents($pipes[2]);
+        fclose($pipes[1]);
+        fclose($pipes[2]);
         self::assertSame(0, proc_close($process), $output);
 
         $checksum = hash_file('sha256', $archive);
@@ -152,17 +191,25 @@ SH);
     }
 
     /** @return array{int, string} */
-    private function runInstaller(string $system = 'Linux', string $machine = 'x86_64'): array
+    private function runInstaller(
+        string $system = 'Linux',
+        string $machine = 'x86_64',
+        ?string $installDirectory = null,
+        string $version = 'latest',
+    ): array
     {
         $systemPath = getenv('PATH');
         self::assertIsString($systemPath);
         $environment = [
             'PATH' => $this->root . '/bin:' . $systemPath,
-            'YIIPRESS_INSTALL_DIR' => $this->root . '/install',
+            'YIIPRESS_INSTALL_DIR' => $installDirectory ?? $this->root . '/install',
             'YIIPRESS_REPOSITORY' => 'test/engine',
             'YIIPRESS_TEST_RELEASE_DIR' => $this->root . '/release',
+            'YIIPRESS_TEST_CURL_LOG' => $this->root . '/curl.log',
             'YIIPRESS_TEST_SYSTEM' => $system,
             'YIIPRESS_TEST_MACHINE' => $machine,
+            'YIIPRESS_TEST_SUDO_LOG' => $this->root . '/sudo.log',
+            'YIIPRESS_VERSION' => $version,
         ];
         $pipes = [];
         $process = proc_open(
@@ -174,6 +221,8 @@ SH);
         );
         self::assertIsResource($process);
         $output = stream_get_contents($pipes[1]) . stream_get_contents($pipes[2]);
+        fclose($pipes[1]);
+        fclose($pipes[2]);
 
         return [proc_close($process), $output];
     }


### PR DESCRIPTION
## Summary

- add a checksum-verified installer/updater for Linux x86-64 and Apple-silicon macOS
- add a native PowerShell installer/updater for Windows x86-64 that persists its directory in the user PATH
- atomically replace existing binaries and support install-directory and version overrides
- put the platform commands near the beginning of the README and documentation, and update the roadmap
- add integration coverage for Linux and simulated macOS, plus Windows installer contract coverage

Closes #129.

## Verification

- `make test CLI_ARGS=tests/Unit/Packaging/InstallerTest.php` — 6 tests, 91 assertions
- `make psalm`
- `sh -n install.sh`
- ran the Linux installer twice against the latest published release using a temporary install directory; the installed binary ran successfully

macOS and Windows execution cannot be performed on this Linux host; their release asset selection, checksum, atomic replacement, and update contracts are covered by the installer tests.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added one-command installers for Linux, macOS Apple silicon, and Windows.
  * Installers verify downloads, support pinned versions and custom directories, update existing installations, and add the command to PATH.
  * Added Windows PowerShell installation support.

* **Documentation**
  * Updated installation and quickstart guides to use the globally installed `yiipress` command.
  * Added guidance for checksum verification, updates, PATH configuration, and common commands.

* **Tests**
  * Added coverage for successful installations, updates, platform selection, custom paths, checksum failures, and Windows installation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->