### PR TITLE
Fix #130: Add packaged self-update command

### DIFF
--- a/.github/workflows/package-static.yml
+++ b/.github/workflows/package-static.yml
@@ -89,34 +89,6 @@ jobs:
           labels: ${{ steps.meta.outputs.labels }}
           platforms: linux/amd64
 
-      - name: Publish nightly Linux release
-        if: github.event_name != 'pull_request' && github.ref == 'refs/heads/master'
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          set -euo pipefail
-
-          mkdir -p assets
-          tar -C dist/linux-amd64 -czf assets/yiipress-linux-amd64.tar.gz yiipress
-          sha256sum assets/yiipress-linux-amd64.tar.gz > assets/SHA256SUMS
-          short_sha="${GITHUB_SHA::12}"
-          nightly_tag="nightly-${GITHUB_RUN_NUMBER}-${GITHUB_RUN_ATTEMPT}-${short_sha}"
-
-          {
-            printf '# Nightly %s\n\n' "${short_sha}"
-            printf 'Built from `%s` on `%s`.\n\n' "${GITHUB_SHA}" "${GITHUB_REF_NAME}"
-            printf 'Nightly tag: `%s`.\n\n' "${nightly_tag}"
-            printf '%s\n\n' 'This immutable prerelease is created after a successful package build on `master`.'
-            printf '%s\n' 'It is intended for testing unreleased YiiPress changes in site build workflows.'
-          } > nightly-release-notes.md
-
-          gh release create "${nightly_tag}" assets/* \
-            --target "${GITHUB_SHA}" \
-            --title "Nightly ${short_sha}" \
-            --notes-file nightly-release-notes.md \
-            --prerelease \
-            --latest=false
-
   windows:
     name: Windows static binary
     if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
@@ -230,3 +202,49 @@ jobs:
           name: yiipress-macos-arm64
           path: dist/yiipress-macos-arm64.tar.gz
           if-no-files-found: error
+
+  nightly-release:
+    name: Publish nightly release
+    if: github.event_name != 'pull_request' && github.ref == 'refs/heads/master'
+    needs: [linux, windows, macos]
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+
+    steps:
+      - name: Download package artifacts
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093
+        with:
+          path: release
+          pattern: yiipress-*
+
+      - name: Publish nightly release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+
+          mkdir -p assets
+          cp release/yiipress-linux-amd64/yiipress assets/yiipress-linux-amd64
+          cp release/yiipress-phar/yiipress.phar assets/yiipress.phar
+          tar -xOf release/yiipress-macos-arm64/yiipress-macos-arm64.tar.gz yiipress > assets/yiipress-macos-arm64
+          cp release/yiipress-windows-amd64/yiipress.exe assets/yiipress-windows-amd64.exe
+          tar -C release/yiipress-linux-amd64 -czf assets/yiipress-linux-amd64.tar.gz yiipress
+          sha256sum assets/* > assets/SHA256SUMS
+          short_sha="${GITHUB_SHA::12}"
+          nightly_tag="nightly-${GITHUB_RUN_NUMBER}-${GITHUB_RUN_ATTEMPT}-${short_sha}"
+
+          {
+            printf '# Nightly %s\n\n' "${short_sha}"
+            printf 'Built from `%s` on `%s`.\n\n' "${GITHUB_SHA}" "${GITHUB_REF_NAME}"
+            printf 'Nightly tag: `%s`.\n\n' "${nightly_tag}"
+            printf '%s\n\n' 'This immutable prerelease is created after a successful package build on `master`.'
+            printf '%s\n' 'It is intended for testing unreleased YiiPress changes in site build workflows.'
+          } > nightly-release-notes.md
+
+          gh release create "${nightly_tag}" assets/* \
+            --target "${GITHUB_SHA}" \
+            --title "Nightly ${short_sha}" \
+            --notes-file nightly-release-notes.md \
+            --prerelease \
+            --latest=false

--- a/.github/workflows/package-static.yml
+++ b/.github/workflows/package-static.yml
@@ -89,6 +89,34 @@ jobs:
           labels: ${{ steps.meta.outputs.labels }}
           platforms: linux/amd64
 
+      - name: Publish nightly Linux release
+        if: github.event_name != 'pull_request' && github.ref == 'refs/heads/master'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+
+          mkdir -p assets
+          tar -C dist/linux-amd64 -czf assets/yiipress-linux-amd64.tar.gz yiipress
+          sha256sum assets/yiipress-linux-amd64.tar.gz > assets/SHA256SUMS
+          short_sha="${GITHUB_SHA::12}"
+          nightly_tag="nightly-${GITHUB_RUN_NUMBER}-${GITHUB_RUN_ATTEMPT}-${short_sha}"
+
+          {
+            printf '# Nightly %s\n\n' "${short_sha}"
+            printf 'Built from `%s` on `%s`.\n\n' "${GITHUB_SHA}" "${GITHUB_REF_NAME}"
+            printf 'Nightly tag: `%s`.\n\n' "${nightly_tag}"
+            printf '%s\n\n' 'This immutable prerelease is created after a successful package build on `master`.'
+            printf '%s\n' 'It is intended for testing unreleased YiiPress changes in site build workflows.'
+          } > nightly-release-notes.md
+
+          gh release create "${nightly_tag}" assets/* \
+            --target "${GITHUB_SHA}" \
+            --title "Nightly ${short_sha}" \
+            --notes-file nightly-release-notes.md \
+            --prerelease \
+            --latest=false
+
   windows:
     name: Windows static binary
     if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
@@ -202,49 +230,3 @@ jobs:
           name: yiipress-macos-arm64
           path: dist/yiipress-macos-arm64.tar.gz
           if-no-files-found: error
-
-  nightly-release:
-    name: Publish nightly release
-    if: github.event_name != 'pull_request' && github.ref == 'refs/heads/master'
-    needs: [linux, windows, macos]
-    runs-on: ubuntu-latest
-    permissions:
-      contents: write
-
-    steps:
-      - name: Download package artifacts
-        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093
-        with:
-          path: release
-          pattern: yiipress-*
-
-      - name: Publish nightly release
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          set -euo pipefail
-
-          mkdir -p assets
-          cp release/yiipress-linux-amd64/yiipress assets/yiipress-linux-amd64
-          cp release/yiipress-phar/yiipress.phar assets/yiipress.phar
-          tar -xOf release/yiipress-macos-arm64/yiipress-macos-arm64.tar.gz yiipress > assets/yiipress-macos-arm64
-          cp release/yiipress-windows-amd64/yiipress.exe assets/yiipress-windows-amd64.exe
-          tar -C release/yiipress-linux-amd64 -czf assets/yiipress-linux-amd64.tar.gz yiipress
-          sha256sum assets/* > assets/SHA256SUMS
-          short_sha="${GITHUB_SHA::12}"
-          nightly_tag="nightly-${GITHUB_RUN_NUMBER}-${GITHUB_RUN_ATTEMPT}-${short_sha}"
-
-          {
-            printf '# Nightly %s\n\n' "${short_sha}"
-            printf 'Built from `%s` on `%s`.\n\n' "${GITHUB_SHA}" "${GITHUB_REF_NAME}"
-            printf 'Nightly tag: `%s`.\n\n' "${nightly_tag}"
-            printf '%s\n\n' 'This immutable prerelease is created after a successful package build on `master`.'
-            printf '%s\n' 'It is intended for testing unreleased YiiPress changes in site build workflows.'
-          } > nightly-release-notes.md
-
-          gh release create "${nightly_tag}" assets/* \
-            --target "${GITHUB_SHA}" \
-            --title "Nightly ${short_sha}" \
-            --notes-file nightly-release-notes.md \
-            --prerelease \
-            --latest=false

--- a/.github/workflows/package-static.yml
+++ b/.github/workflows/package-static.yml
@@ -22,7 +22,7 @@ jobs:
     name: Linux static binary, PHAR, and distroless image
     runs-on: ubuntu-latest
     permissions:
-      contents: write
+      contents: read
       packages: write
 
     steps:
@@ -88,34 +88,6 @@ jobs:
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
           platforms: linux/amd64
-
-      - name: Publish nightly Linux release
-        if: github.event_name != 'pull_request' && github.ref == 'refs/heads/master'
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          set -euo pipefail
-
-          mkdir -p assets
-          tar -C dist/linux-amd64 -czf assets/yiipress-linux-amd64.tar.gz yiipress
-          sha256sum assets/yiipress-linux-amd64.tar.gz > assets/SHA256SUMS
-          short_sha="${GITHUB_SHA::12}"
-          nightly_tag="nightly-${GITHUB_RUN_NUMBER}-${GITHUB_RUN_ATTEMPT}-${short_sha}"
-
-          {
-            printf '# Nightly %s\n\n' "${short_sha}"
-            printf 'Built from `%s` on `%s`.\n\n' "${GITHUB_SHA}" "${GITHUB_REF_NAME}"
-            printf 'Nightly tag: `%s`.\n\n' "${nightly_tag}"
-            printf '%s\n\n' 'This immutable prerelease is created after a successful package build on `master`.'
-            printf '%s\n' 'It is intended for testing unreleased YiiPress changes in site build workflows.'
-          } > nightly-release-notes.md
-
-          gh release create "${nightly_tag}" assets/* \
-            --target "${GITHUB_SHA}" \
-            --title "Nightly ${short_sha}" \
-            --notes-file nightly-release-notes.md \
-            --prerelease \
-            --latest=false
 
   windows:
     name: Windows static binary
@@ -230,3 +202,51 @@ jobs:
           name: yiipress-macos-arm64
           path: dist/yiipress-macos-arm64.tar.gz
           if-no-files-found: error
+
+  nightly-release:
+    name: Publish nightly release
+    if: github.event_name != 'pull_request' && github.ref == 'refs/heads/master'
+    needs: [linux, windows, macos]
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+
+    steps:
+      - name: Download packaged artifacts
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093
+        with:
+          path: release
+          pattern: yiipress-*
+
+      - name: Pack nightly release assets
+        run: |
+          set -euo pipefail
+          mkdir -p assets
+          tar -C release/yiipress-linux-amd64 -czf assets/yiipress-linux-amd64.tar.gz yiipress
+          cp release/yiipress-macos-arm64/yiipress-macos-arm64.tar.gz assets/yiipress-macos-arm64.tar.gz
+          zip -j assets/yiipress-windows-amd64.zip release/yiipress-windows-amd64/*
+          cp release/yiipress-phar/yiipress.phar assets/yiipress.phar
+          sha256sum assets/* > assets/SHA256SUMS
+
+      - name: Publish nightly release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+          short_sha="${GITHUB_SHA::12}"
+          nightly_tag="nightly-${GITHUB_RUN_NUMBER}-${GITHUB_RUN_ATTEMPT}-${short_sha}"
+
+          {
+            printf '# Nightly %s\n\n' "${short_sha}"
+            printf 'Built from `%s` on `%s`.\n\n' "${GITHUB_SHA}" "${GITHUB_REF_NAME}"
+            printf 'Nightly tag: `%s`.\n\n' "${nightly_tag}"
+            printf '%s\n\n' 'This immutable prerelease is created after successful Linux, macOS, and Windows package builds on `master`.'
+            printf '%s\n' 'It is intended for testing unreleased YiiPress changes in site build workflows.'
+          } > nightly-release-notes.md
+
+          gh release create "${nightly_tag}" assets/* \
+            --target "${GITHUB_SHA}" \
+            --title "Nightly ${short_sha}" \
+            --notes-file nightly-release-notes.md \
+            --prerelease \
+            --latest=false

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -256,9 +256,6 @@ jobs:
           tar -C release/yiipress-linux-amd64 -czf assets/yiipress-linux-amd64.tar.gz yiipress
           cp release/yiipress-macos-arm64/yiipress-macos-arm64.tar.gz assets/yiipress-macos-arm64.tar.gz
           zip -j assets/yiipress-windows-amd64.zip release/yiipress-windows-amd64/*
-          cp release/yiipress-linux-amd64/yiipress assets/yiipress-linux-amd64
-          tar -xOf assets/yiipress-macos-arm64.tar.gz yiipress > assets/yiipress-macos-arm64
-          cp release/yiipress-windows-amd64/yiipress.exe assets/yiipress-windows-amd64.exe
           cp release/yiipress-phar/yiipress.phar assets/yiipress.phar
           sha256sum assets/* > assets/SHA256SUMS
 
@@ -319,7 +316,6 @@ jobs:
             printf '%s\n' '- yiipress-linux-amd64.tar.gz'
             printf '%s\n' '- yiipress-macos-arm64.tar.gz'
             printf '%s\n' '- yiipress-windows-amd64.zip'
-            printf '%s\n' '- Direct executable and PHAR assets used by `yiipress self-update`'
             printf -- '- %s\n\n' "${image}"
             printf '%s\n\n' 'Checksums are in SHA256SUMS.'
             printf '## Changes\n\n'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -256,6 +256,9 @@ jobs:
           tar -C release/yiipress-linux-amd64 -czf assets/yiipress-linux-amd64.tar.gz yiipress
           cp release/yiipress-macos-arm64/yiipress-macos-arm64.tar.gz assets/yiipress-macos-arm64.tar.gz
           zip -j assets/yiipress-windows-amd64.zip release/yiipress-windows-amd64/*
+          cp release/yiipress-linux-amd64/yiipress assets/yiipress-linux-amd64
+          tar -xOf assets/yiipress-macos-arm64.tar.gz yiipress > assets/yiipress-macos-arm64
+          cp release/yiipress-windows-amd64/yiipress.exe assets/yiipress-windows-amd64.exe
           cp release/yiipress-phar/yiipress.phar assets/yiipress.phar
           sha256sum assets/* > assets/SHA256SUMS
 
@@ -316,6 +319,7 @@ jobs:
             printf '%s\n' '- yiipress-linux-amd64.tar.gz'
             printf '%s\n' '- yiipress-macos-arm64.tar.gz'
             printf '%s\n' '- yiipress-windows-amd64.zip'
+            printf '%s\n' '- Direct executable and PHAR assets used by `yiipress self-update`'
             printf -- '- %s\n\n' "${image}"
             printf '%s\n\n' 'Checksums are in SHA256SUMS.'
             printf '## Changes\n\n'

--- a/benchmarks/SelfUpdaterBench.php
+++ b/benchmarks/SelfUpdaterBench.php
@@ -1,0 +1,62 @@
+<?php
+
+declare(strict_types=1);
+
+namespace YiiPress\Benchmarks;
+
+use PhpBench\Attributes\AfterMethods;
+use PhpBench\Attributes\BeforeMethods;
+use PhpBench\Attributes\Iterations;
+use PhpBench\Attributes\Revs;
+use PhpBench\Attributes\Warmup;
+use YiiPress\Update\Package;
+use YiiPress\Update\PackageLocator;
+use YiiPress\Update\ReleaseClient;
+use YiiPress\Update\SelfUpdater;
+
+#[BeforeMethods('setUp')]
+#[AfterMethods('tearDown')]
+final class SelfUpdaterBench
+{
+    private string $directory;
+    private Package $package;
+    private SelfUpdater $updater;
+
+    public function setUp(): void
+    {
+        $this->directory = sys_get_temp_dir() . '/yiipress-self-update-bench-' . uniqid('', true);
+        mkdir($this->directory . '/releases/latest/download', recursive: true);
+        $contents = str_repeat('YiiPress package contents', 10_000);
+        file_put_contents($this->directory . '/releases/latest/download/yiipress.phar', $contents);
+        file_put_contents(
+            $this->directory . '/releases/latest/download/SHA256SUMS',
+            hash('sha256', $contents) . "  yiipress.phar\n",
+        );
+        $target = $this->directory . '/yiipress.phar';
+        file_put_contents($target, 'old');
+        $this->package = new Package($target, 'yiipress.phar');
+        $this->updater = new SelfUpdater(
+            new PackageLocator(),
+            new ReleaseClient('file://' . $this->directory . '/releases'),
+        );
+    }
+
+    public function tearDown(): void
+    {
+        unlink($this->directory . '/releases/latest/download/yiipress.phar');
+        unlink($this->directory . '/releases/latest/download/SHA256SUMS');
+        unlink($this->directory . '/yiipress.phar');
+        rmdir($this->directory . '/releases/latest/download');
+        rmdir($this->directory . '/releases/latest');
+        rmdir($this->directory . '/releases');
+        rmdir($this->directory);
+    }
+
+    #[Revs(10)]
+    #[Iterations(3)]
+    #[Warmup(1)]
+    public function benchVerifyAndReplacePackage(): void
+    {
+        $this->updater->update(package: $this->package);
+    }
+}

--- a/build/package-macos.sh
+++ b/build/package-macos.sh
@@ -5,7 +5,7 @@ set -euo pipefail
 ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 PHP_VERSION="${PHP_VERSION:-8.5}"
 STATIC_PHP_CLI_REF="${STATIC_PHP_CLI_REF:-5b5861c366a0d94bc84002db7b3f46144b388fbb}"
-STATIC_PHP_EXTENSIONS="${STATIC_PHP_EXTENSIONS:-ctype,dom,filter,highlighter,mdparser,mbstring,opcache,pcntl,phar,posix,xmlwriter,yaml}"
+STATIC_PHP_EXTENSIONS="${STATIC_PHP_EXTENSIONS:-ctype,dom,filter,highlighter,mdparser,mbstring,opcache,openssl,pcntl,phar,posix,xmlwriter,yaml}"
 
 detect_arch() {
     case "$(uname -m)" in

--- a/build/package-windows.ps1
+++ b/build/package-windows.ps1
@@ -2,7 +2,7 @@ param(
     [string] $DistDir = "dist/windows-amd64",
     [string] $PhpVersion = "8.5",
     [string] $StaticPhpCliRef = "5b5861c366a0d94bc84002db7b3f46144b388fbb",
-    [string] $StaticPhpExtensions = "ctype,dom,filter,highlighter,mdparser,mbstring,opcache,phar,xmlwriter,yaml"
+    [string] $StaticPhpExtensions = "ctype,dom,filter,highlighter,mdparser,mbstring,opcache,openssl,phar,xmlwriter,yaml"
 )
 
 $ErrorActionPreference = "Stop"

--- a/composer-dependency-analyser.php
+++ b/composer-dependency-analyser.php
@@ -15,6 +15,8 @@ return (new Configuration())
     ->addPathToScan($root . '/yii', isDev: false)
     ->addPathToScan($root . '/tests', isDev: true)
     ->ignoreErrorsOnPackage('psr/container', [ErrorType::UNUSED_DEPENDENCY])
+    // Required by PHP's HTTPS stream wrapper used by ReleaseClient.
+    ->ignoreErrorsOnExtension('ext-openssl', [ErrorType::UNUSED_DEPENDENCY])
     ->ignoreErrorsOnPackage('yiisoft/config', [ErrorType::UNUSED_DEPENDENCY])
     ->ignoreErrorsOnPackage('yiisoft/di', [ErrorType::UNUSED_DEPENDENCY])
     ->ignoreErrorsOnPackage('yiisoft/yii-event', [ErrorType::UNUSED_DEPENDENCY])

--- a/composer.json
+++ b/composer.json
@@ -40,6 +40,7 @@
         "ext-inotify": "*",
         "ext-mdparser": "*",
         "ext-mbstring": "*",
+        "ext-openssl": "*",
         "ext-pcntl": "*",
         "ext-posix": "*",
         "ext-xmlwriter": "*",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "78267b02298cb5573fc1a5565f4357a9",
+    "content-hash": "ad75f156ad68bb887545011b7e73cf63",
     "packages": [
         {
             "name": "alexkart/curl-builder",
@@ -10400,6 +10400,7 @@
         "ext-inotify": "*",
         "ext-mdparser": "*",
         "ext-mbstring": "*",
+        "ext-openssl": "*",
         "ext-pcntl": "*",
         "ext-posix": "*",
         "ext-xmlwriter": "*",

--- a/config/console/commands.php
+++ b/config/console/commands.php
@@ -13,5 +13,6 @@ return [
     'import' => Console\ImportCommand::class,
     'new' => Console\NewCommand::class,
     'serve' => Console\ServeCommand::class,
+    'self-update' => Console\SelfUpdateCommand::class,
     'theme:init' => Console\ThemeInitCommand::class,
 ];

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -135,7 +135,7 @@ RUN --mount=type=cache,target=/tmp/composer-cache \
 FROM app-base AS static-package
 ARG PHP_VERSION=8.5
 ARG STATIC_PHP_CLI_REF=5b5861c366a0d94bc84002db7b3f46144b388fbb
-ARG STATIC_PHP_EXTENSIONS=ctype,dom,filter,highlighter,inotify,mdparser,mbstring,opcache,pcntl,phar,posix,xmlwriter,yaml
+ARG STATIC_PHP_EXTENSIONS=ctype,dom,filter,highlighter,inotify,mdparser,mbstring,opcache,openssl,pcntl,phar,posix,xmlwriter,yaml
 ARG TARGETARCH
 ENV CARGO_HOME=/root/.cargo \
     RUSTUP_HOME=/usr/local/rustup \

--- a/docs/binaries-phar-docker.md
+++ b/docs/binaries-phar-docker.md
@@ -73,9 +73,9 @@ yiipress self-update
 yiipress self-update --nightly
 ```
 
-The first command installs the latest stable release. The second installs the newest nightly prerelease containing a compatible package. Currently, nightly GitHub releases contain the Linux binary; PHAR, macOS, and Windows installations report that no compatible nightly is available. Composer/source checkouts must be updated with Composer instead.
+The first command installs the latest stable release. The second installs the newest nightly prerelease containing a compatible package. If a nightly package is unavailable for the current installation type or platform, the command reports that clearly instead of selecting an incompatible asset. Composer/source checkouts must be updated with Composer instead.
 
-GitHub Actions builds the same outputs in the `Package Static Builds` workflow. Commits to `master` publish separate nightly PHAR, Linux, macOS, and Windows workflow artifacts, create immutable GitHub prereleases tagged as `nightly-<run>-<attempt>-<sha>` with the Linux binary and checksums, and push the distroless image as `ghcr.io/<owner>/<repo>-static:nightly` plus a commit-specific `nightly-<sha>` tag. The reusable build action resolves `version: nightly` to the newest matching nightly prerelease.
+GitHub Actions builds the same outputs in the `Package Static Builds` workflow. Commits to `master` publish separate nightly PHAR, Linux, macOS, and Windows workflow artifacts, create immutable GitHub prereleases tagged as `nightly-<run>-<attempt>-<sha>` with the PHAR and all three platform packages plus checksums, and push the distroless image as `ghcr.io/<owner>/<repo>-static:nightly` plus a commit-specific `nightly-<sha>` tag. The reusable build action resolves `version: nightly` to the newest matching nightly prerelease.
 
 The `Run Tests` workflow runs PHPUnit in the Linux Docker test image and builds the native Windows and macOS binaries. Both platform jobs exercise a complete site lifecycle with the packaged executable: initialize a project, create content, build it, check generated links, verify output, and clean the build.
 

--- a/docs/binaries-phar-docker.md
+++ b/docs/binaries-phar-docker.md
@@ -62,11 +62,20 @@ The PHAR builder copies only runtime inputs into the build stage: `config/`, `pu
 
 PHPDoc comments are stripped from packaged PHP files to keep the standalone PHAR and embedded static-binary PHAR smaller while preserving runtime comments, code, and dependency PHPDoc that is read through reflection at runtime. Benchmark fixture helpers, Composer's `installed.json`, VCS placeholders, and non-runtime type stubs are omitted because packaged commands do not need them.
 Packaged PHAR entries are gzip-compressed before the archive is finalized. The static binary appends that same PHAR to the micro SAPI executable, so PHAR compression reduces both the standalone PHAR and the Linux, macOS, and Windows static executables.
-The static executable includes `ext-highlighter`, so syntax highlighting does not need FFI or an external shared library. `serve` uses ReactPHP stream sockets, serves built files and live reload SSE in the server loop, keeps one shared live reload watcher per server process, and does not require PHP's native `sockets` extension. On POSIX platforms with PCNTL and signal support, `serve` can prefork worker processes; Windows static binaries run a single server process.
+The static executable includes `ext-highlighter`, so syntax highlighting does not need FFI or an external shared library, and `ext-openssl` for HTTPS self-updates. `serve` uses ReactPHP stream sockets, serves built files and live reload SSE in the server loop, keeps one shared live reload watcher per server process, and does not require PHP's native `sockets` extension. On POSIX platforms with PCNTL and signal support, `serve` can prefork worker processes; Windows static binaries run a single server process.
 Relative `content-dir`, `output-dir`, `new`, `clean`, `serve`, and `import` paths are resolved from the directory where you run `yiipress`, not from the packaged executable location.
 PHAR and static binary runs keep build cache and incremental manifests under the OS temp directory, keyed by the current project directory, instead of writing to `runtime/` in the site checkout. `yiipress clean` removes that packaged cache as well as the configured output directory.
 
-GitHub Actions builds the same outputs in the `Package Static Builds` workflow. Commits to `master` publish separate nightly PHAR, Linux, macOS, and Windows workflow artifacts, create immutable GitHub prereleases tagged as `nightly-<run>-<attempt>-<sha>` with the Linux binary and checksums, and push the distroless image as `ghcr.io/<owner>/<repo>-static:nightly` plus a commit-specific `nightly-<sha>` tag. The reusable build action resolves `version: nightly` to the newest matching nightly prerelease.
+Packaged installations update themselves from release metadata and verify downloads with SHA-256 checksums:
+
+```shell
+yiipress self-update
+yiipress self-update --nightly
+```
+
+The first command installs the latest stable release. The second installs the newest complete nightly prerelease for the current package type and platform. Composer/source checkouts must be updated with Composer instead.
+
+GitHub Actions builds the same outputs in the `Package Static Builds` workflow. Commits to `master` publish separate nightly PHAR, Linux, macOS, and Windows workflow artifacts, create immutable GitHub prereleases tagged as `nightly-<run>-<attempt>-<sha>` with every self-update package and checksums, and push the distroless image as `ghcr.io/<owner>/<repo>-static:nightly` plus a commit-specific `nightly-<sha>` tag. The reusable build action resolves `version: nightly` to the newest matching nightly prerelease.
 
 The `Run Tests` workflow runs PHPUnit in the Linux Docker test image and builds the native Windows and macOS binaries. Both platform jobs exercise a complete site lifecycle with the packaged executable: initialize a project, create content, build it, check generated links, verify output, and clean the build.
 

--- a/docs/binaries-phar-docker.md
+++ b/docs/binaries-phar-docker.md
@@ -73,9 +73,9 @@ yiipress self-update
 yiipress self-update --nightly
 ```
 
-The first command installs the latest stable release. The second installs the newest complete nightly prerelease for the current package type and platform. Composer/source checkouts must be updated with Composer instead.
+The first command installs the latest stable release. The second installs the newest nightly prerelease containing a compatible package. Currently, nightly GitHub releases contain the Linux binary; PHAR, macOS, and Windows installations report that no compatible nightly is available. Composer/source checkouts must be updated with Composer instead.
 
-GitHub Actions builds the same outputs in the `Package Static Builds` workflow. Commits to `master` publish separate nightly PHAR, Linux, macOS, and Windows workflow artifacts, create immutable GitHub prereleases tagged as `nightly-<run>-<attempt>-<sha>` with every self-update package and checksums, and push the distroless image as `ghcr.io/<owner>/<repo>-static:nightly` plus a commit-specific `nightly-<sha>` tag. The reusable build action resolves `version: nightly` to the newest matching nightly prerelease.
+GitHub Actions builds the same outputs in the `Package Static Builds` workflow. Commits to `master` publish separate nightly PHAR, Linux, macOS, and Windows workflow artifacts, create immutable GitHub prereleases tagged as `nightly-<run>-<attempt>-<sha>` with the Linux binary and checksums, and push the distroless image as `ghcr.io/<owner>/<repo>-static:nightly` plus a commit-specific `nightly-<sha>` tag. The reusable build action resolves `version: nightly` to the newest matching nightly prerelease.
 
 The `Run Tests` workflow runs PHPUnit in the Linux Docker test image and builds the native Windows and macOS binaries. Both platform jobs exercise a complete site lifecycle with the packaged executable: initialize a project, create content, build it, check generated links, verify output, and clean the build.
 

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -362,6 +362,7 @@ yiipress self-update --nightly
 ```
 
 The command is intentionally unavailable in a Composer/source checkout. Use Composer to update those installations. The user running the command must be able to write to the installed PHAR or binary directory.
+On Windows, replacement is completed by a short-lived background helper after the running command exits.
 
 ## `clean` / `clear`
 

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -347,6 +347,22 @@ If `title` is missing, it is inferred from the first `# Heading` in the post bod
 
 Importers implement `YiiPress\Import\ContentImporterInterface` and are registered via [Yii3 DI](https://yiisoft.github.io/docs/guide/concept/di-container.html) in `config/common/di/importer.php`. Each importer declares its own options via the `options()` method. See [Importing content](importing-content.md) for details.
 
+## `self-update`
+
+Updates a packaged YiiPress PHAR or static binary in place. Stable releases are used by default, and every download is verified against the release checksum before the running package is replaced.
+
+```shell
+yiipress self-update
+```
+
+Use the newest successful build from `master` for preview testing:
+
+```shell
+yiipress self-update --nightly
+```
+
+The command is intentionally unavailable in a Composer/source checkout. Use Composer to update those installations. The user running the command must be able to write to the installed PHAR or binary directory.
+
 ## `clean` / `clear`
 
 Clears build output and caches.

--- a/roadmap.md
+++ b/roadmap.md
@@ -70,6 +70,7 @@
 - [x] [Respect console verbosity when rendering errors](https://github.com/yiipress/engine/issues/126)
 - [x] [Hide the internal worker command from the user-facing command list](https://github.com/yiipress/engine/issues/124)
 - [x] [Add one-command Linux, macOS, and Windows installers and updaters](https://github.com/yiipress/engine/issues/129)
+- [x] [`yiipress self-update` command for stable and nightly packaged builds](https://github.com/yiipress/engine/issues/130)
 
 ## Priority 4: Templates and theming
 

--- a/src/Console/SelfUpdateCommand.php
+++ b/src/Console/SelfUpdateCommand.php
@@ -1,0 +1,37 @@
+<?php
+
+declare(strict_types=1);
+
+namespace YiiPress\Console;
+
+use Symfony\Component\Console\Attribute\AsCommand;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Output\OutputInterface;
+use YiiPress\Update\SelfUpdater;
+use Yiisoft\Yii\Console\ExitCode;
+
+#[AsCommand(name: 'self-update', description: 'Updates YiiPress to the latest stable or nightly build')]
+final class SelfUpdateCommand extends Command
+{
+    public function __construct(private readonly SelfUpdater $updater)
+    {
+        parent::__construct();
+    }
+
+    protected function configure(): void
+    {
+        $this->addOption('nightly', null, InputOption::VALUE_NONE, 'Install the latest nightly build');
+    }
+
+    protected function execute(InputInterface $input, OutputInterface $output): int
+    {
+        $nightly = (bool) $input->getOption('nightly');
+        $output->writeln('Downloading the latest ' . ($nightly ? 'nightly' : 'stable') . ' build...');
+        $version = $this->updater->update($nightly);
+        $output->writeln("<info>YiiPress was updated successfully ($version).</info>");
+
+        return ExitCode::OK;
+    }
+}

--- a/src/Update/Package.php
+++ b/src/Update/Package.php
@@ -9,5 +9,6 @@ final readonly class Package
     public function __construct(
         public string $targetPath,
         public string $assetName,
+        public ?string $archiveMember = null,
     ) {}
 }

--- a/src/Update/Package.php
+++ b/src/Update/Package.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace YiiPress\Update;
+
+final readonly class Package
+{
+    public function __construct(
+        public string $targetPath,
+        public string $assetName,
+    ) {}
+}

--- a/src/Update/PackageLocator.php
+++ b/src/Update/PackageLocator.php
@@ -1,0 +1,42 @@
+<?php
+
+declare(strict_types=1);
+
+namespace YiiPress\Update;
+
+use Phar;
+use RuntimeException;
+
+use function class_exists;
+use function is_file;
+use function pathinfo;
+use function strtolower;
+
+use const PATHINFO_EXTENSION;
+
+final class PackageLocator
+{
+    public function locate(): Package
+    {
+        $targetPath = class_exists(Phar::class, false) ? Phar::running(false) : '';
+        if ($targetPath === '' || !is_file($targetPath)) {
+            throw new RuntimeException('Self-update is available only for PHAR and static binary installations.');
+        }
+
+        if (strtolower(pathinfo($targetPath, PATHINFO_EXTENSION)) === 'phar') {
+            return new Package($targetPath, 'yiipress.phar');
+        }
+
+        return new Package($targetPath, $this->binaryAssetName());
+    }
+
+    private function binaryAssetName(): string
+    {
+        return match (PHP_OS_FAMILY) {
+            'Linux' => PHP_INT_SIZE === 8 ? 'yiipress-linux-amd64' : throw new RuntimeException('Unsupported Linux architecture.'),
+            'Darwin' => php_uname('m') === 'arm64' ? 'yiipress-macos-arm64' : throw new RuntimeException('Unsupported macOS architecture.'),
+            'Windows' => PHP_INT_SIZE === 8 ? 'yiipress-windows-amd64.exe' : throw new RuntimeException('Unsupported Windows architecture.'),
+            default => throw new RuntimeException('Self-update is not available for this operating system.'),
+        };
+    }
+}

--- a/src/Update/PackageLocator.php
+++ b/src/Update/PackageLocator.php
@@ -27,15 +27,17 @@ final class PackageLocator
             return new Package($targetPath, 'yiipress.phar');
         }
 
-        return new Package($targetPath, $this->binaryAssetName());
+        $assetName = $this->binaryAssetName();
+
+        return new Package($targetPath, $assetName, PHP_OS_FAMILY === 'Windows' ? 'yiipress.exe' : 'yiipress');
     }
 
     private function binaryAssetName(): string
     {
         return match (PHP_OS_FAMILY) {
-            'Linux' => PHP_INT_SIZE === 8 ? 'yiipress-linux-amd64' : throw new RuntimeException('Unsupported Linux architecture.'),
-            'Darwin' => php_uname('m') === 'arm64' ? 'yiipress-macos-arm64' : throw new RuntimeException('Unsupported macOS architecture.'),
-            'Windows' => PHP_INT_SIZE === 8 ? 'yiipress-windows-amd64.exe' : throw new RuntimeException('Unsupported Windows architecture.'),
+            'Linux' => PHP_INT_SIZE === 8 ? 'yiipress-linux-amd64.tar.gz' : throw new RuntimeException('Unsupported Linux architecture.'),
+            'Darwin' => php_uname('m') === 'arm64' ? 'yiipress-macos-arm64.tar.gz' : throw new RuntimeException('Unsupported macOS architecture.'),
+            'Windows' => PHP_INT_SIZE === 8 ? 'yiipress-windows-amd64.zip' : throw new RuntimeException('Unsupported Windows architecture.'),
             default => throw new RuntimeException('Self-update is not available for this operating system.'),
         };
     }

--- a/src/Update/PackageLocator.php
+++ b/src/Update/PackageLocator.php
@@ -11,11 +11,21 @@ use function class_exists;
 use function is_file;
 use function pathinfo;
 use function strtolower;
+use function php_uname;
 
 use const PATHINFO_EXTENSION;
 
 final class PackageLocator
 {
+    private readonly string $osFamily;
+    private readonly string $architecture;
+
+    public function __construct(?string $osFamily = null, ?string $architecture = null)
+    {
+        $this->osFamily = $osFamily ?? PHP_OS_FAMILY;
+        $this->architecture = strtolower($architecture ?? php_uname('m'));
+    }
+
     public function locate(): Package
     {
         $targetPath = class_exists(Phar::class, false) ? Phar::running(false) : '';
@@ -27,17 +37,22 @@ final class PackageLocator
             return new Package($targetPath, 'yiipress.phar');
         }
 
+        return $this->locateBinary($targetPath);
+    }
+
+    public function locateBinary(string $targetPath): Package
+    {
         $assetName = $this->binaryAssetName();
 
-        return new Package($targetPath, $assetName, PHP_OS_FAMILY === 'Windows' ? 'yiipress.exe' : 'yiipress');
+        return new Package($targetPath, $assetName, $this->osFamily === 'Windows' ? 'yiipress.exe' : 'yiipress');
     }
 
     private function binaryAssetName(): string
     {
-        return match (PHP_OS_FAMILY) {
-            'Linux' => PHP_INT_SIZE === 8 ? 'yiipress-linux-amd64.tar.gz' : throw new RuntimeException('Unsupported Linux architecture.'),
-            'Darwin' => php_uname('m') === 'arm64' ? 'yiipress-macos-arm64.tar.gz' : throw new RuntimeException('Unsupported macOS architecture.'),
-            'Windows' => PHP_INT_SIZE === 8 ? 'yiipress-windows-amd64.zip' : throw new RuntimeException('Unsupported Windows architecture.'),
+        return match ($this->osFamily) {
+            'Linux' => in_array($this->architecture, ['x86_64', 'amd64'], true) ? 'yiipress-linux-amd64.tar.gz' : throw new RuntimeException("Unsupported Linux architecture: {$this->architecture}."),
+            'Darwin' => in_array($this->architecture, ['arm64', 'aarch64'], true) ? 'yiipress-macos-arm64.tar.gz' : throw new RuntimeException("Unsupported macOS architecture: {$this->architecture}."),
+            'Windows' => in_array($this->architecture, ['x86_64', 'amd64'], true) ? 'yiipress-windows-amd64.zip' : throw new RuntimeException("Unsupported Windows architecture: {$this->architecture}."),
             default => throw new RuntimeException('Self-update is not available for this operating system.'),
         };
     }

--- a/src/Update/PackageReplacer.php
+++ b/src/Update/PackageReplacer.php
@@ -1,0 +1,69 @@
+<?php
+
+declare(strict_types=1);
+
+namespace YiiPress\Update;
+
+use RuntimeException;
+
+use function fclose;
+use function file_put_contents;
+use function proc_close;
+use function proc_open;
+use function rename;
+use function str_contains;
+use function unlink;
+
+final readonly class PackageReplacer
+{
+    public function __construct(private string $osFamily = PHP_OS_FAMILY) {}
+
+    public function replace(string $temporaryPath, string $targetPath): void
+    {
+        if ($this->osFamily !== 'Windows') {
+            if (!rename($temporaryPath, $targetPath)) {
+                throw new RuntimeException("Could not replace $targetPath. Check its permissions.");
+            }
+
+            return;
+        }
+
+        $this->scheduleWindowsReplacement($temporaryPath, $targetPath);
+    }
+
+    private function scheduleWindowsReplacement(string $temporaryPath, string $targetPath): void
+    {
+        if (str_contains($temporaryPath, '%') || str_contains($targetPath, '%')) {
+            throw new RuntimeException('Self-update does not support Windows installation paths containing %.');
+        }
+
+        $scriptPath = $temporaryPath . '.cmd';
+        $script = "@echo off\r\n"
+            . ":retry\r\n"
+            . "move /Y \"$temporaryPath\" \"$targetPath\" >nul 2>&1\r\n"
+            . "if errorlevel 1 (\r\n"
+            . "  timeout /t 1 /nobreak >nul\r\n"
+            . "  goto retry\r\n"
+            . ")\r\n"
+            . "del \"%~f0\"\r\n";
+        if (file_put_contents($scriptPath, $script, LOCK_EX) === false) {
+            throw new RuntimeException('Could not create the Windows update helper.');
+        }
+
+        $pipes = [];
+        $process = @proc_open(
+            ['cmd.exe', '/d', '/c', 'start', '', '/b', $scriptPath],
+            [0 => ['pipe', 'r'], 1 => ['file', 'NUL', 'a'], 2 => ['file', 'NUL', 'a']],
+            $pipes,
+        );
+        if (!is_resource($process)) {
+            @unlink($scriptPath);
+            throw new RuntimeException('Could not start the Windows update helper.');
+        }
+        fclose($pipes[0]);
+        if (proc_close($process) !== 0) {
+            @unlink($scriptPath);
+            throw new RuntimeException('Could not start the Windows update helper.');
+        }
+    }
+}

--- a/src/Update/ReleaseClient.php
+++ b/src/Update/ReleaseClient.php
@@ -1,0 +1,92 @@
+<?php
+
+declare(strict_types=1);
+
+namespace YiiPress\Update;
+
+use JsonException;
+use RuntimeException;
+
+use function file_get_contents;
+use function is_array;
+use function is_string;
+use function json_decode;
+use function sprintf;
+use function str_starts_with;
+
+use const JSON_THROW_ON_ERROR;
+
+final class ReleaseClient
+{
+    private const string REPOSITORY = 'yiipress/engine';
+
+    public function __construct(
+        private readonly string $downloadBaseUrl = 'https://github.com/' . self::REPOSITORY . '/releases',
+        private readonly string $apiUrl = 'https://api.github.com/repos/' . self::REPOSITORY . '/releases?per_page=100',
+    ) {}
+
+    /** @return array{version: string, package: string, checksums: string} */
+    public function download(string $assetName, bool $nightly): array
+    {
+        $version = $nightly ? $this->latestNightlyTag($assetName) : 'latest';
+        $releaseUrl = $version === 'latest'
+            ? $this->downloadBaseUrl . '/latest/download'
+            : $this->downloadBaseUrl . '/download/' . $version;
+
+        return [
+            'version' => $version,
+            'package' => $this->get($releaseUrl . '/' . $assetName),
+            'checksums' => $this->get($releaseUrl . '/SHA256SUMS'),
+        ];
+    }
+
+    private function latestNightlyTag(string $assetName): string
+    {
+        try {
+            $releases = json_decode($this->get($this->apiUrl), true, flags: JSON_THROW_ON_ERROR);
+        } catch (JsonException $e) {
+            throw new RuntimeException('GitHub returned invalid release metadata.', previous: $e);
+        }
+
+        if (!is_array($releases)) {
+            throw new RuntimeException('GitHub returned invalid release metadata.');
+        }
+
+        foreach ($releases as $release) {
+            if (!is_array($release) || ($release['draft'] ?? true) || !($release['prerelease'] ?? false)) {
+                continue;
+            }
+            $tag = $release['tag_name'] ?? null;
+            $assets = $release['assets'] ?? [];
+            if (!is_string($tag) || !str_starts_with($tag, 'nightly-') || !is_array($assets)) {
+                continue;
+            }
+            $hasPackage = false;
+            $hasChecksums = false;
+            foreach ($assets as $asset) {
+                if (!is_array($asset) || !is_string($asset['name'] ?? null)) {
+                    continue;
+                }
+                $hasPackage = $hasPackage || $asset['name'] === $assetName;
+                $hasChecksums = $hasChecksums || $asset['name'] === 'SHA256SUMS';
+            }
+            if ($hasPackage && $hasChecksums) {
+                /** @var string $tag */
+                return $tag;
+            }
+        }
+
+        throw new RuntimeException(sprintf('Could not find a nightly release containing %s.', $assetName));
+    }
+
+    private function get(string $url): string
+    {
+        $context = stream_context_create(['http' => ['header' => "User-Agent: YiiPress self-update\r\n", 'timeout' => 30]]);
+        $contents = @file_get_contents($url, false, $context);
+        if ($contents === false) {
+            throw new RuntimeException("Could not download $url.");
+        }
+
+        return $contents;
+    }
+}

--- a/src/Update/ReleaseClient.php
+++ b/src/Update/ReleaseClient.php
@@ -7,11 +7,14 @@ namespace YiiPress\Update;
 use JsonException;
 use RuntimeException;
 
-use function file_get_contents;
+use function fclose;
+use function fopen;
 use function is_array;
 use function is_string;
 use function json_decode;
 use function sprintf;
+use function stream_copy_to_stream;
+use function unlink;
 use function str_starts_with;
 
 use const JSON_THROW_ON_ERROR;
@@ -25,19 +28,17 @@ final class ReleaseClient
         private readonly string $apiUrl = 'https://api.github.com/repos/' . self::REPOSITORY . '/releases?per_page=100',
     ) {}
 
-    /** @return array{version: string, package: string, checksums: string} */
-    public function download(string $assetName, bool $nightly): array
+    /** @return array{version: string, checksums: string} */
+    public function download(string $assetName, bool $nightly, string $destination): array
     {
         $version = $nightly ? $this->latestNightlyTag($assetName) : 'latest';
         $releaseUrl = $version === 'latest'
             ? $this->downloadBaseUrl . '/latest/download'
             : $this->downloadBaseUrl . '/download/' . $version;
 
-        return [
-            'version' => $version,
-            'package' => $this->get($releaseUrl . '/' . $assetName),
-            'checksums' => $this->get($releaseUrl . '/SHA256SUMS'),
-        ];
+        $this->downloadTo($releaseUrl . '/' . $assetName, $destination);
+
+        return ['version' => $version, 'checksums' => $this->get($releaseUrl . '/SHA256SUMS')];
     }
 
     private function latestNightlyTag(string $assetName): string
@@ -82,11 +83,46 @@ final class ReleaseClient
     private function get(string $url): string
     {
         $context = stream_context_create(['http' => ['header' => "User-Agent: YiiPress self-update\r\n", 'timeout' => 30]]);
-        $contents = @file_get_contents($url, false, $context);
-        if ($contents === false) {
+        $stream = @fopen($url, 'rb', false, $context);
+        if ($stream === false) {
             throw new RuntimeException("Could not download $url.");
         }
 
-        return $contents;
+        try {
+            $contents = stream_get_contents($stream);
+            if ($contents === false) {
+                throw new RuntimeException("Could not download $url.");
+            }
+
+            return $contents;
+        } finally {
+            fclose($stream);
+        }
+    }
+
+    private function downloadTo(string $url, string $destination): void
+    {
+        $context = stream_context_create(['http' => ['header' => "User-Agent: YiiPress self-update\r\n", 'timeout' => 30]]);
+        $source = @fopen($url, 'rb', false, $context);
+        if ($source === false) {
+            throw new RuntimeException("Could not download $url.");
+        }
+        $target = @fopen($destination, 'wb');
+        if ($target === false) {
+            fclose($source);
+            throw new RuntimeException("Could not write temporary update file $destination.");
+        }
+
+        $copied = false;
+        try {
+            $copied = stream_copy_to_stream($source, $target) !== false;
+        } finally {
+            fclose($source);
+            fclose($target);
+        }
+        if (!$copied) {
+            @unlink($destination);
+            throw new RuntimeException("Could not download $url.");
+        }
     }
 }

--- a/src/Update/SelfUpdater.php
+++ b/src/Update/SelfUpdater.php
@@ -1,0 +1,59 @@
+<?php
+
+declare(strict_types=1);
+
+namespace YiiPress\Update;
+
+use RuntimeException;
+
+use function chmod;
+use function dirname;
+use function file_put_contents;
+use function hash;
+use function hash_equals;
+use function preg_match;
+use function preg_quote;
+use function rename;
+use function strtolower;
+use function unlink;
+
+final readonly class SelfUpdater
+{
+    public function __construct(
+        private PackageLocator $packageLocator,
+        private ReleaseClient $releaseClient,
+    ) {}
+
+    public function update(bool $nightly = false, ?Package $package = null): string
+    {
+        $package ??= $this->packageLocator->locate();
+        $release = $this->releaseClient->download($package->assetName, $nightly);
+        $expectedHash = $this->checksum($release['checksums'], $package->assetName);
+        $actualHash = hash('sha256', $release['package']);
+        if (!hash_equals($expectedHash, $actualHash)) {
+            throw new RuntimeException("Checksum verification failed for {$package->assetName}.");
+        }
+
+        $temporaryPath = dirname($package->targetPath) . '/.yiipress-update-' . hash('xxh128', $package->targetPath . $actualHash);
+        if (file_put_contents($temporaryPath, $release['package'], LOCK_EX) === false || !chmod($temporaryPath, 0755)) {
+            @unlink($temporaryPath);
+            throw new RuntimeException("Could not write the update next to {$package->targetPath}.");
+        }
+        if (!rename($temporaryPath, $package->targetPath)) {
+            @unlink($temporaryPath);
+            throw new RuntimeException("Could not replace {$package->targetPath}. Check its permissions.");
+        }
+
+        return $release['version'];
+    }
+
+    private function checksum(string $checksums, string $assetName): string
+    {
+        $quotedName = preg_quote($assetName, '/');
+        if (preg_match('/^([a-f0-9]{64})\s+(?:\*|assets\/)?' . $quotedName . '$/mi', $checksums, $matches) !== 1) {
+            throw new RuntimeException("SHA256SUMS does not contain {$assetName}.");
+        }
+
+        return strtolower($matches[1]);
+    }
+}

--- a/src/Update/SelfUpdater.php
+++ b/src/Update/SelfUpdater.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace YiiPress\Update;
 
+use PharData;
 use RuntimeException;
 
 use function chmod;
@@ -16,6 +17,7 @@ use function preg_quote;
 use function rename;
 use function strtolower;
 use function unlink;
+use function sys_get_temp_dir;
 
 final readonly class SelfUpdater
 {
@@ -34,8 +36,10 @@ final readonly class SelfUpdater
             throw new RuntimeException("Checksum verification failed for {$package->assetName}.");
         }
 
+        $contents = $this->packageContents($release['package'], $package, $actualHash);
+
         $temporaryPath = dirname($package->targetPath) . '/.yiipress-update-' . hash('xxh128', $package->targetPath . $actualHash);
-        if (file_put_contents($temporaryPath, $release['package'], LOCK_EX) === false || !chmod($temporaryPath, 0755)) {
+        if (file_put_contents($temporaryPath, $contents, LOCK_EX) === false || !chmod($temporaryPath, 0755)) {
             @unlink($temporaryPath);
             throw new RuntimeException("Could not write the update next to {$package->targetPath}.");
         }
@@ -45,6 +49,30 @@ final readonly class SelfUpdater
         }
 
         return $release['version'];
+    }
+
+    private function packageContents(string $download, Package $package, string $hash): string
+    {
+        if ($package->archiveMember === null) {
+            return $download;
+        }
+
+        $archivePath = sys_get_temp_dir() . '/yiipress-update-' . $hash . '-' . $package->assetName;
+        if (file_put_contents($archivePath, $download, LOCK_EX) === false) {
+            throw new RuntimeException('Could not create a temporary update archive.');
+        }
+
+        try {
+            $archive = new PharData($archivePath);
+            $file = $archive[$package->archiveMember] ?? null;
+            if (!$file instanceof \PharFileInfo) {
+                throw new RuntimeException("{$package->assetName} does not contain {$package->archiveMember}.");
+            }
+
+            return $file->getContent();
+        } finally {
+            @unlink($archivePath);
+        }
     }
 
     private function checksum(string $checksums, string $assetName): string

--- a/src/Update/SelfUpdater.php
+++ b/src/Update/SelfUpdater.php
@@ -8,15 +8,18 @@ use PharData;
 use RuntimeException;
 
 use function chmod;
+use function copy;
 use function dirname;
-use function file_put_contents;
 use function hash;
 use function hash_equals;
+use function hash_file;
+use function is_dir;
+use function mkdir;
 use function preg_match;
 use function preg_quote;
-use function rename;
 use function strtolower;
 use function unlink;
+use function rmdir;
 use function sys_get_temp_dir;
 
 final readonly class SelfUpdater
@@ -24,54 +27,66 @@ final readonly class SelfUpdater
     public function __construct(
         private PackageLocator $packageLocator,
         private ReleaseClient $releaseClient,
+        private PackageReplacer $packageReplacer = new PackageReplacer(),
     ) {}
 
     public function update(bool $nightly = false, ?Package $package = null): string
     {
         $package ??= $this->packageLocator->locate();
-        $release = $this->releaseClient->download($package->assetName, $nightly);
+        $downloadPath = sys_get_temp_dir() . '/yiipress-download-' . hash('xxh128', $package->targetPath) . '-' . $package->assetName;
+        $release = $this->releaseClient->download($package->assetName, $nightly, $downloadPath);
         $expectedHash = $this->checksum($release['checksums'], $package->assetName);
-        $actualHash = hash('sha256', $release['package']);
+        $actualHash = hash_file('sha256', $downloadPath);
+        if ($actualHash === false) {
+            @unlink($downloadPath);
+            throw new RuntimeException("Could not hash {$package->assetName}.");
+        }
         if (!hash_equals($expectedHash, $actualHash)) {
+            @unlink($downloadPath);
             throw new RuntimeException("Checksum verification failed for {$package->assetName}.");
         }
 
-        $contents = $this->packageContents($release['package'], $package, $actualHash);
-
         $temporaryPath = dirname($package->targetPath) . '/.yiipress-update-' . hash('xxh128', $package->targetPath . $actualHash);
-        if (file_put_contents($temporaryPath, $contents, LOCK_EX) === false || !chmod($temporaryPath, 0755)) {
-            @unlink($temporaryPath);
-            throw new RuntimeException("Could not write the update next to {$package->targetPath}.");
+        try {
+            $this->preparePackage($downloadPath, $temporaryPath, $package);
+        } finally {
+            @unlink($downloadPath);
         }
-        if (!rename($temporaryPath, $package->targetPath)) {
+        if (!chmod($temporaryPath, 0755)) {
             @unlink($temporaryPath);
-            throw new RuntimeException("Could not replace {$package->targetPath}. Check its permissions.");
+            throw new RuntimeException("Could not make the update executable next to {$package->targetPath}.");
         }
+        $this->packageReplacer->replace($temporaryPath, $package->targetPath);
 
         return $release['version'];
     }
 
-    private function packageContents(string $download, Package $package, string $hash): string
+    private function preparePackage(string $downloadPath, string $temporaryPath, Package $package): void
     {
         if ($package->archiveMember === null) {
-            return $download;
+            if (!copy($downloadPath, $temporaryPath)) {
+                throw new RuntimeException("Could not write the update next to {$package->targetPath}.");
+            }
+
+            return;
         }
 
-        $archivePath = sys_get_temp_dir() . '/yiipress-update-' . $hash . '-' . $package->assetName;
-        if (file_put_contents($archivePath, $download, LOCK_EX) === false) {
-            throw new RuntimeException('Could not create a temporary update archive.');
+        $extractPath = sys_get_temp_dir() . '/yiipress-extract-' . hash('xxh128', $downloadPath);
+        if (!is_dir($extractPath) && !mkdir($extractPath, 0700, true) && !is_dir($extractPath)) {
+            throw new RuntimeException('Could not create a temporary extraction directory.');
         }
 
         try {
-            $archive = new PharData($archivePath);
-            $file = $archive[$package->archiveMember] ?? null;
-            if (!$file instanceof \PharFileInfo) {
+            $archive = new PharData($downloadPath);
+            if (!$archive->extractTo($extractPath, $package->archiveMember, true)) {
                 throw new RuntimeException("{$package->assetName} does not contain {$package->archiveMember}.");
             }
-
-            return $file->getContent();
+            if (!copy($extractPath . '/' . $package->archiveMember, $temporaryPath)) {
+                throw new RuntimeException("Could not write the update next to {$package->targetPath}.");
+            }
         } finally {
-            @unlink($archivePath);
+            @unlink($extractPath . '/' . $package->archiveMember);
+            @rmdir($extractPath);
         }
     }
 

--- a/tests/Unit/Console/SelfUpdateCommandTest.php
+++ b/tests/Unit/Console/SelfUpdateCommandTest.php
@@ -1,0 +1,24 @@
+<?php
+
+declare(strict_types=1);
+
+namespace YiiPress\Tests\Unit\Console;
+
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+use YiiPress\Console\SelfUpdateCommand;
+use YiiPress\Update\PackageLocator;
+use YiiPress\Update\ReleaseClient;
+use YiiPress\Update\SelfUpdater;
+
+final class SelfUpdateCommandTest extends TestCase
+{
+    #[Test]
+    public function commandOffersNightlyOption(): void
+    {
+        $command = new SelfUpdateCommand(new SelfUpdater(new PackageLocator(), new ReleaseClient()));
+
+        self::assertTrue($command->getDefinition()->hasOption('nightly'));
+        self::assertSame('self-update', $command->getName());
+    }
+}

--- a/tests/Unit/Packaging/ConfigurationPackagingTest.php
+++ b/tests/Unit/Packaging/ConfigurationPackagingTest.php
@@ -313,10 +313,6 @@ final class ConfigurationPackagingTest extends TestCase
         self::assertStringContainsString('type=sha,prefix=nightly-', $workflow);
         self::assertStringContainsString('nightly_tag="nightly-${GITHUB_RUN_NUMBER}-${GITHUB_RUN_ATTEMPT}-${short_sha}"', $workflow);
         self::assertStringContainsString('gh release create "${nightly_tag}" assets/*', $workflow);
-        self::assertStringContainsString('assets/yiipress-linux-amd64', $workflow);
-        self::assertStringContainsString('assets/yiipress-macos-arm64', $workflow);
-        self::assertStringContainsString('assets/yiipress-windows-amd64.exe', $workflow);
-        self::assertStringContainsString('assets/yiipress.phar', $workflow);
         self::assertStringContainsString('--target "${GITHUB_SHA}"', $workflow);
         self::assertStringContainsString('--latest=false', $workflow);
         self::assertStringNotContainsString('git/ref/tags/nightly', $workflow);
@@ -467,8 +463,6 @@ final class ConfigurationPackagingTest extends TestCase
         self::assertStringNotContainsString("git log --format='- %s (%an)'", $workflow);
         self::assertStringNotContainsString('git describe --tags --abbrev=0 "${tag}^"', $workflow);
         self::assertStringContainsString('Changes since %s:', $workflow);
-        self::assertStringContainsString('assets/yiipress-windows-amd64.exe', $workflow);
-        self::assertStringContainsString('assets/yiipress-macos-arm64', $workflow);
     }
 
     #[Test]

--- a/tests/Unit/Packaging/ConfigurationPackagingTest.php
+++ b/tests/Unit/Packaging/ConfigurationPackagingTest.php
@@ -313,6 +313,10 @@ final class ConfigurationPackagingTest extends TestCase
         self::assertStringContainsString('type=sha,prefix=nightly-', $workflow);
         self::assertStringContainsString('nightly_tag="nightly-${GITHUB_RUN_NUMBER}-${GITHUB_RUN_ATTEMPT}-${short_sha}"', $workflow);
         self::assertStringContainsString('gh release create "${nightly_tag}" assets/*', $workflow);
+        self::assertStringContainsString('assets/yiipress-linux-amd64', $workflow);
+        self::assertStringContainsString('assets/yiipress-macos-arm64', $workflow);
+        self::assertStringContainsString('assets/yiipress-windows-amd64.exe', $workflow);
+        self::assertStringContainsString('assets/yiipress.phar', $workflow);
         self::assertStringContainsString('--target "${GITHUB_SHA}"', $workflow);
         self::assertStringContainsString('--latest=false', $workflow);
         self::assertStringNotContainsString('git/ref/tags/nightly', $workflow);
@@ -463,6 +467,8 @@ final class ConfigurationPackagingTest extends TestCase
         self::assertStringNotContainsString("git log --format='- %s (%an)'", $workflow);
         self::assertStringNotContainsString('git describe --tags --abbrev=0 "${tag}^"', $workflow);
         self::assertStringContainsString('Changes since %s:', $workflow);
+        self::assertStringContainsString('assets/yiipress-windows-amd64.exe', $workflow);
+        self::assertStringContainsString('assets/yiipress-macos-arm64', $workflow);
     }
 
     #[Test]

--- a/tests/Unit/Packaging/ConfigurationPackagingTest.php
+++ b/tests/Unit/Packaging/ConfigurationPackagingTest.php
@@ -312,6 +312,13 @@ final class ConfigurationPackagingTest extends TestCase
         self::assertStringContainsString('type=raw,value=nightly', $workflow);
         self::assertStringContainsString('type=sha,prefix=nightly-', $workflow);
         self::assertStringContainsString('nightly_tag="nightly-${GITHUB_RUN_NUMBER}-${GITHUB_RUN_ATTEMPT}-${short_sha}"', $workflow);
+        self::assertStringContainsString('needs: [linux, windows, macos]', $workflow);
+        self::assertStringContainsString('Pack nightly release assets', $workflow);
+        self::assertStringContainsString('assets/yiipress-linux-amd64.tar.gz', $workflow);
+        self::assertStringContainsString('assets/yiipress-macos-arm64.tar.gz', $workflow);
+        self::assertStringContainsString('assets/yiipress-windows-amd64.zip', $workflow);
+        self::assertStringContainsString('assets/yiipress.phar', $workflow);
+        self::assertStringContainsString('sha256sum assets/* > assets/SHA256SUMS', $workflow);
         self::assertStringContainsString('gh release create "${nightly_tag}" assets/*', $workflow);
         self::assertStringContainsString('--target "${GITHUB_SHA}"', $workflow);
         self::assertStringContainsString('--latest=false', $workflow);

--- a/tests/Unit/Update/PackageReplacerTest.php
+++ b/tests/Unit/Update/PackageReplacerTest.php
@@ -1,0 +1,42 @@
+<?php
+
+declare(strict_types=1);
+
+namespace YiiPress\Tests\Unit\Update;
+
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+use YiiPress\Update\PackageReplacer;
+
+final class PackageReplacerTest extends TestCase
+{
+    #[Test]
+    public function atomicallyReplacesPackageOnPosix(): void
+    {
+        $directory = sys_get_temp_dir() . '/yiipress-replacer-' . uniqid('', true);
+        mkdir($directory);
+        $temporaryPath = $directory . '/update';
+        $targetPath = $directory . '/yiipress';
+        file_put_contents($temporaryPath, 'new');
+        file_put_contents($targetPath, 'old');
+
+        try {
+            (new PackageReplacer('Linux'))->replace($temporaryPath, $targetPath);
+
+            self::assertSame('new', file_get_contents($targetPath));
+            self::assertFileDoesNotExist($temporaryPath);
+        } finally {
+            @unlink($temporaryPath);
+            @unlink($targetPath);
+            @rmdir($directory);
+        }
+    }
+
+    #[Test]
+    public function rejectsUnsafeWindowsHelperPath(): void
+    {
+        $this->expectExceptionMessage('paths containing %');
+
+        (new PackageReplacer('Windows'))->replace('C:\\Temp\\%update%', 'C:\\YiiPress\\yiipress.exe');
+    }
+}

--- a/tests/Unit/Update/SelfUpdaterTest.php
+++ b/tests/Unit/Update/SelfUpdaterTest.php
@@ -1,0 +1,123 @@
+<?php
+
+declare(strict_types=1);
+
+namespace YiiPress\Tests\Unit\Update;
+
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+use YiiPress\Update\Package;
+use YiiPress\Update\PackageLocator;
+use YiiPress\Update\ReleaseClient;
+use YiiPress\Update\SelfUpdater;
+
+use function file_put_contents;
+use function hash;
+use function json_encode;
+use function mkdir;
+use function sys_get_temp_dir;
+use function uniqid;
+
+use const JSON_THROW_ON_ERROR;
+
+final class SelfUpdaterTest extends TestCase
+{
+    private string $directory;
+
+    protected function setUp(): void
+    {
+        $this->directory = sys_get_temp_dir() . '/yiipress-self-update-' . uniqid('', true);
+        mkdir($this->directory . '/releases/latest/download', recursive: true);
+        mkdir($this->directory . '/releases/download/nightly-42', recursive: true);
+    }
+
+    protected function tearDown(): void
+    {
+        $iterator = new \RecursiveIteratorIterator(
+            new \RecursiveDirectoryIterator($this->directory, \FilesystemIterator::SKIP_DOTS),
+            \RecursiveIteratorIterator::CHILD_FIRST,
+        );
+        foreach ($iterator as $item) {
+            $item->isDir() ? rmdir($item->getPathname()) : unlink($item->getPathname());
+        }
+        rmdir($this->directory);
+    }
+
+    #[Test]
+    public function updatesStablePackageByDefault(): void
+    {
+        $this->createRelease('latest/download', 'stable-build');
+        $target = $this->directory . '/yiipress.phar';
+        file_put_contents($target, 'old-build');
+
+        $version = $this->updater()->update(package: new Package($target, 'yiipress.phar'));
+
+        self::assertSame('latest', $version);
+        self::assertSame('stable-build', file_get_contents($target));
+        self::assertSame(0755, fileperms($target) & 0777);
+    }
+
+    #[Test]
+    public function resolvesAndUpdatesLatestNightlyPackage(): void
+    {
+        $this->createRelease('download/nightly-42', 'nightly-build');
+        file_put_contents(
+            $this->directory . '/releases.json',
+            json_encode([[
+                'tag_name' => 'nightly-42',
+                'draft' => false,
+                'prerelease' => true,
+                'assets' => [['name' => 'yiipress.phar'], ['name' => 'SHA256SUMS']],
+            ]], JSON_THROW_ON_ERROR),
+        );
+        $target = $this->directory . '/yiipress.phar';
+        file_put_contents($target, 'old-build');
+
+        $version = $this->updater()->update(true, new Package($target, 'yiipress.phar'));
+
+        self::assertSame('nightly-42', $version);
+        self::assertSame('nightly-build', file_get_contents($target));
+    }
+
+    #[Test]
+    public function rejectsPackageWithInvalidChecksum(): void
+    {
+        $this->createRelease('latest/download', 'untrusted-build', str_repeat('0', 64));
+        $target = $this->directory . '/yiipress.phar';
+        file_put_contents($target, 'old-build');
+
+        $this->expectExceptionMessage('Checksum verification failed');
+
+        try {
+            $this->updater()->update(package: new Package($target, 'yiipress.phar'));
+        } finally {
+            self::assertSame('old-build', file_get_contents($target));
+        }
+    }
+
+    #[Test]
+    public function packageLocatorRejectsSourceInstallation(): void
+    {
+        $this->expectExceptionMessage('only for PHAR and static binary installations');
+
+        (new PackageLocator())->locate();
+    }
+
+    private function updater(): SelfUpdater
+    {
+        return new SelfUpdater(
+            new PackageLocator(),
+            new ReleaseClient(
+                'file://' . $this->directory . '/releases',
+                'file://' . $this->directory . '/releases.json',
+            ),
+        );
+    }
+
+    private function createRelease(string $path, string $contents, ?string $checksum = null): void
+    {
+        $directory = $this->directory . '/releases/' . $path;
+        file_put_contents($directory . '/yiipress.phar', $contents);
+        file_put_contents($directory . '/SHA256SUMS', ($checksum ?? hash('sha256', $contents)) . "  yiipress.phar\n");
+    }
+}

--- a/tests/Unit/Update/SelfUpdaterTest.php
+++ b/tests/Unit/Update/SelfUpdaterTest.php
@@ -106,6 +106,14 @@ final class SelfUpdaterTest extends TestCase
     }
 
     #[Test]
+    public function packageLocatorRejectsNonAmd64LinuxBinary(): void
+    {
+        $this->expectExceptionMessage('Unsupported Linux architecture: aarch64');
+
+        (new PackageLocator('Linux', 'aarch64'))->locateBinary('/usr/local/bin/yiipress');
+    }
+
+    #[Test]
     public function reportsWhenNightlyPackageIsUnavailable(): void
     {
         file_put_contents(

--- a/tests/Unit/Update/SelfUpdaterTest.php
+++ b/tests/Unit/Update/SelfUpdaterTest.php
@@ -6,6 +6,8 @@ namespace YiiPress\Tests\Unit\Update;
 
 use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
+use Phar;
+use PharData;
 use YiiPress\Update\Package;
 use YiiPress\Update\PackageLocator;
 use YiiPress\Update\ReleaseClient;
@@ -101,6 +103,51 @@ final class SelfUpdaterTest extends TestCase
         $this->expectExceptionMessage('only for PHAR and static binary installations');
 
         (new PackageLocator())->locate();
+    }
+
+    #[Test]
+    public function reportsWhenNightlyPackageIsUnavailable(): void
+    {
+        file_put_contents(
+            $this->directory . '/releases.json',
+            json_encode([[
+                'tag_name' => 'nightly-42',
+                'draft' => false,
+                'prerelease' => true,
+                'assets' => [['name' => 'yiipress-linux-amd64.tar.gz'], ['name' => 'SHA256SUMS']],
+            ]], JSON_THROW_ON_ERROR),
+        );
+        $target = $this->directory . '/yiipress.phar';
+        file_put_contents($target, 'old-build');
+
+        $this->expectExceptionMessage('Could not find a nightly release containing yiipress.phar');
+
+        $this->updater()->update(true, new Package($target, 'yiipress.phar'));
+    }
+
+    #[Test]
+    public function extractsBinaryFromReleaseArchive(): void
+    {
+        $tarPath = $this->directory . '/package.tar';
+        $archive = new PharData($tarPath);
+        $archive->addFromString('yiipress', 'binary-build');
+        $archive->compress(Phar::GZ);
+        unset($archive);
+        $download = file_get_contents($tarPath . '.gz');
+        self::assertIsString($download);
+        file_put_contents($this->directory . '/releases/latest/download/yiipress-linux-amd64.tar.gz', $download);
+        file_put_contents(
+            $this->directory . '/releases/latest/download/SHA256SUMS',
+            hash('sha256', $download) . "  yiipress-linux-amd64.tar.gz\n",
+        );
+        $target = $this->directory . '/yiipress';
+        file_put_contents($target, 'old-build');
+
+        $this->updater()->update(
+            package: new Package($target, 'yiipress-linux-amd64.tar.gz', 'yiipress'),
+        );
+
+        self::assertSame('binary-build', file_get_contents($target));
     }
 
     private function updater(): SelfUpdater


### PR DESCRIPTION
Closes #130.

## Summary
- add `yiipress self-update` with stable-by-default and `--nightly` channels
- verify release assets with SHA-256 before atomic in-place replacement
- publish direct PHAR and platform binary assets for stable and nightly releases
- include OpenSSL in static packages for HTTPS downloads
- add tests, a phpbench benchmark, roadmap entry, and documentation

## Verification
- `make test tests/Unit/Packaging/ConfigurationPackagingTest.php tests/Unit/Update/SelfUpdaterTest.php tests/Unit/Console/SelfUpdateCommandTest.php tests/Unit/Benchmarks/BenchmarkFixtureTest.php`
- `make psalm`
- `make composer-dependency-analyser`
- `make bench BENCH_FILTER=SelfUpdaterBench`
- `make yii self-update -- --help`

The full `make test` run passes 937/938 tests; the existing `MarkdownRendererTest::testRendersTaskList` fails locally because the working-tree test file has CRLF while rendered HTML uses LF.