### PR TITLE
Support nightly binary installation

### DIFF
--- a/docs/binaries-phar-docker.md
+++ b/docs/binaries-phar-docker.md
@@ -22,7 +22,11 @@ release, set environment variables before invoking the installer. For example, w
 ```shell
 curl -fsSL https://raw.githubusercontent.com/yiipress/engine/master/install.sh | YIIPRESS_INSTALL_DIR="$HOME/.local/bin" sh
 curl -fsSL https://raw.githubusercontent.com/yiipress/engine/master/install.sh | YIIPRESS_VERSION=X.Y.Z sh
+curl -fsSL https://raw.githubusercontent.com/yiipress/engine/master/install.sh | YIIPRESS_VERSION=nightly sh
 ```
+
+`YIIPRESS_VERSION=nightly` resolves the newest immutable nightly prerelease through the GitHub releases API. It does not require
+`jq` or GitHub CLI. Nightly builds contain unreleased changes and are intended for preview and testing.
 
 YiiPress can be packaged as reproducible artifacts:
 

--- a/install.sh
+++ b/install.sh
@@ -54,10 +54,30 @@ work_dir="$(mktemp -d)"
 trap 'rm -rf "$work_dir"' EXIT HUP INT TERM
 
 if [ "$version" = "nightly" ]; then
-    curl -fsSL --retry 3 --retry-delay 2 \
-        "https://api.github.com/repos/${repository}/releases?per_page=100" \
-        -o "${work_dir}/releases.json"
-    version="$(awk -F '"' '$2 == "tag_name" && $4 ~ /^nightly-[0-9]+-[0-9]+-[0-9a-f]+$/ { print $4; exit }' "${work_dir}/releases.json")"
+    version=""
+    page=1
+    while [ -z "$version" ]; do
+        curl -fsSL --retry 3 --retry-delay 2 \
+            "https://api.github.com/repos/${repository}/releases?per_page=100&page=${page}" \
+            -o "${work_dir}/releases.json"
+        version="$(awk -F '"' '
+            {
+                for (field = 2; field + 2 <= NF; field += 2) {
+                    if ($field == "tag_name" && $(field + 2) ~ /^nightly-[0-9]+-[0-9]+-[0-9a-f]+$/) {
+                        print $(field + 2)
+                        exit
+                    }
+                }
+            }
+        ' "${work_dir}/releases.json")"
+        if [ -n "$version" ]; then
+            break
+        fi
+        if awk '{ content = content $0 } END { gsub(/[[:space:]]/, "", content); exit content == "[]" ? 0 : 1 }' "${work_dir}/releases.json"; then
+            break
+        fi
+        page=$((page + 1))
+    done
     if [ -z "$version" ]; then
         echo "Could not find a YiiPress nightly release for ${repository}." >&2
         exit 1

--- a/install.sh
+++ b/install.sh
@@ -50,14 +50,25 @@ if ! command -v "$checksum_command" >/dev/null 2>&1; then
 fi
 
 asset="yiipress-${platform}-${architecture}.tar.gz"
+work_dir="$(mktemp -d)"
+trap 'rm -rf "$work_dir"' EXIT HUP INT TERM
+
+if [ "$version" = "nightly" ]; then
+    curl -fsSL --retry 3 --retry-delay 2 \
+        "https://api.github.com/repos/${repository}/releases?per_page=100" \
+        -o "${work_dir}/releases.json"
+    version="$(awk -F '"' '$2 == "tag_name" && $4 ~ /^nightly-[0-9]+-[0-9]+-[0-9a-f]+$/ { print $4; exit }' "${work_dir}/releases.json")"
+    if [ -z "$version" ]; then
+        echo "Could not find a YiiPress nightly release for ${repository}." >&2
+        exit 1
+    fi
+fi
+
 if [ "$version" = "latest" ]; then
     release_url="https://github.com/${repository}/releases/latest/download"
 else
     release_url="https://github.com/${repository}/releases/download/${version}"
 fi
-
-work_dir="$(mktemp -d)"
-trap 'rm -rf "$work_dir"' EXIT HUP INT TERM
 
 echo "Downloading YiiPress ${version} for ${platform}/${architecture}..."
 curl -fsSL --retry 3 --retry-delay 2 "${release_url}/${asset}" -o "${work_dir}/${asset}"

--- a/roadmap.md
+++ b/roadmap.md
@@ -71,6 +71,7 @@
 - [x] [Hide the internal worker command from the user-facing command list](https://github.com/yiipress/engine/issues/124)
 - [x] [Add one-command Linux, macOS, and Windows installers and updaters](https://github.com/yiipress/engine/issues/129)
 - [x] [`yiipress self-update` command for stable and nightly packaged builds](https://github.com/yiipress/engine/issues/130)
+- [x] Install the newest nightly binary with `YIIPRESS_VERSION=nightly`
 
 ## Priority 4: Templates and theming
 

--- a/tests/Unit/Packaging/InstallerTest.php
+++ b/tests/Unit/Packaging/InstallerTest.php
@@ -53,7 +53,8 @@ while [ "$#" -gt 0 ]; do
     esac
 done
 case "$url" in
-    https://api.github.com/*) cp "${YIIPRESS_TEST_RELEASES}" "$output" ;;
+    https://api.github.com/*page=2) cp "${YIIPRESS_TEST_RELEASES_PAGE_2}" "$output" ;;
+    https://api.github.com/*) cp "${YIIPRESS_TEST_RELEASES_PAGE_1}" "$output" ;;
     *) cp "${YIIPRESS_TEST_RELEASE_DIR}/${url##*/}" "$output" ;;
 esac
 printf '%s\n' "$url" >> "${YIIPRESS_TEST_CURL_LOG}"
@@ -77,8 +78,12 @@ SH);
         chmod($this->root . '/bin/sudo', 0755);
 
         file_put_contents(
-            $this->root . '/releases.json',
-            "[{\"tag_name\":\"nightly-42-1-abcdef123456\",\"prerelease\":true}]\n",
+            $this->root . '/releases-page-1.json',
+            "[{\"prerelease\":false,\"tag_name\":\"1.2.3\"}]\n",
+        );
+        file_put_contents(
+            $this->root . '/releases-page-2.json',
+            "[{\"prerelease\":true,\"draft\":false,\"tag_name\":\"nightly-42-1-abcdef123456\"}]\n",
         );
     }
 
@@ -177,7 +182,8 @@ SH);
         self::assertSame('nightly-version', file_get_contents($this->root . '/install/yiipress'));
         $curlLog = file_get_contents($this->root . '/curl.log');
         self::assertIsString($curlLog);
-        self::assertStringContainsString('/repos/test/engine/releases?per_page=100', $curlLog);
+        self::assertStringContainsString('/repos/test/engine/releases?per_page=100&page=1', $curlLog);
+        self::assertStringContainsString('/repos/test/engine/releases?per_page=100&page=2', $curlLog);
         self::assertStringContainsString(
             '/releases/download/nightly-42-1-abcdef123456/yiipress-linux-amd64.tar.gz',
             $curlLog,
@@ -191,7 +197,7 @@ SH);
     #[Test]
     public function reportsWhenANightlyReleaseIsUnavailable(): void
     {
-        file_put_contents($this->root . '/releases.json', "[]\n");
+        file_put_contents($this->root . '/releases-page-1.json', "[]\n");
 
         [$exitCode, $output] = $this->runInstaller(version: 'nightly');
 
@@ -280,7 +286,8 @@ SH);
             'YIIPRESS_INSTALL_DIR' => $installDirectory ?? $this->root . '/install',
             'YIIPRESS_REPOSITORY' => 'test/engine',
             'YIIPRESS_TEST_RELEASE_DIR' => $this->root . '/release',
-            'YIIPRESS_TEST_RELEASES' => $this->root . '/releases.json',
+            'YIIPRESS_TEST_RELEASES_PAGE_1' => $this->root . '/releases-page-1.json',
+            'YIIPRESS_TEST_RELEASES_PAGE_2' => $this->root . '/releases-page-2.json',
             'YIIPRESS_TEST_CURL_LOG' => $this->root . '/curl.log',
             'YIIPRESS_TEST_SYSTEM' => $system,
             'YIIPRESS_TEST_MACHINE' => $machine,

--- a/tests/Unit/Packaging/InstallerTest.php
+++ b/tests/Unit/Packaging/InstallerTest.php
@@ -50,7 +50,10 @@ while [ "$#" -gt 0 ]; do
         *) shift ;;
     esac
 done
-cp "${YIIPRESS_TEST_RELEASE_DIR}/${url##*/}" "$output"
+case "$url" in
+    https://api.github.com/*) cp "${YIIPRESS_TEST_RELEASES}" "$output" ;;
+    *) cp "${YIIPRESS_TEST_RELEASE_DIR}/${url##*/}" "$output" ;;
+esac
 printf '%s\n' "$url" >> "${YIIPRESS_TEST_CURL_LOG}"
 SH);
         file_put_contents($this->root . '/bin/curl', $curl);
@@ -67,6 +70,11 @@ SH);
         $sudo = "#!/bin/sh\nprintf '%s\\n' \"\$*\" >> \"\$YIIPRESS_TEST_SUDO_LOG\"\n";
         file_put_contents($this->root . '/bin/sudo', $sudo);
         chmod($this->root . '/bin/sudo', 0755);
+
+        file_put_contents(
+            $this->root . '/releases.json',
+            "[{\"tag_name\":\"nightly-42-1-abcdef123456\",\"prerelease\":true}]\n",
+        );
     }
 
     protected function tearDown(): void
@@ -144,6 +152,41 @@ SH);
         self::assertIsString($curlLog);
         self::assertStringContainsString('/releases/download/0.1.8/yiipress-linux-amd64.tar.gz', $curlLog);
         self::assertStringNotContainsString('/releases/latest/download', $curlLog);
+    }
+
+    #[Test]
+    public function installsTheNewestNightlyRelease(): void
+    {
+        $this->createRelease('nightly-version');
+
+        [$exitCode, $output] = $this->runInstaller(version: 'nightly');
+
+        self::assertSame(0, $exitCode, $output);
+        self::assertStringContainsString('Downloading YiiPress nightly-42-1-abcdef123456', $output);
+        self::assertSame('nightly-version', file_get_contents($this->root . '/install/yiipress'));
+        $curlLog = file_get_contents($this->root . '/curl.log');
+        self::assertIsString($curlLog);
+        self::assertStringContainsString('/repos/test/engine/releases?per_page=100', $curlLog);
+        self::assertStringContainsString(
+            '/releases/download/nightly-42-1-abcdef123456/yiipress-linux-amd64.tar.gz',
+            $curlLog,
+        );
+        self::assertStringContainsString(
+            '/releases/download/nightly-42-1-abcdef123456/SHA256SUMS',
+            $curlLog,
+        );
+    }
+
+    #[Test]
+    public function reportsWhenANightlyReleaseIsUnavailable(): void
+    {
+        file_put_contents($this->root . '/releases.json', "[]\n");
+
+        [$exitCode, $output] = $this->runInstaller(version: 'nightly');
+
+        self::assertSame(1, $exitCode);
+        self::assertStringContainsString('Could not find a YiiPress nightly release for test/engine.', $output);
+        self::assertFileDoesNotExist($this->root . '/install/yiipress');
     }
 
     #[Test]
@@ -228,6 +271,7 @@ SH);
             'YIIPRESS_INSTALL_DIR' => $installDirectory ?? $this->root . '/install',
             'YIIPRESS_REPOSITORY' => 'test/engine',
             'YIIPRESS_TEST_RELEASE_DIR' => $this->root . '/release',
+            'YIIPRESS_TEST_RELEASES' => $this->root . '/releases.json',
             'YIIPRESS_TEST_CURL_LOG' => $this->root . '/curl.log',
             'YIIPRESS_TEST_SYSTEM' => $system,
             'YIIPRESS_TEST_MACHINE' => $machine,


### PR DESCRIPTION
## Summary

- support `YIIPRESS_VERSION=nightly` in the shell installer
- resolve the newest immutable nightly tag through the GitHub releases API without requiring `jq`
- retain checksum verification and atomic installation for nightly binaries
- document the command and mark the roadmap item complete

## Tests

- `make test tests/Unit/Packaging/InstallerTest.php` — 9 tests, 137 assertions
- `make psalm` — no errors