### PR TITLE
Support immutable nightly binary installation

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,7 +13,6 @@ env:
   REGISTRY: ghcr.io
   IMAGE_NAME: ${{ github.repository }}-static
   COMPOSER_ROOT_VERSION: ${{ github.ref_name }}
-  YIIPRESS_COMMIT: ${{ github.sha }}
 
 jobs:
   linux:
@@ -45,7 +44,6 @@ jobs:
           platforms: linux/amd64
           build-args: |
             COMPOSER_ROOT_VERSION=${{ github.ref_name }}
-            YIIPRESS_COMMIT=${{ github.sha }}
 
       - name: Smoke test Linux binary
         run: test "$(./dist/linux-amd64/yiipress --version)" = "YiiPress ${GITHUB_REF_NAME}"
@@ -164,7 +162,7 @@ jobs:
             release-macos-package-${{ runner.os }}-${{ runner.arch }}-
 
       - name: Build macOS artifact
-        run: make package-macos PACKAGE_MACOS_ARCH=arm64 PACKAGE_MACOS_DIST=dist/macos-arm64 YIIPRESS_COMMIT=${GITHUB_SHA}
+        run: make package-macos PACKAGE_MACOS_ARCH=arm64 PACKAGE_MACOS_DIST=dist/macos-arm64
 
       - name: Smoke test macOS binary
         run: ./dist/macos-arm64/yiipress --version | grep -Fqx "YiiPress ${GITHUB_REF_NAME}"

--- a/docs/binaries-phar-docker.md
+++ b/docs/binaries-phar-docker.md
@@ -22,7 +22,11 @@ release, set environment variables before invoking the installer. For example, w
 ```shell
 curl -fsSL https://raw.githubusercontent.com/yiipress/engine/master/install.sh | YIIPRESS_INSTALL_DIR="$HOME/.local/bin" sh
 curl -fsSL https://raw.githubusercontent.com/yiipress/engine/master/install.sh | YIIPRESS_VERSION=X.Y.Z sh
+curl -fsSL https://raw.githubusercontent.com/yiipress/engine/master/install.sh | YIIPRESS_VERSION=nightly sh
 ```
+
+`YIIPRESS_VERSION=nightly` resolves the newest immutable nightly prerelease through the GitHub releases API. It does not require
+`jq` or GitHub CLI. Nightly builds contain unreleased changes and are intended for preview and testing.
 
 YiiPress can be packaged as reproducible artifacts:
 

--- a/docs/binaries-phar-docker.md
+++ b/docs/binaries-phar-docker.md
@@ -17,7 +17,7 @@ irm https://raw.githubusercontent.com/yiipress/engine/master/install.ps1 | iex
 The installers download the latest release archive and `SHA256SUMS`, verify the archive, and atomically install the executable.
 The shell installer prints the exact resolved release version before downloading its archive.
 The installed binary reports that same release tag with `yiipress --version`.
-Development artifacts report the full commit SHA from which they were built instead of a placeholder version.
+Development and nightly artifacts report the full commit SHA from which they were built, even when cached Composer metadata contains an older stable version.
 The shell installer uses `/usr/local/bin/yiipress`; the PowerShell installer uses the current user's local application directory
 and adds it to the user `PATH`. Re-run the same command to update an existing installation. To use another directory or a fixed
 release, set environment variables before invoking the installer. For example, with the shell installer:

--- a/install.sh
+++ b/install.sh
@@ -56,16 +56,43 @@ trap 'rm -rf "$work_dir"' EXIT HUP INT TERM
 if [ "$version" = "nightly" ]; then
     version=""
     page=1
-    while [ -z "$version" ]; do
+    max_pages=10
+    while [ -z "$version" ] && [ "$page" -le "$max_pages" ]; do
         curl -fsSL --retry 3 --retry-delay 2 \
             "https://api.github.com/repos/${repository}/releases?per_page=100&page=${page}" \
             -o "${work_dir}/releases.json"
-        version="$(awk -F '"' '
+        version="$(awk '
             {
-                for (field = 2; field + 2 <= NF; field += 2) {
-                    if ($field == "tag_name" && $(field + 2) ~ /^nightly-[0-9]+-[0-9]+-[0-9a-f]+$/) {
-                        print $(field + 2)
-                        exit
+                for (position = 1; position <= length($0); position++) {
+                    character = substr($0, position, 1)
+                    if (depth > 0) {
+                        release = release character
+                    }
+                    if (escaped) {
+                        escaped = 0
+                    } else if (in_string && character == "\\") {
+                        escaped = 1
+                    } else if (character == "\"") {
+                        in_string = !in_string
+                    } else if (!in_string && character == "{") {
+                        if (depth == 0) {
+                            release = "{"
+                        }
+                        depth++
+                    } else if (!in_string && character == "}") {
+                        depth--
+                        if (depth == 0) {
+                            if (release ~ /"prerelease"[[:space:]]*:[[:space:]]*true/) {
+                                fields = split(release, values, "\"")
+                                for (field = 2; field + 2 <= fields; field += 2) {
+                                    if (values[field] == "tag_name" && values[field + 2] ~ /^nightly-[0-9]+-[0-9]+-[0-9a-f]+$/) {
+                                        print values[field + 2]
+                                        exit
+                                    }
+                                }
+                            }
+                            release = ""
+                        }
                     }
                 }
             }

--- a/install.sh
+++ b/install.sh
@@ -54,10 +54,30 @@ work_dir="$(mktemp -d)"
 trap 'rm -rf "$work_dir"' EXIT HUP INT TERM
 
 if [ "$version" = "nightly" ]; then
-    curl -fsSL --retry 3 --retry-delay 2 \
-        "https://api.github.com/repos/${repository}/releases?per_page=100" \
-        -o "${work_dir}/releases.json"
-    version="$(awk -F '"' '$2 == "tag_name" && $4 ~ /^nightly-[0-9]+-[0-9]+-[0-9a-f]+$/ { print $4; exit }' "${work_dir}/releases.json")"
+    version=""
+    page=1
+    while [ -z "$version" ]; do
+        curl -fsSL --retry 3 --retry-delay 2 \
+            "https://api.github.com/repos/${repository}/releases?per_page=100&page=${page}" \
+            -o "${work_dir}/releases.json"
+        version="$(awk -F '"' '
+            {
+                for (field = 2; field + 2 <= NF; field += 2) {
+                    if ($field == "tag_name" && $(field + 2) ~ /^nightly-[0-9]+-[0-9]+-[0-9a-f]+$/) {
+                        print $(field + 2)
+                        exit
+                    }
+                }
+            }
+        ' "${work_dir}/releases.json")"
+        if [ -n "$version" ]; then
+            break
+        fi
+        if awk '{ content = content $0 } END { gsub(/[[:space:]]/, "", content); exit content == "[]" ? 0 : 1 }' "${work_dir}/releases.json"; then
+            break
+        fi
+        page=$((page + 1))
+    done
     if [ -z "$version" ]; then
         echo "Could not find a YiiPress nightly release for ${repository}." >&2
         exit 1

--- a/install.sh
+++ b/install.sh
@@ -50,14 +50,25 @@ if ! command -v "$checksum_command" >/dev/null 2>&1; then
 fi
 
 asset="yiipress-${platform}-${architecture}.tar.gz"
+work_dir="$(mktemp -d)"
+trap 'rm -rf "$work_dir"' EXIT HUP INT TERM
+
+if [ "$version" = "nightly" ]; then
+    curl -fsSL --retry 3 --retry-delay 2 \
+        "https://api.github.com/repos/${repository}/releases?per_page=100" \
+        -o "${work_dir}/releases.json"
+    version="$(awk -F '"' '$2 == "tag_name" && $4 ~ /^nightly-[0-9]+-[0-9]+-[0-9a-f]+$/ { print $4; exit }' "${work_dir}/releases.json")"
+    if [ -z "$version" ]; then
+        echo "Could not find a YiiPress nightly release for ${repository}." >&2
+        exit 1
+    fi
+fi
+
 if [ "$version" = "latest" ]; then
     release_url="https://github.com/${repository}/releases/latest/download"
 else
     release_url="https://github.com/${repository}/releases/download/${version}"
 fi
-
-work_dir="$(mktemp -d)"
-trap 'rm -rf "$work_dir"' EXIT HUP INT TERM
 
 echo "Downloading YiiPress ${version} for ${platform}/${architecture}..."
 curl -fsSL --retry 3 --retry-delay 2 "${release_url}/${asset}" -o "${work_dir}/${asset}"

--- a/roadmap.md
+++ b/roadmap.md
@@ -71,6 +71,7 @@
 - [x] [Hide the internal worker command from the user-facing command list](https://github.com/yiipress/engine/issues/124)
 - [x] [Add one-command Linux, macOS, and Windows installers and updaters](https://github.com/yiipress/engine/issues/129)
 - [x] [`yiipress self-update` command for stable and nightly packaged builds](https://github.com/yiipress/engine/issues/130)
+- [x] Install the newest nightly binary with `YIIPRESS_VERSION=nightly`
 
 ## Priority 4: Templates and theming
 

--- a/src/ApplicationInfo.php
+++ b/src/ApplicationInfo.php
@@ -20,10 +20,10 @@ final class ApplicationInfo
         return self::resolveVersion($version, $reference);
     }
 
-    private static function resolveVersion(?string $version, ?string $reference): string
+    private static function resolveVersion(?string $version, ?string $reference, string $commit = self::COMMIT): string
     {
-        if (self::COMMIT !== '') {
-            return self::COMMIT;
+        if ($commit !== '') {
+            return $commit;
         }
 
         if (

--- a/src/ApplicationInfo.php
+++ b/src/ApplicationInfo.php
@@ -22,6 +22,10 @@ final class ApplicationInfo
 
     private static function resolveVersion(?string $version, ?string $reference): string
     {
+        if (self::COMMIT !== '') {
+            return self::COMMIT;
+        }
+
         if (
             $version !== null
             && !str_ends_with($version, '+no-version-set')
@@ -31,6 +35,6 @@ final class ApplicationInfo
             return $version;
         }
 
-        return self::COMMIT !== '' ? self::COMMIT : ($reference ?? self::VERSION);
+        return $reference ?? self::VERSION;
     }
 }

--- a/tests/Unit/ApplicationInfoTest.php
+++ b/tests/Unit/ApplicationInfoTest.php
@@ -39,4 +39,29 @@ final class ApplicationInfoTest extends TestCase
 
         self::assertSame(ApplicationInfo::VERSION, $method->invoke(null, null, null));
     }
+
+    #[Test]
+    public function packagedCommitTakesPrecedenceOverStaleReleaseMetadata(): void
+    {
+        $source = file_get_contents(dirname(__DIR__, 2) . '/src/ApplicationInfo.php');
+        self::assertIsString($source);
+
+        $source = str_replace(
+            "public const string COMMIT = '';",
+            "public const string COMMIT = 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa';",
+            $source,
+            $replacementCount,
+        );
+        self::assertSame(1, $replacementCount);
+
+        $className = 'PackagedApplicationInfo' . bin2hex(random_bytes(8));
+        $source = str_replace('final class ApplicationInfo', "final class {$className}", $source);
+        eval(substr($source, 5));
+
+        $method = new ReflectionMethod("YiiPress\\{$className}", 'resolveVersion');
+        self::assertSame(
+            'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
+            $method->invoke(null, '1.0.0', 'bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb'),
+        );
+    }
 }

--- a/tests/Unit/ApplicationInfoTest.php
+++ b/tests/Unit/ApplicationInfoTest.php
@@ -43,25 +43,15 @@ final class ApplicationInfoTest extends TestCase
     #[Test]
     public function packagedCommitTakesPrecedenceOverStaleReleaseMetadata(): void
     {
-        $source = file_get_contents(dirname(__DIR__, 2) . '/src/ApplicationInfo.php');
-        self::assertIsString($source);
-
-        $source = str_replace(
-            "public const string COMMIT = '';",
-            "public const string COMMIT = 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa';",
-            $source,
-            $replacementCount,
-        );
-        self::assertSame(1, $replacementCount);
-
-        $className = 'PackagedApplicationInfo' . bin2hex(random_bytes(8));
-        $source = str_replace('final class ApplicationInfo', "final class {$className}", $source);
-        eval(substr($source, 5));
-
-        $method = new ReflectionMethod("YiiPress\\{$className}", 'resolveVersion');
+        $method = new ReflectionMethod(ApplicationInfo::class, 'resolveVersion');
         self::assertSame(
             'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
-            $method->invoke(null, '1.0.0', 'bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb'),
+            $method->invoke(
+                null,
+                '1.0.0',
+                'bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb',
+                'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
+            ),
         );
     }
 }

--- a/tests/Unit/Packaging/ConfigurationPackagingTest.php
+++ b/tests/Unit/Packaging/ConfigurationPackagingTest.php
@@ -470,9 +470,8 @@ final class ConfigurationPackagingTest extends TestCase
 
         self::assertStringContainsString("tags:\n      - '*.*.*'", $workflow);
         self::assertStringContainsString('COMPOSER_ROOT_VERSION: ${{ github.ref_name }}', $workflow);
-        self::assertStringContainsString('YIIPRESS_COMMIT: ${{ github.sha }}', $workflow);
         self::assertStringContainsString('COMPOSER_ROOT_VERSION=${{ github.ref_name }}', $workflow);
-        self::assertStringContainsString('YIIPRESS_COMMIT=${{ github.sha }}', $workflow);
+        self::assertStringNotContainsString('YIIPRESS_COMMIT: ${{ github.sha }}', $workflow);
         self::assertStringContainsString(
             'test "$(./dist/linux-amd64/yiipress --version)" = "YiiPress ${GITHUB_REF_NAME}"',
             $workflow,
@@ -486,7 +485,7 @@ final class ConfigurationPackagingTest extends TestCase
             $workflow,
         );
         self::assertStringContainsString(
-            'make package-macos PACKAGE_MACOS_ARCH=arm64 PACKAGE_MACOS_DIST=dist/macos-arm64 YIIPRESS_COMMIT=${GITHUB_SHA}',
+            'make package-macos PACKAGE_MACOS_ARCH=arm64 PACKAGE_MACOS_DIST=dist/macos-arm64',
             $workflow,
         );
         self::assertStringContainsString(

--- a/tests/Unit/Packaging/ConfigurationPackagingTest.php
+++ b/tests/Unit/Packaging/ConfigurationPackagingTest.php
@@ -467,11 +467,12 @@ final class ConfigurationPackagingTest extends TestCase
     {
         $workflow = file_get_contents(dirname(__DIR__, 3) . '/.github/workflows/release.yml');
         self::assertIsString($workflow);
+        $workflow = str_replace("\r\n", "\n", $workflow);
 
         self::assertStringContainsString("tags:\n      - '*.*.*'", $workflow);
         self::assertStringContainsString('COMPOSER_ROOT_VERSION: ${{ github.ref_name }}', $workflow);
         self::assertStringContainsString('COMPOSER_ROOT_VERSION=${{ github.ref_name }}', $workflow);
-        self::assertStringNotContainsString('YIIPRESS_COMMIT: ${{ github.sha }}', $workflow);
+        self::assertStringNotContainsString('YIIPRESS_COMMIT', $workflow);
         self::assertStringContainsString(
             'test "$(./dist/linux-amd64/yiipress --version)" = "YiiPress ${GITHUB_REF_NAME}"',
             $workflow,

--- a/tests/Unit/Packaging/InstallerTest.php
+++ b/tests/Unit/Packaging/InstallerTest.php
@@ -53,7 +53,8 @@ while [ "$#" -gt 0 ]; do
     esac
 done
 case "$url" in
-    https://api.github.com/*) cp "${YIIPRESS_TEST_RELEASES}" "$output" ;;
+    https://api.github.com/*page=2) cp "${YIIPRESS_TEST_RELEASES_PAGE_2}" "$output" ;;
+    https://api.github.com/*) cp "${YIIPRESS_TEST_RELEASES_PAGE_1}" "$output" ;;
     *) cp "${YIIPRESS_TEST_RELEASE_DIR}/${url##*/}" "$output" ;;
 esac
 printf '%s\n' "$url" >> "${YIIPRESS_TEST_CURL_LOG}"
@@ -77,8 +78,12 @@ SH);
         chmod($this->root . '/bin/sudo', 0755);
 
         file_put_contents(
-            $this->root . '/releases.json',
-            "[{\"tag_name\":\"nightly-42-1-abcdef123456\",\"prerelease\":true}]\n",
+            $this->root . '/releases-page-1.json',
+            "[{\"prerelease\":false,\"tag_name\":\"1.2.3\"}]\n",
+        );
+        file_put_contents(
+            $this->root . '/releases-page-2.json',
+            "[{\"prerelease\":true,\"draft\":false,\"tag_name\":\"nightly-42-1-abcdef123456\"}]\n",
         );
     }
 
@@ -177,7 +182,8 @@ SH);
         self::assertSame('nightly-version', file_get_contents($this->root . '/install/yiipress'));
         $curlLog = file_get_contents($this->root . '/curl.log');
         self::assertIsString($curlLog);
-        self::assertStringContainsString('/repos/test/engine/releases?per_page=100', $curlLog);
+        self::assertStringContainsString('/repos/test/engine/releases?per_page=100&page=1', $curlLog);
+        self::assertStringContainsString('/repos/test/engine/releases?per_page=100&page=2', $curlLog);
         self::assertStringContainsString(
             '/releases/download/nightly-42-1-abcdef123456/yiipress-linux-amd64.tar.gz',
             $curlLog,
@@ -191,7 +197,7 @@ SH);
     #[Test]
     public function reportsWhenANightlyReleaseIsUnavailable(): void
     {
-        file_put_contents($this->root . '/releases.json', "[]\n");
+        file_put_contents($this->root . '/releases-page-1.json', "[]\n");
 
         [$exitCode, $output] = $this->runInstaller(version: 'nightly');
 
@@ -280,7 +286,8 @@ SH);
             'YIIPRESS_INSTALL_DIR' => $installDirectory ?? $this->root . '/install',
             'YIIPRESS_REPOSITORY' => 'test/engine',
             'YIIPRESS_TEST_RELEASE_DIR' => $this->root . '/release',
-            'YIIPRESS_TEST_RELEASES' => $this->root . '/releases.json',
+            'YIIPRESS_TEST_RELEASES_PAGE_1' => $this->root . '/releases-page-1.json',
+            'YIIPRESS_TEST_RELEASES_PAGE_2' => $this->root . '/releases-page-2.json',
             'YIIPRESS_TEST_CURL_LOG' => $this->root . '/curl.log',
             'YIIPRESS_TEST_SYSTEM' => $system,
             'YIIPRESS_TEST_MACHINE' => $machine,

--- a/tests/Unit/Packaging/InstallerTest.php
+++ b/tests/Unit/Packaging/InstallerTest.php
@@ -50,7 +50,10 @@ while [ "$#" -gt 0 ]; do
         *) shift ;;
     esac
 done
-cp "${YIIPRESS_TEST_RELEASE_DIR}/${url##*/}" "$output"
+case "$url" in
+    https://api.github.com/*) cp "${YIIPRESS_TEST_RELEASES}" "$output" ;;
+    *) cp "${YIIPRESS_TEST_RELEASE_DIR}/${url##*/}" "$output" ;;
+esac
 printf '%s\n' "$url" >> "${YIIPRESS_TEST_CURL_LOG}"
 SH);
         file_put_contents($this->root . '/bin/curl', $curl);
@@ -67,6 +70,11 @@ SH);
         $sudo = "#!/bin/sh\nprintf '%s\\n' \"\$*\" >> \"\$YIIPRESS_TEST_SUDO_LOG\"\n";
         file_put_contents($this->root . '/bin/sudo', $sudo);
         chmod($this->root . '/bin/sudo', 0755);
+
+        file_put_contents(
+            $this->root . '/releases.json',
+            "[{\"tag_name\":\"nightly-42-1-abcdef123456\",\"prerelease\":true}]\n",
+        );
     }
 
     protected function tearDown(): void
@@ -144,6 +152,41 @@ SH);
         self::assertIsString($curlLog);
         self::assertStringContainsString('/releases/download/0.1.8/yiipress-linux-amd64.tar.gz', $curlLog);
         self::assertStringNotContainsString('/releases/latest/download', $curlLog);
+    }
+
+    #[Test]
+    public function installsTheNewestNightlyRelease(): void
+    {
+        $this->createRelease('nightly-version');
+
+        [$exitCode, $output] = $this->runInstaller(version: 'nightly');
+
+        self::assertSame(0, $exitCode, $output);
+        self::assertStringContainsString('Downloading YiiPress nightly-42-1-abcdef123456', $output);
+        self::assertSame('nightly-version', file_get_contents($this->root . '/install/yiipress'));
+        $curlLog = file_get_contents($this->root . '/curl.log');
+        self::assertIsString($curlLog);
+        self::assertStringContainsString('/repos/test/engine/releases?per_page=100', $curlLog);
+        self::assertStringContainsString(
+            '/releases/download/nightly-42-1-abcdef123456/yiipress-linux-amd64.tar.gz',
+            $curlLog,
+        );
+        self::assertStringContainsString(
+            '/releases/download/nightly-42-1-abcdef123456/SHA256SUMS',
+            $curlLog,
+        );
+    }
+
+    #[Test]
+    public function reportsWhenANightlyReleaseIsUnavailable(): void
+    {
+        file_put_contents($this->root . '/releases.json', "[]\n");
+
+        [$exitCode, $output] = $this->runInstaller(version: 'nightly');
+
+        self::assertSame(1, $exitCode);
+        self::assertStringContainsString('Could not find a YiiPress nightly release for test/engine.', $output);
+        self::assertFileDoesNotExist($this->root . '/install/yiipress');
     }
 
     #[Test]
@@ -228,6 +271,7 @@ SH);
             'YIIPRESS_INSTALL_DIR' => $installDirectory ?? $this->root . '/install',
             'YIIPRESS_REPOSITORY' => 'test/engine',
             'YIIPRESS_TEST_RELEASE_DIR' => $this->root . '/release',
+            'YIIPRESS_TEST_RELEASES' => $this->root . '/releases.json',
             'YIIPRESS_TEST_CURL_LOG' => $this->root . '/curl.log',
             'YIIPRESS_TEST_SYSTEM' => $system,
             'YIIPRESS_TEST_MACHINE' => $machine,

--- a/tests/Unit/Packaging/InstallerTest.php
+++ b/tests/Unit/Packaging/InstallerTest.php
@@ -83,7 +83,8 @@ SH);
         );
         file_put_contents(
             $this->root . '/releases-page-2.json',
-            "[{\"prerelease\":true,\"draft\":false,\"tag_name\":\"nightly-42-1-abcdef123456\"}]\n",
+            "[{\"prerelease\":false,\"draft\":false,\"tag_name\":\"nightly-41-1-deadbeef1234\"},"
+            . "{\"prerelease\":true,\"draft\":false,\"tag_name\":\"nightly-42-1-abcdef123456\"}]\n",
         );
     }
 
@@ -204,6 +205,24 @@ SH);
         self::assertSame(1, $exitCode);
         self::assertStringContainsString('Could not find a YiiPress nightly release for test/engine.', $output);
         self::assertFileDoesNotExist($this->root . '/install/yiipress');
+    }
+
+    #[Test]
+    public function stopsNightlyDiscoveryAfterTenPages(): void
+    {
+        file_put_contents(
+            $this->root . '/releases-page-2.json',
+            "[{\"prerelease\":false,\"tag_name\":\"1.2.2\"}]\n",
+        );
+
+        [$exitCode, $output] = $this->runInstaller(version: 'nightly');
+
+        self::assertSame(1, $exitCode);
+        self::assertStringContainsString('Could not find a YiiPress nightly release for test/engine.', $output);
+        $curlLog = file_get_contents($this->root . '/curl.log');
+        self::assertIsString($curlLog);
+        self::assertStringContainsString('/releases?per_page=100&page=10', $curlLog);
+        self::assertStringNotContainsString('/releases?per_page=100&page=11', $curlLog);
     }
 
     #[Test]


### PR DESCRIPTION
## Summary

- resolve and install the newest immutable nightly prerelease from shell, PowerShell, GitHub Actions, and self-update flows
- harden paginated nightly release discovery and validate required assets
- make packaged nightly binaries report their embedded commit SHA even if Composer metadata still contains an older stable version
- keep tagged releases reporting their release tag and document nightly version behavior

## Tests

- `make test CLI_ARGS='tests/Unit/ApplicationInfoTest.php'` (4 tests, 12 assertions)
- focused packaging tests exercised 35 tests; the existing CRLF checkout mismatch causes the workflow fixture assertion to fail before the new assertions

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Install the newest nightly binary with `YIIPRESS_VERSION=nightly`.
  * Nightly resolution searches paginated releases, stops after 10 pages, and clearly reports when no nightly release is available.
  * Development and nightly artifacts now display their full commit SHA.
* **Bug Fixes**
  * Packaged commit information now takes precedence over outdated release metadata when displaying the application version.
* **Documentation**
  * Added installation examples and guidance for nightly releases, including API-based version resolution without additional command-line tools.
* **Chores**
  * Simplified release artifact packaging by removing the commit override configuration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->