### PR TITLE
Fix self-update detection in static binaries

### DIFF
--- a/docs/binaries-phar-docker.md
+++ b/docs/binaries-phar-docker.md
@@ -80,7 +80,7 @@ yiipress self-update
 yiipress self-update --nightly
 ```
 
-The first command installs the latest stable release. The second installs the newest nightly prerelease containing a compatible package. If a nightly package is unavailable for the current installation type or platform, the command reports that clearly instead of selecting an incompatible asset. Composer/source checkouts must be updated with Composer instead.
+The first command installs the latest stable release. The second installs the newest nightly prerelease containing a compatible package. Static binaries identify their outer executable through the micro SAPI runtime and replace that executable in place. If a nightly package is unavailable for the current installation type or platform, the command reports that clearly instead of selecting an incompatible asset. Composer/source checkouts must be updated with Composer instead.
 
 GitHub Actions builds the same outputs in the `Package Static Builds` workflow. Commits to `master` publish separate nightly PHAR, Linux, macOS, and Windows workflow artifacts, create immutable GitHub prereleases tagged as `nightly-<run>-<attempt>-<sha>` with the PHAR and all three platform packages plus checksums, and push the distroless image as `ghcr.io/<owner>/<repo>-static:nightly` plus a commit-specific `nightly-<sha>` tag. The reusable build action resolves `version: nightly` to the newest matching nightly prerelease.
 

--- a/src/Update/PackageLocator.php
+++ b/src/Update/PackageLocator.php
@@ -8,6 +8,8 @@ use Phar;
 use RuntimeException;
 
 use function class_exists;
+use function call_user_func;
+use function function_exists;
 use function is_file;
 use function pathinfo;
 use function strtolower;
@@ -19,16 +21,21 @@ final class PackageLocator
 {
     private readonly string $osFamily;
     private readonly string $architecture;
+    private readonly string $staticBinaryPath;
 
-    public function __construct(?string $osFamily = null, ?string $architecture = null)
+    public function __construct(?string $osFamily = null, ?string $architecture = null, ?string $staticBinaryPath = null)
     {
         $this->osFamily = $osFamily ?? PHP_OS_FAMILY;
         $this->architecture = strtolower($architecture ?? php_uname('m'));
+        $this->staticBinaryPath = $staticBinaryPath ?? $this->detectStaticBinaryPath();
     }
 
     public function locate(): Package
     {
         $targetPath = class_exists(Phar::class, false) ? Phar::running(false) : '';
+        if ($targetPath === '') {
+            $targetPath = $this->staticBinaryPath;
+        }
         if ($targetPath === '' || !is_file($targetPath)) {
             throw new RuntimeException('Self-update is available only for PHAR and static binary installations.');
         }
@@ -55,5 +62,10 @@ final class PackageLocator
             'Windows' => in_array($this->architecture, ['x86_64', 'amd64'], true) ? 'yiipress-windows-amd64.zip' : throw new RuntimeException("Unsupported Windows architecture: {$this->architecture}."),
             default => throw new RuntimeException('Self-update is not available for this operating system.'),
         };
+    }
+
+    private function detectStaticBinaryPath(): string
+    {
+        return function_exists('micro_get_self_filename') ? (string) call_user_func('micro_get_self_filename') : '';
     }
 }

--- a/tests/Unit/Update/SelfUpdaterTest.php
+++ b/tests/Unit/Update/SelfUpdaterTest.php
@@ -106,6 +106,19 @@ final class SelfUpdaterTest extends TestCase
     }
 
     #[Test]
+    public function packageLocatorDetectsStaticBinaryInstallation(): void
+    {
+        $target = $this->directory . '/yiipress';
+        file_put_contents($target, 'binary-build');
+
+        $package = (new PackageLocator('Linux', 'x86_64', $target))->locate();
+
+        self::assertSame($target, $package->targetPath);
+        self::assertSame('yiipress-linux-amd64.tar.gz', $package->assetName);
+        self::assertSame('yiipress', $package->archiveMember);
+    }
+
+    #[Test]
     public function packageLocatorRejectsNonAmd64LinuxBinary(): void
     {
         $this->expectExceptionMessage('Unsupported Linux architecture: aarch64');


### PR DESCRIPTION
## Summary

- detect the outer executable through `micro_get_self_filename()` when running a static micro SAPI binary
- preserve existing PHAR and source-checkout detection behavior
- add regression coverage and document in-place static binary updates

## Verification

- `make test -- --filter SelfUpdaterTest` (passes: 8 tests, 15 assertions)
- `make psalm` (passes)
- `git diff --check` (passes)
- `make test` (checkout-wide existing CRLF mismatch causes 92 unrelated failures, primarily `/usr/bin/env: php\r`; focused updater suite passes)