### PR TITLE
Fix nightly release publishing checkout

### DIFF
--- a/.github/workflows/package-static.yml
+++ b/.github/workflows/package-static.yml
@@ -218,6 +218,11 @@ jobs:
       contents: write
 
     steps:
+      - name: Checkout repository
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
+        with:
+          persist-credentials: false
+
       - name: Download packaged artifacts
         uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093
         with:

--- a/tests/Unit/Packaging/ConfigurationPackagingTest.php
+++ b/tests/Unit/Packaging/ConfigurationPackagingTest.php
@@ -327,6 +327,10 @@ final class ConfigurationPackagingTest extends TestCase
         self::assertStringContainsString('type=sha,prefix=nightly-', $workflow);
         self::assertStringContainsString('nightly_tag="nightly-${GITHUB_RUN_NUMBER}-${GITHUB_RUN_ATTEMPT}-${short_sha}"', $workflow);
         self::assertStringContainsString('needs: [linux, windows, macos]', $workflow);
+        self::assertMatchesRegularExpression(
+            '/nightly-release:.*?steps:\s+- name: Checkout repository\s+uses: actions\/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5/s',
+            $workflow,
+        );
         self::assertStringContainsString('Pack nightly release assets', $workflow);
         self::assertStringContainsString('assets/yiipress-linux-amd64.tar.gz', $workflow);
         self::assertStringContainsString('assets/yiipress-macos-arm64.tar.gz', $workflow);
@@ -345,7 +349,7 @@ final class ConfigurationPackagingTest extends TestCase
         self::assertStringContainsString('yiipress-macos-arm64.tar.gz', $workflow);
         self::assertDoesNotMatchRegularExpression('/uses:\s+[^@\s]+@v\d+/', $workflow);
         self::assertStringNotContainsString('dtolnay/rust-toolchain@stable', $workflow);
-        self::assertSame(3, substr_count($workflow, 'persist-credentials: false'));
+        self::assertSame(4, substr_count($workflow, 'persist-credentials: false'));
     }
 
     #[Test]


### PR DESCRIPTION
## Summary

- check out the triggering revision in the nightly release job before invoking `gh release create`
- keep checkout credentials disabled
- add workflow regression coverage scoped to the nightly release job

## Failure

Fixes the `fatal: not a git repository` failure in job 92264288673 from run 30992351035.

## Verification

- `make test -- --filter ConfigurationPackagingTest` (31 tests, 489 assertions)
- `git diff --check`