### PR TITLE
Check self-update permissions before download

### DIFF
--- a/docs/commands.md
+++ b/docs/commands.md
@@ -361,7 +361,7 @@ Use the newest successful build from `master` for preview testing:
 yiipress self-update --nightly
 ```
 
-The command is intentionally unavailable in a Composer/source checkout. Use Composer to update those installations. The user running the command must be able to write to the installed PHAR or binary directory.
+The command is intentionally unavailable in a Composer/source checkout. Use Composer to update those installations. Before downloading a release, the command verifies that the user can write to the installed PHAR or binary directory and reports an actionable permissions error otherwise.
 On Windows, replacement is completed by a short-lived background helper after the running command exits.
 
 ## `clean` / `clear`

--- a/src/Update/SelfUpdater.php
+++ b/src/Update/SelfUpdater.php
@@ -14,6 +14,7 @@ use function hash;
 use function hash_equals;
 use function hash_file;
 use function is_dir;
+use function is_writable;
 use function mkdir;
 use function preg_match;
 use function preg_quote;
@@ -33,6 +34,14 @@ final readonly class SelfUpdater
     public function update(bool $nightly = false, ?Package $package = null): string
     {
         $package ??= $this->packageLocator->locate();
+        $targetDirectory = dirname($package->targetPath);
+        if (!is_writable($targetDirectory)) {
+            throw new RuntimeException(
+                "Could not update {$package->targetPath}: installation directory $targetDirectory is not writable. "
+                . 'Check its permissions or rerun with appropriate privileges.',
+            );
+        }
+
         $downloadPath = sys_get_temp_dir() . '/yiipress-download-' . hash('xxh128', $package->targetPath) . '-' . $package->assetName;
         $release = $this->releaseClient->download($package->assetName, $nightly, $downloadPath);
         $expectedHash = $this->checksum($release['checksums'], $package->assetName);
@@ -64,7 +73,7 @@ final readonly class SelfUpdater
     private function preparePackage(string $downloadPath, string $temporaryPath, Package $package): void
     {
         if ($package->archiveMember === null) {
-            if (!copy($downloadPath, $temporaryPath)) {
+            if (!@copy($downloadPath, $temporaryPath)) {
                 throw new RuntimeException("Could not write the update next to {$package->targetPath}.");
             }
 
@@ -81,7 +90,7 @@ final readonly class SelfUpdater
             if (!$archive->extractTo($extractPath, $package->archiveMember, true)) {
                 throw new RuntimeException("{$package->assetName} does not contain {$package->archiveMember}.");
             }
-            if (!copy($extractPath . '/' . $package->archiveMember, $temporaryPath)) {
+            if (!@copy($extractPath . '/' . $package->archiveMember, $temporaryPath)) {
                 throw new RuntimeException("Could not write the update next to {$package->targetPath}.");
             }
         } finally {

--- a/tests/Unit/Update/SelfUpdaterTest.php
+++ b/tests/Unit/Update/SelfUpdaterTest.php
@@ -13,6 +13,7 @@ use YiiPress\Update\PackageLocator;
 use YiiPress\Update\ReleaseClient;
 use YiiPress\Update\SelfUpdater;
 
+use function chmod;
 use function file_put_contents;
 use function hash;
 use function json_encode;
@@ -94,6 +95,24 @@ final class SelfUpdaterTest extends TestCase
             $this->updater()->update(package: new Package($target, 'yiipress.phar'));
         } finally {
             self::assertSame('old-build', file_get_contents($target));
+        }
+    }
+
+    #[Test]
+    public function rejectsUnwritableInstallationDirectoryBeforeDownloading(): void
+    {
+        $installationDirectory = $this->directory . '/installation';
+        mkdir($installationDirectory);
+        $target = $installationDirectory . '/yiipress.phar';
+        file_put_contents($target, 'old-build');
+        chmod($installationDirectory, 0555);
+
+        $this->expectExceptionMessage('installation directory ' . $installationDirectory . ' is not writable');
+
+        try {
+            $this->updater()->update(package: new Package($target, 'missing.phar'));
+        } finally {
+            chmod($installationDirectory, 0755);
         }
     }
 


### PR DESCRIPTION
## Summary

- check installation directory writability before release lookup or download
- report an actionable permission error and suppress raw copy warnings
- document the preflight and cover it with a unit test

## Tests

- `make test CLI_ARGS='tests/Unit/Update/SelfUpdaterTest.php tests/Unit/Update/PackageReplacerTest.php'`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Self-updates now check installation directory permissions before downloading.
  * Added a clear, actionable error when the installation directory is not writable.
  * Improved handling of package-copy failures to provide more reliable update behavior.

* **Documentation**
  * Updated self-update documentation to describe permission checks and error guidance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->