### PR TITLE
Defer self-update replacement until shutdown

### DIFF
--- a/docs/binaries-phar-docker.md
+++ b/docs/binaries-phar-docker.md
@@ -80,7 +80,7 @@ yiipress self-update
 yiipress self-update --nightly
 ```
 
-The first command installs the latest stable release. The second installs the newest nightly prerelease containing a compatible package. Static binaries identify their outer executable through the micro SAPI runtime and replace that executable in place. If a nightly package is unavailable for the current installation type or platform, the command reports that clearly instead of selecting an incompatible asset. Composer/source checkouts must be updated with Composer instead.
+The first command installs the latest stable release. The second installs the newest nightly prerelease containing a compatible package. Static binaries identify their outer executable through the micro SAPI runtime. The verified replacement is staged beside the installed package and activated only after normal command shutdown, avoiding stale PHAR metadata while the old package is still running. If a nightly package is unavailable for the current installation type or platform, the command reports that clearly instead of selecting an incompatible asset. Composer/source checkouts must be updated with Composer instead.
 
 GitHub Actions builds the same outputs in the `Package Static Builds` workflow. Commits to `master` publish separate nightly PHAR, Linux, macOS, and Windows workflow artifacts, create immutable GitHub prereleases tagged as `nightly-<run>-<attempt>-<sha>` with the PHAR and all three platform packages plus checksums, and push the distroless image as `ghcr.io/<owner>/<repo>-static:nightly` plus a commit-specific `nightly-<sha>` tag. The reusable build action resolves `version: nightly` to the newest matching nightly prerelease.
 

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -362,7 +362,7 @@ yiipress self-update --nightly
 ```
 
 The command is intentionally unavailable in a Composer/source checkout. Use Composer to update those installations. The user running the command must be able to write to the installed PHAR or binary directory.
-On Windows, replacement is completed by a short-lived background helper after the running command exits.
+The verified package is staged next to the installation and replacement is deferred until the running command has shut down, so PHP never reads the new archive using cached metadata from the old one. On Windows, replacement is completed by a short-lived background helper after the running command exits.
 
 ## `clean` / `clear`
 

--- a/src/Update/PackageReplacer.php
+++ b/src/Update/PackageReplacer.php
@@ -4,26 +4,41 @@ declare(strict_types=1);
 
 namespace YiiPress\Update;
 
+use Closure;
 use RuntimeException;
 
 use function fclose;
 use function file_put_contents;
 use function proc_close;
 use function proc_open;
+use function register_shutdown_function;
 use function rename;
 use function str_contains;
 use function unlink;
 
 final readonly class PackageReplacer
 {
-    public function __construct(private string $osFamily = PHP_OS_FAMILY) {}
+    /** @var Closure(Closure(): void): void */
+    private Closure $shutdownRegistrar;
+
+    /**
+     * @param Closure(Closure(): void): void|null $shutdownRegistrar
+     */
+    public function __construct(private string $osFamily = PHP_OS_FAMILY, ?Closure $shutdownRegistrar = null)
+    {
+        $this->shutdownRegistrar = $shutdownRegistrar ?? static function (Closure $callback): void {
+            register_shutdown_function($callback);
+        };
+    }
 
     public function replace(string $temporaryPath, string $targetPath): void
     {
         if ($this->osFamily !== 'Windows') {
-            if (!rename($temporaryPath, $targetPath)) {
-                throw new RuntimeException("Could not replace $targetPath. Check its permissions.");
-            }
+            ($this->shutdownRegistrar)(static function () use ($temporaryPath, $targetPath): void {
+                if (!rename($temporaryPath, $targetPath)) {
+                    throw new RuntimeException("Could not replace $targetPath. Check its permissions.");
+                }
+            });
 
             return;
         }

--- a/tests/Unit/Update/PackageReplacerTest.php
+++ b/tests/Unit/Update/PackageReplacerTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace YiiPress\Tests\Unit\Update;
 
+use Closure;
 use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
 use YiiPress\Update\PackageReplacer;
@@ -11,7 +12,7 @@ use YiiPress\Update\PackageReplacer;
 final class PackageReplacerTest extends TestCase
 {
     #[Test]
-    public function atomicallyReplacesPackageOnPosix(): void
+    public function replacesPackageAfterApplicationShutdownOnPosix(): void
     {
         $directory = sys_get_temp_dir() . '/yiipress-replacer-' . uniqid('', true);
         mkdir($directory);
@@ -19,9 +20,19 @@ final class PackageReplacerTest extends TestCase
         $targetPath = $directory . '/yiipress';
         file_put_contents($temporaryPath, 'new');
         file_put_contents($targetPath, 'old');
+        $replacement = null;
 
         try {
-            (new PackageReplacer('Linux'))->replace($temporaryPath, $targetPath);
+            $registrar = static function (Closure $callback) use (&$replacement): void {
+                $replacement = $callback;
+            };
+            (new PackageReplacer('Linux', $registrar))->replace($temporaryPath, $targetPath);
+
+            self::assertSame('old', file_get_contents($targetPath));
+            self::assertFileExists($temporaryPath);
+            self::assertInstanceOf(Closure::class, $replacement);
+
+            $replacement();
 
             self::assertSame('new', file_get_contents($targetPath));
             self::assertFileDoesNotExist($temporaryPath);

--- a/tests/Unit/Update/SelfUpdaterTest.php
+++ b/tests/Unit/Update/SelfUpdaterTest.php
@@ -4,12 +4,14 @@ declare(strict_types=1);
 
 namespace YiiPress\Tests\Unit\Update;
 
+use Closure;
 use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
 use Phar;
 use PharData;
 use YiiPress\Update\Package;
 use YiiPress\Update\PackageLocator;
+use YiiPress\Update\PackageReplacer;
 use YiiPress\Update\ReleaseClient;
 use YiiPress\Update\SelfUpdater;
 
@@ -179,6 +181,9 @@ final class SelfUpdaterTest extends TestCase
                 'file://' . $this->directory . '/releases',
                 'file://' . $this->directory . '/releases.json',
             ),
+            new PackageReplacer('Linux', static function (Closure $callback): void {
+                $callback();
+            }),
         );
     }
 


### PR DESCRIPTION
## Summary

- defer POSIX package replacement until PHP shutdown so the running PHAR keeps reading the original archive
- make the shutdown registrar injectable and cover the replacement timing with a regression test
- document staged, post-shutdown activation for packaged updates

## Testing

- `make test CLI_ARGS='tests/Unit/Update/PackageReplacerTest.php tests/Unit/Update/SelfUpdaterTest.php'`
- `make psalm`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Self-update now stages verified packages and activates them after the current command exits, preventing runtime conflicts.
  * Static binaries continue to correctly identify their executable location.
  * Windows updates continue using a background helper to complete replacement after shutdown.

* **Documentation**
  * Updated self-update guidance to explain deferred replacement behavior across supported platforms.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->