### PR TITLE
Fix code blocks in dark theme

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -12,17 +12,23 @@ show_title: false
 
 ## Install or update
 
-Linux (x86-64) and macOS (Apple silicon):
-
+[code-group]
+[code-tab label="Linux (x86-64)"]
 ```shell
 curl -fsSL https://raw.githubusercontent.com/yiipress/engine/master/install.sh | sh
 ```
-
-Windows (x86-64, PowerShell):
-
+[/code-tab]
+[code-tab label="macOS (Apple silicon)"]
+```shell
+curl -fsSL https://raw.githubusercontent.com/yiipress/engine/master/install.sh | sh
+```
+[/code-tab]
+[code-tab label="Windows (x86-64)"]
 ```powershell
 irm https://raw.githubusercontent.com/yiipress/engine/master/install.ps1 | iex
 ```
+[/code-tab]
+[/code-group]
 
 Both installers verify the latest release checksum and put `yiipress` on `PATH`. Run the same command again to update it.
 Set `YIIPRESS_INSTALL_DIR` to install into another directory.

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -1,6 +1,6 @@
 # Commands
 
-The examples below assume the static binary is in your project directory and use `./yiipress` so they work without changing `PATH`. Source checkouts expose the same commands through `./yii`; engine contributors should run them through the repository `make` targets.
+The examples below assume the static binary is installed on `PATH`. Source checkouts expose the same commands through `./yii`; engine contributors should run them through the repository `make` targets.
 
 All commands support Symfony's standard verbosity options. By default, errors contain only information useful to an end user. Use `-v` to include the exception type, `-vv` to include its source location, or `-vvv` to include the debugging stack trace.
 
@@ -8,8 +8,8 @@ All commands support Symfony's standard verbosity options. By default, errors co
 
 Generates static HTML content from source files.
 
-```
-./yiipress build [--content-dir=content] [--output-dir=output] [--workers=auto] [--no-cache] [--drafts] [--future] [--dry-run] [--no-write] [--profile]
+```shell
+yiipress build [--content-dir=content] [--output-dir=output] [--workers=auto] [--no-cache] [--drafts] [--future] [--dry-run] [--no-write] [--profile]
 ```
 
 **Options:**
@@ -65,7 +65,7 @@ With `--workers=N` (N > 1), entry rendering and writing is parallelized across N
 Checks generated HTML output for broken local links, missing `src` targets, and missing anchor fragments.
 
 ```bash
-./yiipress check:links [--output-dir=output] [--external]
+yiipress check:links [--output-dir=output] [--external]
 ```
 
 **Options:**
@@ -79,8 +79,8 @@ Run `build` first, then `check:links` against the generated output. Local checks
 
 Starts the preview server for local development.
 
-```
-./yiipress serve [address] [--content-dir=content] [--output-dir=output] [--port=19777] [--workers=2]
+```shell
+yiipress serve [address] [--content-dir=content] [--output-dir=output] [--port=19777] [--workers=2]
 ```
 
 **Options:**
@@ -94,7 +94,7 @@ On startup, `serve` prints the URL it is listening on. Build progress is printed
 
 HTML pages served by `serve` include a fixed bottom-right **Edit** button. It opens the markdown source file for the current page using the `editor` command from `content/config.yaml`; when `editor` is omitted, YiiPress uses the platform default opener (`open`, `xdg-open`, or Windows `start`). The button resolves source files through the build manifest, so it is available for entry and standalone markdown pages and hidden failures are reported in the browser console.
 
-Before starting the server, `serve` verifies that the content directory exists and that the output directory exists or can be created and written to. If the check fails, pass explicit paths, for example `./yiipress serve --content-dir=content --output-dir=output`.
+Before starting the server, `serve` verifies that the content directory exists and that the output directory exists or can be created and written to. If the check fails, pass explicit paths, for example `yiipress serve --content-dir=content --output-dir=output`.
 
 See [Preview](preview.md) for static file serving and live reload behavior. Implementation details are in [Engine](engine.md#serve-mode).
 
@@ -107,8 +107,8 @@ Initializes a content directory with the minimal YiiPress structure:
 - `page/_collection.yaml`
 - `blog/_collection.yaml`
 
-```
-./yiipress init:content [--content-dir=content]
+```shell
+yiipress init:content [--content-dir=content]
 ```
 
 **Options:**
@@ -121,8 +121,8 @@ The command creates parent directories as needed and fails if any scaffolded fil
 
 Initializes a project content processor plugin with a no-op callable ready to customize.
 
-```
-./yiipress init:plugin <name> [--content-dir=content]
+```shell
+yiipress init:plugin <name> [--content-dir=content]
 ```
 
 **Arguments:**
@@ -139,8 +139,8 @@ For example, `init:plugin "Badge Labels"` creates `content/processors/badge-labe
 
 Initializes editable theme files in the project from a bundled theme.
 
-```
-./yiipress init:theme [target-dir] [--theme=minimal] [--content-dir=content]
+```shell
+yiipress init:theme [target-dir] [--theme=minimal] [--content-dir=content]
 ```
 
 **Arguments:**
@@ -158,8 +158,8 @@ The command creates parent directories as needed, fails if any target file alrea
 
 Scaffolds a new content entry or standalone page.
 
-```
-./yiipress new <title> [--collection=<name>] [--content-dir=content] [--draft]
+```shell
+yiipress new <title> [--collection=<name>] [--content-dir=content] [--draft]
 ```
 
 **Arguments:**
@@ -183,17 +183,17 @@ Scaffolds a new content entry or standalone page.
 **Examples:**
 
 ```bash
-./yiipress new "My First Post" --collection=blog
-./yiipress new "Draft Ideas" --collection=blog --draft
-./yiipress new "About Us"
+yiipress new "My First Post" --collection=blog
+yiipress new "Draft Ideas" --collection=blog --draft
+yiipress new "About Us"
 ```
 
 ## `import`
 
 Imports content from external sources into a YiiPress collection.
 
-```
-./yiipress import <source> [--collection=blog] [--content-dir=content] [--<importer-options>...]
+```shell
+yiipress import <source> [--collection=blog] [--content-dir=content] [--<importer-options>...]
 ```
 
 **Arguments:**
@@ -240,9 +240,9 @@ Supports both single-chat exports (`result.json` with `messages` array) and full
 **Examples:**
 
 ```bash
-./yiipress import telegram --directory=/path/to/telegram-export
-./yiipress import telegram --directory=/path/to/telegram-export --collection=channel
-./yiipress import telegram --directory=./telegram-data --content-dir=content
+yiipress import telegram --directory=/path/to/telegram-export
+yiipress import telegram --directory=/path/to/telegram-export --collection=channel
+yiipress import telegram --directory=./telegram-data --content-dir=content
 ```
 
 ### Medium Markdown import
@@ -260,8 +260,8 @@ Duplicate output filenames get numeric suffixes so earlier files are not overwri
 **Examples:**
 
 ```bash
-./yiipress import medium --directory=/path/to/medium-markdown-export
-./yiipress import medium --directory=./medium --collection=blog
+yiipress import medium --directory=/path/to/medium-markdown-export
+yiipress import medium --directory=./medium --collection=blog
 ```
 
 ### Ghost import
@@ -283,8 +283,8 @@ Published posts are imported normally. Non-published posts and pages are importe
 **Examples:**
 
 ```bash
-./yiipress import ghost --file=/path/to/ghost-export.json
-./yiipress import ghost --file=./ghost.json --collection=blog
+yiipress import ghost --file=/path/to/ghost-export.json
+yiipress import ghost --file=./ghost.json --collection=blog
 ```
 
 ### WordPress import
@@ -306,8 +306,8 @@ Published posts are imported normally. Non-published posts and pages are importe
 **Examples:**
 
 ```bash
-./yiipress import wordpress --file=/path/to/wordpress-export.xml
-./yiipress import wordpress --file=./export.xml --collection=blog
+yiipress import wordpress --file=/path/to/wordpress-export.xml
+yiipress import wordpress --file=./export.xml --collection=blog
 ```
 
 ### Jekyll import
@@ -331,8 +331,8 @@ If `title` is missing, it is inferred from the first `# Heading` in the post bod
 **Examples:**
 
 ```bash
-./yiipress import jekyll --directory=/path/to/jekyll-site
-./yiipress import jekyll --directory=../old-blog --collection=blog
+yiipress import jekyll --directory=/path/to/jekyll-site
+yiipress import jekyll --directory=../old-blog --collection=blog
 ```
 
 ### Hugo import
@@ -357,8 +357,8 @@ If `title` is missing, it is inferred from the first `# Heading` in the post bod
 **Examples:**
 
 ```bash
-./yiipress import hugo --directory=/path/to/hugo-site
-./yiipress import hugo --directory=../old-hugo-site --collection=blog
+yiipress import hugo --directory=/path/to/hugo-site
+yiipress import hugo --directory=../old-hugo-site --collection=blog
 ```
 
 ### Adding custom importers
@@ -386,9 +386,9 @@ On Windows, replacement is completed by a short-lived background helper after th
 
 Clears build output and caches.
 
-```
-./yiipress clean [--output-dir=output]
-./yiipress clear [--output-dir=output]
+```shell
+yiipress clean [--output-dir=output]
+yiipress clear [--output-dir=output]
 ```
 
 **Options:**

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -220,10 +220,10 @@ Language-tagged fenced blocks retain their normalized language identifier in gen
 </div>
 ```
 
-The bundled `minimal` theme displays this label next to the copy button with regular-weight text
-on the same background as the code block. Long labels are truncated so they do not overlap the
-first line of code. Highlighted code remains readable when visitors switch between the light and
-dark color schemes. Custom themes can use `data-language` and
+The bundled `minimal` theme displays this label in the same position and text alignment as the copy
+button, with regular-weight text on the same background as the code block. Long labels are truncated
+so they do not overlap the first line of code. Highlighted code remains readable when visitors
+switch between the light and dark color schemes. Custom themes can use `data-language` and
 `.code-language-label` without parsing the highlighted code.
 
 ### Assets

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -221,8 +221,9 @@ Language-tagged fenced blocks retain their normalized language identifier in gen
 ```
 
 The bundled `minimal` theme displays this label next to the copy button with regular-weight text
-on the same background as the code block. Highlighted code remains readable when visitors switch
-between the light and dark color schemes. Custom themes can use `data-language` and
+on the same background as the code block. Long labels are truncated so they do not overlap the
+first line of code. Highlighted code remains readable when visitors switch between the light and
+dark color schemes. Custom themes can use `data-language` and
 `.code-language-label` without parsing the highlighted code.
 
 ### Assets

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -220,8 +220,10 @@ Language-tagged fenced blocks retain their normalized language identifier in gen
 </div>
 ```
 
-The bundled `minimal` theme displays this label next to the copy button. Custom themes can use
-`data-language` and `.code-language-label` without parsing the highlighted code.
+The bundled `minimal` theme displays this label next to the copy button with regular-weight text
+on the same background as the code block. Highlighted code remains readable when visitors switch
+between the light and dark color schemes. Custom themes can use `data-language` and
+`.code-language-label` without parsing the highlighted code.
 
 ### Assets
 

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -5,7 +5,7 @@ YiiPress generates static HTML, CSS, JavaScript, feeds, and metadata files durin
 The recommended build tool is the static `yiipress` binary:
 
 ```bash
-./yiipress build --content-dir=content
+yiipress build --content-dir=content
 ```
 
 The generated files will be placed in the output directory (default: `output`). You can then host this directory with any static file server or hosting service.
@@ -22,7 +22,7 @@ Prefer these options in this order:
 
 The simplest deployment option is to upload the build output directly to your hosting provider's webroot:
 
-1. Build your site: `./yiipress build --content-dir=content`
+1. Build your site: `yiipress build --content-dir=content`
 2. Open your hosting control panel or FTP client.
 3. Upload the entire contents of the `output` directory to your server's webroot folder. This folder is commonly named `www`, `public_html`, `htdocs`, or `html` depending on your provider.
 4. Your site is live. The server only serves static files.
@@ -103,7 +103,7 @@ For project sites such as `https://user.github.io/project/`, set `base_url` to t
      ```bash
      curl -fsSLO https://github.com/yiipress/engine/releases/download/X.Y.Z/yiipress-linux-amd64.tar.gz && curl -fsSLO https://github.com/yiipress/engine/releases/download/X.Y.Z/SHA256SUMS && checksum="$(awk '$2 ~ /(^|\/)yiipress-linux-amd64\.tar\.gz$/ { print $1; exit }' SHA256SUMS)" && test -n "$checksum" && printf '%s  yiipress-linux-amd64.tar.gz\n' "$checksum" | sha256sum -c - && tar -xzf yiipress-linux-amd64.tar.gz && chmod +x yiipress
      ```
-   - **Build command:** `./yiipress build --output-dir=_site --no-cache`
+   - **Build command:** `yiipress build --output-dir=_site --no-cache`
    - **Build output directory:** `_site`
 4. Click **Save and Deploy**.
 
@@ -121,7 +121,7 @@ You can package your generated static site into a tiny Docker image using [`lipa
 Build the site first:
 
 ```bash
-./yiipress build --output-dir=_site --no-cache
+yiipress build --output-dir=_site --no-cache
 ```
 
 Then create a `Dockerfile` in your project root:

--- a/docs/preview.md
+++ b/docs/preview.md
@@ -3,14 +3,14 @@
 The preview server serves the built site during local development:
 
 ```bash
-./yiipress serve
+yiipress serve
 ```
 
 The static binary is the recommended way to run preview. It resolves `content/` and `output/` from the current directory by default, and custom paths can be passed with `--content-dir` and `--output-dir`.
 
 On Windows, the preview server runs as a single ReactPHP server process. Preforked `--workers` and POSIX signal handlers are used only on platforms where PCNTL and signal constants are available.
 
-The command validates paths before opening the socket. The content directory must exist, and the output directory must exist or be creatable and writable. If either check fails, run it with explicit paths such as `./yiipress serve --content-dir=content --output-dir=output`.
+The command validates paths before opening the socket. The content directory must exist, and the output directory must exist or be creatable and writable. If either check fails, run it with explicit paths such as `yiipress serve --content-dir=content --output-dir=output`.
 
 ## Static file serving
 

--- a/docs/templates.md
+++ b/docs/templates.md
@@ -77,7 +77,7 @@ theme: brand
 To start editing the bundled theme in a PHAR or static binary build, initialize it into `themes/custom/`:
 
 ```bash
-./yiipress init:theme
+yiipress init:theme
 ```
 
 The command updates `content/config.yaml` automatically to set `theme: custom`.

--- a/tests/Unit/Processor/SyntaxHighlightProcessorTest.php
+++ b/tests/Unit/Processor/SyntaxHighlightProcessorTest.php
@@ -67,6 +67,20 @@ final class SyntaxHighlightProcessorTest extends TestCase
         assertStringContainsString('some code', $result);
     }
 
+    public function testPreservesArbitrarilyLongLanguageIdentifier(): void
+    {
+        $language = 'custom-language-identifier-that-is-longer-than-the-label';
+        $html = '<pre><code class="language-' . $language . '">some code</code></pre>';
+
+        $result = (new SyntaxHighlightProcessor(new Highlighter()))->process($html, $this->createEntry());
+
+        assertStringContainsString('data-language="' . $language . '"', $result);
+        assertStringContainsString(
+            '<span class="code-language-label">' . strtoupper($language) . '</span>',
+            $result,
+        );
+    }
+
     public function testLeavesUnlabeledCodeBlockUnwrapped(): void
     {
         $html = '<pre><code>plain code</code></pre>';

--- a/tests/Unit/Theme/MinimalThemeAssetsTest.php
+++ b/tests/Unit/Theme/MinimalThemeAssetsTest.php
@@ -165,6 +165,38 @@ final class MinimalThemeAssetsTest extends TestCase
         assertStringContainsString('white-space: nowrap;', $rule);
     }
 
+    public function testCopyButtonTextAlignsWithLanguageLabel(): void
+    {
+        $css = file_get_contents(dirname(__DIR__, 3) . '/themes/minimal/assets/style.css');
+
+        self::assertNotFalse($css);
+        self::assertSame(1, preg_match('/\.code-language-label \{(?<rule>[^}]*)}/', $css, $labelMatches));
+        self::assertSame(1, preg_match('/\.code-copy-button \{(?<rule>[^}]*)}/', $css, $buttonMatches));
+
+        $labelRule = $labelMatches['rule'];
+        $buttonRule = $buttonMatches['rule'];
+
+        $sharedDeclarations = [
+            'top: .75rem;',
+            'right: .75rem;',
+            'font-size: .75rem;',
+            'font-weight: 400;',
+            'line-height: 1;',
+        ];
+        foreach ($sharedDeclarations as $declaration) {
+            assertStringContainsString($declaration, $labelRule);
+        }
+        $buttonDeclarations = [
+            'top: .75rem;',
+            'right: .75rem;',
+            'height: 1.25rem;',
+            'font: 400 .75rem/1 var(--font-sans);',
+        ];
+        foreach ($buttonDeclarations as $declaration) {
+            assertStringContainsString($declaration, $buttonRule);
+        }
+    }
+
     public function testCodeCopyScriptEnhancesContentPreBlocks(): void
     {
         $script = file_get_contents(dirname(__DIR__, 3) . '/themes/minimal/assets/code-copy.js');

--- a/tests/Unit/Theme/MinimalThemeAssetsTest.php
+++ b/tests/Unit/Theme/MinimalThemeAssetsTest.php
@@ -129,6 +129,27 @@ final class MinimalThemeAssetsTest extends TestCase
         assertStringContainsString('pointer-events: auto;', $css);
     }
 
+    public function testStyleKeepsHighlightedCodeReadableInDarkMode(): void
+    {
+        $css = file_get_contents(dirname(__DIR__, 3) . '/themes/minimal/assets/style.css');
+
+        self::assertNotFalse($css);
+        assertStringContainsString(
+            '[data-theme="dark"] .content pre[style] { color: var(--c-text) !important; }',
+            $css,
+        );
+    }
+
+    public function testCodeLanguageLabelMatchesCodeBlock(): void
+    {
+        $css = file_get_contents(dirname(__DIR__, 3) . '/themes/minimal/assets/style.css');
+
+        self::assertNotFalse($css);
+        assertStringContainsString('padding: .25rem .375rem;', $css);
+        assertStringContainsString('background: var(--c-code-bg);', $css);
+        assertStringContainsString('font-weight: 400;', $css);
+    }
+
     public function testCodeCopyScriptEnhancesContentPreBlocks(): void
     {
         $script = file_get_contents(dirname(__DIR__, 3) . '/themes/minimal/assets/code-copy.js');

--- a/tests/Unit/Theme/MinimalThemeAssetsTest.php
+++ b/tests/Unit/Theme/MinimalThemeAssetsTest.php
@@ -145,9 +145,24 @@ final class MinimalThemeAssetsTest extends TestCase
         $css = file_get_contents(dirname(__DIR__, 3) . '/themes/minimal/assets/style.css');
 
         self::assertNotFalse($css);
-        assertStringContainsString('padding: .25rem .375rem;', $css);
-        assertStringContainsString('background: var(--c-code-bg);', $css);
-        assertStringContainsString('font-weight: 400;', $css);
+        self::assertSame(1, preg_match('/\.code-block \{(?<rule>[^}]*)}/', $css, $blockMatches));
+        self::assertSame(1, preg_match('/\.code-block pre \{(?<rule>[^}]*)}/', $css, $preMatches));
+        self::assertSame(1, preg_match('/\.code-language-label \{(?<rule>[^}]*)}/', $css, $matches));
+
+        assertStringContainsString('--code-language-label-width: 8rem;', $blockMatches['rule']);
+        assertStringContainsString(
+            'padding-right: calc(var(--code-language-label-width) + 1.5rem);',
+            $preMatches['rule'],
+        );
+
+        $rule = $matches['rule'];
+        assertStringContainsString('max-width: var(--code-language-label-width);', $rule);
+        assertStringContainsString('padding: .25rem .375rem;', $rule);
+        assertStringContainsString('background: var(--c-code-bg);', $rule);
+        assertStringContainsString('font-weight: 400;', $rule);
+        assertStringContainsString('overflow: hidden;', $rule);
+        assertStringContainsString('text-overflow: ellipsis;', $rule);
+        assertStringContainsString('white-space: nowrap;', $rule);
     }
 
     public function testCodeCopyScriptEnhancesContentPreBlocks(): void

--- a/themes/minimal/assets/style.css
+++ b/themes/minimal/assets/style.css
@@ -330,17 +330,17 @@ article h1 { font-size: 2rem; font-weight: 700; line-height: 1.25; margin-bottom
 }
 .code-copy-button {
     position: absolute;
-    top: .5rem;
-    right: .5rem;
+    top: .75rem;
+    right: .75rem;
     z-index: 1;
     min-width: 3rem;
-    height: 2rem;
-    padding: 0 .625rem;
+    height: 1.25rem;
+    padding: 0 .375rem;
     border: 1px solid var(--c-border);
-    border-radius: .375rem;
+    border-radius: .25rem;
     background: color-mix(in srgb, var(--c-bg) 88%, transparent);
     color: var(--c-text-muted);
-    font: 600 .75rem/1 var(--font-sans);
+    font: 400 .75rem/1 var(--font-sans);
     cursor: pointer;
     opacity: 0;
     pointer-events: none;

--- a/themes/minimal/assets/style.css
+++ b/themes/minimal/assets/style.css
@@ -309,9 +309,12 @@ article h1 { font-size: 2rem; font-weight: 700; line-height: 1.25; margin-bottom
     top: .75rem;
     right: .75rem;
     z-index: 1;
+    padding: .25rem .375rem;
+    border-radius: .25rem;
+    background: var(--c-code-bg);
     color: var(--c-text-muted);
     font-size: .75rem;
-    font-weight: 600;
+    font-weight: 400;
     line-height: 1;
     pointer-events: none;
     transition: opacity .15s;
@@ -359,6 +362,7 @@ article h1 { font-size: 2rem; font-weight: 700; line-height: 1.25; margin-bottom
     border-color: #ef4444;
 }
 .content pre[style] { background-color: var(--c-code-bg) !important; }
+[data-theme="dark"] .content pre[style] { color: var(--c-text) !important; }
 [data-theme="dark"] .content pre[style] span[style] { filter: invert(.85) hue-rotate(180deg); }
 .content code { font-family: var(--font-mono); font-size: .9em; }
 .content :not(pre) > code {

--- a/themes/minimal/assets/style.css
+++ b/themes/minimal/assets/style.css
@@ -297,18 +297,20 @@ article h1 { font-size: 2rem; font-weight: 700; line-height: 1.25; margin-bottom
     transition: background .2s;
 }
 .code-block {
+    --code-language-label-width: 8rem;
     position: relative;
     margin: 1.25rem 0;
 }
 .code-block pre {
     margin: 0;
-    padding-right: 4.5rem;
+    padding-right: calc(var(--code-language-label-width) + 1.5rem);
 }
 .code-language-label {
     position: absolute;
     top: .75rem;
     right: .75rem;
     z-index: 1;
+    max-width: var(--code-language-label-width);
     padding: .25rem .375rem;
     border-radius: .25rem;
     background: var(--c-code-bg);
@@ -316,6 +318,9 @@ article h1 { font-size: 2rem; font-weight: 700; line-height: 1.25; margin-bottom
     font-size: .75rem;
     font-weight: 400;
     line-height: 1;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
     pointer-events: none;
     transition: opacity .15s;
 }


### PR DESCRIPTION
## Summary
- keep unwrapped syntax-highlighted shell text readable in dark mode
- render language labels with regular weight, padding, and the code block background
- document and test the minimal theme behavior

## Testing
- make test CLI_ARGS=tests/Unit/Theme/MinimalThemeAssetsTest.php (passes: 15 tests, 102 assertions)
- make test (fails in 91 existing environment-dependent cases because the checkout has CRLF shebangs reported as php\\r; the focused changed suite passes)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved readability of highlighted code in dark mode.
  * Updated code-language labels to use regular-weight text and a matching code-background style.

* **Documentation**
  * Clarified syntax-highlighting behavior and customization options for the Minimal theme.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->