### PR TITLE
Preserve Mermaid syntax during HTML minification

### DIFF
--- a/docs/plugins.md
+++ b/docs/plugins.md
@@ -160,7 +160,7 @@ gantt
 
 The processor converts the code block to a `<div class="mermaid">` element.
 Mermaid.js (loaded via CDN in the template) renders the diagram as SVG in the browser.
-HTML minification preserves the diagram source whitespace because Mermaid uses line breaks to separate statements.
+HTML minification preserves the diagram source whitespace because Mermaid uses line breaks to separate statements when semicolons are omitted.
 
 Supported diagram types: flowcharts, sequence diagrams, Gantt charts, pie charts, class diagrams, state diagrams, 
 user journey maps, and more.

--- a/docs/plugins.md
+++ b/docs/plugins.md
@@ -160,6 +160,7 @@ gantt
 
 The processor converts the code block to a `<div class="mermaid">` element.
 Mermaid.js (loaded via CDN in the template) renders the diagram as SVG in the browser.
+HTML minification preserves the diagram source whitespace because Mermaid uses line breaks to separate statements.
 
 Supported diagram types: flowcharts, sequence diagrams, Gantt charts, pie charts, class diagrams, state diagrams, 
 user journey maps, and more.

--- a/src/Build/OutputMinifier.php
+++ b/src/Build/OutputMinifier.php
@@ -16,7 +16,7 @@ use function trim;
 
 final class OutputMinifier
 {
-    private const string PROTECTED_START_TAG_PATTERN = '~<(?<tag>pre|textarea|script|style|div(?=(?:[^>"\']+|"[^"]*"|\'[^\']*\')*\bclass\s*=\s*(?:"[^"]*\bmermaid\b[^"]*"|\'[^\']*\bmermaid\b[^\']*\')))\b(?:[^>"\']+|"[^"]*"|\'[^\']*\')*>~i';
+    private const string PROTECTED_START_TAG_PATTERN = '~<(?<tag>pre|textarea|script|style|div(?=(?:[^>"\']+|"[^"]*"|\'[^\']*\')*\sclass\s*=\s*(?:"[^"]*(?<![^\s"])mermaid(?![^\s"])[^"]*"|\'[^\']*(?<![^\s\'])mermaid(?![^\s\'])[^\']*\')))\b(?:[^>"\']+|"[^"]*"|\'[^\']*\')*>~i';
     private const string TAG_PATTERN = '~(<(?:[^>"\']+|"[^"]*"|\'[^\']*\')*>)~';
 
     /**

--- a/src/Build/OutputMinifier.php
+++ b/src/Build/OutputMinifier.php
@@ -16,7 +16,7 @@ use function trim;
 
 final class OutputMinifier
 {
-    private const string PROTECTED_START_TAG_PATTERN = '~<(?<tag>pre|textarea|script|style)\b(?:[^>"\']+|"[^"]*"|\'[^\']*\')*>~i';
+    private const string PROTECTED_START_TAG_PATTERN = '~<(?<tag>pre|textarea|script|style|div(?=[^>]*\bclass\s*=\s*(?:"[^"]*\bmermaid\b[^"]*"|\'[^\']*\bmermaid\b[^\']*\')))\b(?:[^>"\']+|"[^"]*"|\'[^\']*\')*>~i';
     private const string TAG_PATTERN = '~(<(?:[^>"\']+|"[^"]*"|\'[^\']*\')*>)~';
 
     /**

--- a/src/Build/OutputMinifier.php
+++ b/src/Build/OutputMinifier.php
@@ -16,7 +16,7 @@ use function trim;
 
 final class OutputMinifier
 {
-    private const string PROTECTED_START_TAG_PATTERN = '~<(?<tag>pre|textarea|script|style|div(?=[^>]*\bclass\s*=\s*(?:"[^"]*\bmermaid\b[^"]*"|\'[^\']*\bmermaid\b[^\']*\')))\b(?:[^>"\']+|"[^"]*"|\'[^\']*\')*>~i';
+    private const string PROTECTED_START_TAG_PATTERN = '~<(?<tag>pre|textarea|script|style|div(?=(?:[^>"\']+|"[^"]*"|\'[^\']*\')*\bclass\s*=\s*(?:"[^"]*\bmermaid\b[^"]*"|\'[^\']*\bmermaid\b[^\']*\')))\b(?:[^>"\']+|"[^"]*"|\'[^\']*\')*>~i';
     private const string TAG_PATTERN = '~(<(?:[^>"\']+|"[^"]*"|\'[^\']*\')*>)~';
 
     /**

--- a/tests/Unit/Build/OutputMinifierTest.php
+++ b/tests/Unit/Build/OutputMinifierTest.php
@@ -105,6 +105,17 @@ final class OutputMinifierTest extends TestCase
         );
     }
 
+    public function testPreservesMermaidDiagramWhitespaceWithGreaterThanSignInEarlierAttribute(): void
+    {
+        $html = <<<'HTML'
+            <div data-expression="1 > 0" class="diagram mermaid">flowchart LR
+                parse["Parse"] --> render["Render"]
+            </div>
+            HTML;
+
+        assertSame($html, OutputMinifier::html($html));
+    }
+
     public function testKeepsTagsWithGreaterThanSignInQuotedAttributesIntact(): void
     {
         $html = <<<'HTML'

--- a/tests/Unit/Build/OutputMinifierTest.php
+++ b/tests/Unit/Build/OutputMinifierTest.php
@@ -116,6 +116,18 @@ final class OutputMinifierTest extends TestCase
         assertSame($html, OutputMinifier::html($html));
     }
 
+    public function testMinifiesDivWithoutExactMermaidClass(): void
+    {
+        assertSame(
+            '<div data-class="mermaid"> Ordinary content </div>',
+            OutputMinifier::html("<div data-class=\"mermaid\">\n    Ordinary content\n</div>"),
+        );
+        assertSame(
+            '<div class="not-mermaid"> Ordinary content </div>',
+            OutputMinifier::html("<div class=\"not-mermaid\">\n    Ordinary content\n</div>"),
+        );
+    }
+
     public function testKeepsTagsWithGreaterThanSignInQuotedAttributesIntact(): void
     {
         $html = <<<'HTML'

--- a/tests/Unit/Build/OutputMinifierTest.php
+++ b/tests/Unit/Build/OutputMinifierTest.php
@@ -83,6 +83,28 @@ final class OutputMinifierTest extends TestCase
         );
     }
 
+    public function testPreservesMermaidDiagramWhitespace(): void
+    {
+        $html = <<<'HTML'
+            <article>
+                <div class="diagram mermaid" tabindex="0">flowchart LR
+                    parse["Parse"] --> index["Index"]
+                    index --> render["Render"]
+                </div>
+            </article>
+            HTML;
+
+        assertSame(
+            <<<'HTML'
+            <article><div class="diagram mermaid" tabindex="0">flowchart LR
+                    parse["Parse"] --> index["Index"]
+                    index --> render["Render"]
+                </div></article>
+            HTML,
+            OutputMinifier::html($html),
+        );
+    }
+
     public function testKeepsTagsWithGreaterThanSignInQuotedAttributesIntact(): void
     {
         $html = <<<'HTML'


### PR DESCRIPTION
## Summary

- preserve whitespace inside generated Mermaid containers during HTML minification
- cover multiline Mermaid flowcharts with a regression test
- document that Mermaid statement separators survive minification

## Root cause

`OutputMinifier` collapsed whitespace in `<div class="mermaid">` bodies. This joined `flowchart LR` and subsequent statements onto one line without semicolon separators, so Mermaid reported a syntax error for `docs/architecture.md`.

## Verification

- `make test CLI_ARGS="--filter OutputMinifierTest"`
- `make build-docs` and verified multiline Mermaid source in `docs-output/architecture/index.html`
- `make psalm`
- `make test`: 956/957 passed; existing `MarkdownRendererTest::testRendersTaskList` fails only in this checkout because `core.autocrlf=true` makes its heredoc expectation CRLF while mdparser emits LF

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Preserved whitespace inside Mermaid diagrams during HTML minification, ensuring diagrams render correctly.
  * Improved handling of Mermaid containers when earlier HTML attributes include a greater-than sign.

* **Documentation**
  * Documented the requirement to preserve Mermaid diagram source whitespace when semicolons are omitted.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->