### PR TITLE
Style code alternative tabs

### DIFF
--- a/docs/plugins.md
+++ b/docs/plugins.md
@@ -247,6 +247,9 @@ non-empty `label`. Content outside the tab shortcodes is not allowed within a gr
 
 Visitors can select tabs with a pointer or use Left/Right arrow, Home, and End keys.
 When JavaScript is unavailable, all labeled examples remain visible.
+The built-in processor registers its tab stylesheet and script only on pages containing a
+code group. Plugin assets are copied and linked automatically, including on nested pages
+and when asset fingerprinting is disabled.
 
 ### FAQ question blocks
 

--- a/src/Processor/ContentProcessorPipeline.php
+++ b/src/Processor/ContentProcessorPipeline.php
@@ -70,8 +70,8 @@ final class ContentProcessorPipeline
     public function process(string $content, Entry $entry, ?string $rootPath = null): string
     {
         foreach ($this->processors as $processor) {
-            if ($rootPath !== null && $processor instanceof RootPathAwareProcessorInterface) {
-                $processor->applyRootPath($rootPath);
+            if ($processor instanceof RootPathAwareProcessorInterface) {
+                $processor->applyRootPath($rootPath ?? './');
             }
             $content = $processor->process($content, $entry);
         }

--- a/src/Processor/Shortcode/CodeGroupProcessor.php
+++ b/src/Processor/Shortcode/CodeGroupProcessor.php
@@ -60,8 +60,8 @@ final class CodeGroupProcessor implements ContentProcessorInterface, AssetProces
 
         return sprintf(
             "    <link rel=\"stylesheet\" href=\"%s\">\n    <script defer src=\"%s\"></script>\n",
-            $stylesheet,
-            $script,
+            htmlspecialchars($stylesheet, ENT_QUOTES | ENT_SUBSTITUTE | ENT_HTML5),
+            htmlspecialchars($script, ENT_QUOTES | ENT_SUBSTITUTE | ENT_HTML5),
         );
     }
 

--- a/src/Processor/Shortcode/CodeGroupProcessor.php
+++ b/src/Processor/Shortcode/CodeGroupProcessor.php
@@ -4,9 +4,11 @@ declare(strict_types=1);
 
 namespace YiiPress\Processor\Shortcode;
 
+use YiiPress\Build\UrlResolver;
 use YiiPress\Content\Model\Entry;
 use YiiPress\Processor\AssetProcessorInterface;
 use YiiPress\Processor\ContentProcessorInterface;
+use YiiPress\Processor\RootPathAwareProcessorInterface;
 
 use function htmlspecialchars;
 use function implode;
@@ -23,9 +25,16 @@ use function trim;
  * The same processor is intentionally run on both sides of MarkdownProcessor: the first pass
  * preserves shortcode metadata in HTML comments, and the second pass builds the final markup.
  */
-final readonly class CodeGroupProcessor implements ContentProcessorInterface, AssetProcessorInterface
+final class CodeGroupProcessor implements ContentProcessorInterface, AssetProcessorInterface, RootPathAwareProcessorInterface
 {
     use ParsesShortcodeAttributesTrait;
+
+    private string $rootPath = './';
+
+    public function applyRootPath(string $rootPath): void
+    {
+        $this->rootPath = $rootPath;
+    }
 
     public function process(string $content, Entry $entry): string
     {
@@ -46,11 +55,14 @@ final readonly class CodeGroupProcessor implements ContentProcessorInterface, As
             return '';
         }
 
-        return <<<'HTML'
-    <link rel="stylesheet" href="assets/plugins/code-groups.css">
-    <script defer src="assets/plugins/code-groups.js"></script>
+        $stylesheet = UrlResolver::sitePath('assets/plugins/code-groups.css', $this->rootPath);
+        $script = UrlResolver::sitePath('assets/plugins/code-groups.js', $this->rootPath);
 
-HTML;
+        return sprintf(
+            "    <link rel=\"stylesheet\" href=\"%s\">\n    <script defer src=\"%s\"></script>\n",
+            $stylesheet,
+            $script,
+        );
     }
 
     public function assetFiles(): array

--- a/src/Processor/Shortcode/assets/code-groups.css
+++ b/src/Processor/Shortcode/assets/code-groups.css
@@ -2,6 +2,7 @@
     --code-group-accent: var(--c-link, var(--link-color, #2563eb));
     --code-group-border: var(--c-border-strong, var(--border-color, #d1d5db));
     --code-group-tab-hover: rgb(127 127 127 / 10%);
+
     margin: 1.5rem 0;
 }
 

--- a/src/Processor/Shortcode/assets/code-groups.css
+++ b/src/Processor/Shortcode/assets/code-groups.css
@@ -1,28 +1,51 @@
 .code-group {
+    --code-group-accent: var(--c-link, var(--link-color, #2563eb));
+    --code-group-border: var(--c-border-strong, var(--border-color, #d1d5db));
+    --code-group-tab-hover: rgb(127 127 127 / 10%);
     margin: 1.5rem 0;
 }
 
 .code-group-tabs {
     display: flex;
-    gap: .25rem;
+    gap: .125rem;
     overflow-x: auto;
-    border-bottom: 1px solid var(--border-color, #d1d5db);
+    margin-bottom: 1rem;
+    border-bottom: 1px solid var(--code-group-border);
+    scrollbar-width: thin;
 }
 
 .code-group-tabs [role="tab"] {
-    padding: .55rem .8rem;
+    position: relative;
+    margin: 0 0 -1px;
+    padding: .65rem .9rem;
     border: 0;
-    border-bottom: 2px solid transparent;
+    border-bottom: 3px solid transparent;
+    border-radius: .35rem .35rem 0 0;
     background: transparent;
-    color: inherit;
+    color: var(--c-text-muted, var(--muted-color, inherit));
     font: inherit;
+    font-weight: 500;
+    line-height: 1.25;
     white-space: nowrap;
     cursor: pointer;
+    transition: background-color .15s ease, border-color .15s ease, color .15s ease;
+}
+
+.code-group-tabs [role="tab"]:hover {
+    background: var(--code-group-tab-hover);
+    color: inherit;
 }
 
 .code-group-tabs [role="tab"][aria-selected="true"] {
-    border-bottom-color: currentcolor;
+    border-bottom-color: var(--code-group-accent);
+    color: var(--code-group-accent);
     font-weight: 600;
+}
+
+.code-group-tabs [role="tab"]:focus-visible {
+    z-index: 1;
+    outline: 2px solid var(--code-group-accent);
+    outline-offset: -2px;
 }
 
 .code-group-label {
@@ -44,4 +67,10 @@
 
 .code-group-panel > :last-child {
     margin-bottom: 0;
+}
+
+@media (prefers-reduced-motion: reduce) {
+    .code-group-tabs [role="tab"] {
+        transition: none;
+    }
 }

--- a/tests/Unit/Processor/CodeGroupProcessorTest.php
+++ b/tests/Unit/Processor/CodeGroupProcessorTest.php
@@ -7,6 +7,7 @@ namespace YiiPress\Tests\Unit\Processor;
 use DateTimeImmutable;
 use PHPUnit\Framework\TestCase;
 use YiiPress\Content\Model\Entry;
+use YiiPress\Processor\ContentProcessorPipeline;
 use YiiPress\Processor\MarkdownProcessor;
 use YiiPress\Processor\Shortcode\CodeGroupProcessor;
 use YiiPress\Render\MarkdownRenderer;
@@ -114,6 +115,31 @@ MARKDOWN;
         self::assertStringContainsString('src="../../assets/plugins/code-groups.js"', $assets);
     }
 
+    public function testEscapesPluginAssetUrls(): void
+    {
+        $processor = new CodeGroupProcessor();
+        $processor->applyRootPath('./\"><script>alert(1)</script>');
+
+        $assets = $processor->headAssets('<div class="code-group"></div>');
+
+        self::assertStringNotContainsString('<script>alert(1)</script>', $assets);
+        self::assertStringContainsString('&quot;&gt;&lt;script&gt;alert(1)&lt;/script&gt;', $assets);
+    }
+
+    public function testPipelineResetsRootPathWhenNextPageDoesNotProvideOne(): void
+    {
+        $processor = new CodeGroupProcessor();
+        $pipeline = new ContentProcessorPipeline($processor);
+
+        $pipeline->process('nested', $this->entry(), '../../');
+        $pipeline->process('root', $this->entry());
+
+        $assets = $pipeline->collectHeadAssets('<div class="code-group"></div>');
+
+        self::assertStringContainsString('href="./assets/plugins/code-groups.css"', $assets);
+        self::assertStringContainsString('src="./assets/plugins/code-groups.js"', $assets);
+    }
+
     public function testBrowserAssetsUseDelegationKeyboardNavigationAndProgressiveEnhancement(): void
     {
         $directory = dirname(__DIR__, 3) . '/src/Processor/Shortcode/assets/';
@@ -133,6 +159,8 @@ MARKDOWN;
         self::assertStringContainsString('.code-group-tabs [role="tab"]:hover', $style);
         self::assertStringContainsString('.code-group-tabs [role="tab"][aria-selected="true"]', $style);
         self::assertStringContainsString('.code-group-tabs [role="tab"]:focus-visible', $style);
+        self::assertStringContainsString('@media (prefers-reduced-motion: reduce)', $style);
+        self::assertStringContainsString('transition: none;', $style);
     }
 
     private function entry(): Entry

--- a/tests/Unit/Processor/CodeGroupProcessorTest.php
+++ b/tests/Unit/Processor/CodeGroupProcessorTest.php
@@ -103,6 +103,17 @@ MARKDOWN;
         self::assertCount(2, $processor->assetFiles());
     }
 
+    public function testProvidesRootRelativePluginAssetsForNestedPages(): void
+    {
+        $processor = new CodeGroupProcessor();
+        $processor->applyRootPath('../../');
+
+        $assets = $processor->headAssets('<div class="code-group"></div>');
+
+        self::assertStringContainsString('href="../../assets/plugins/code-groups.css"', $assets);
+        self::assertStringContainsString('src="../../assets/plugins/code-groups.js"', $assets);
+    }
+
     public function testBrowserAssetsUseDelegationKeyboardNavigationAndProgressiveEnhancement(): void
     {
         $directory = dirname(__DIR__, 3) . '/src/Processor/Shortcode/assets/';
@@ -119,6 +130,9 @@ MARKDOWN;
         self::assertStringContainsString("group.classList.add('is-enhanced')", $script);
         self::assertStringContainsString("if (!tab)", $script);
         self::assertStringContainsString('.code-group.is-enhanced .code-group-panel[hidden]', $style);
+        self::assertStringContainsString('.code-group-tabs [role="tab"]:hover', $style);
+        self::assertStringContainsString('.code-group-tabs [role="tab"][aria-selected="true"]', $style);
+        self::assertStringContainsString('.code-group-tabs [role="tab"]:focus-visible', $style);
     }
 
     private function entry(): Entry


### PR DESCRIPTION
## Summary

- style code alternatives as accessible tabs with active, hover, and keyboard-focus states
- register root-relative plugin CSS and JavaScript URLs correctly for nested pages when fingerprinting is disabled
- document automatic code-group asset registration

## Tests

- `make test CLI_ARGS='tests/Unit/Processor/CodeGroupProcessorTest.php tests/Unit/Processor/ContentProcessorPipelineConfigTest.php tests/Unit/Build/AssetFileWriterTest.php'` (11 tests, 64 assertions)
- `make psalm`

The complete suite currently has 91 unrelated failures because the Docker test environment reads the launcher shebang as `php\r`; one additional existing Markdown assertion has a newline mismatch.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Code-group assets are now loaded automatically only on pages that contain code groups.
  - Assets work correctly on nested pages and when fingerprinting is disabled.

- **Style**
  - Improved code-group tabs with theme-aware colors, clearer selected and hover states, better spacing, and smoother transitions.
  - Added visible keyboard focus indicators and support for reduced-motion preferences.

- **Documentation**
  - Documented automatic registration and asset handling for code-group styles and scripts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->