### PR TITLE
Remove OpenSSL from static builds

### DIFF
--- a/benchmarks/SelfUpdaterBench.php
+++ b/benchmarks/SelfUpdaterBench.php
@@ -11,8 +11,12 @@ use PhpBench\Attributes\Revs;
 use PhpBench\Attributes\Warmup;
 use YiiPress\Update\Package;
 use YiiPress\Update\PackageLocator;
+use YiiPress\Update\PackageReplacerInterface;
 use YiiPress\Update\ReleaseClient;
 use YiiPress\Update\SelfUpdater;
+use YiiPress\Update\StreamUrlDownloader;
+
+use function rename;
 
 #[BeforeMethods('setUp')]
 #[AfterMethods('tearDown')]
@@ -37,7 +41,16 @@ final class SelfUpdaterBench
         $this->package = new Package($target, 'yiipress.phar');
         $this->updater = new SelfUpdater(
             new PackageLocator(),
-            new ReleaseClient('file://' . $this->directory . '/releases'),
+            new ReleaseClient(
+                'file://' . $this->directory . '/releases',
+                downloader: new StreamUrlDownloader(),
+            ),
+            new class implements PackageReplacerInterface {
+                public function replace(string $temporaryPath, string $targetPath): void
+                {
+                    rename($temporaryPath, $targetPath);
+                }
+            },
         );
     }
 

--- a/build/package-macos.sh
+++ b/build/package-macos.sh
@@ -5,7 +5,7 @@ set -euo pipefail
 ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 PHP_VERSION="${PHP_VERSION:-8.5}"
 STATIC_PHP_CLI_REF="${STATIC_PHP_CLI_REF:-5b5861c366a0d94bc84002db7b3f46144b388fbb}"
-STATIC_PHP_EXTENSIONS="${STATIC_PHP_EXTENSIONS:-ctype,dom,filter,highlighter,mdparser,mbstring,opcache,openssl,pcntl,phar,posix,xmlwriter,yaml}"
+STATIC_PHP_EXTENSIONS="${STATIC_PHP_EXTENSIONS:-ctype,dom,filter,highlighter,mdparser,mbstring,opcache,pcntl,phar,posix,xmlwriter,yaml}"
 
 detect_arch() {
     case "$(uname -m)" in

--- a/build/package-windows.ps1
+++ b/build/package-windows.ps1
@@ -2,7 +2,7 @@ param(
     [string] $DistDir = "dist/windows-amd64",
     [string] $PhpVersion = "8.5",
     [string] $StaticPhpCliRef = "5b5861c366a0d94bc84002db7b3f46144b388fbb",
-    [string] $StaticPhpExtensions = "ctype,dom,filter,highlighter,mdparser,mbstring,opcache,openssl,phar,xmlwriter,yaml"
+    [string] $StaticPhpExtensions = "ctype,dom,filter,highlighter,mdparser,mbstring,opcache,phar,xmlwriter,yaml"
 )
 
 $ErrorActionPreference = "Stop"

--- a/build/static-php/patch-source-config.php
+++ b/build/static-php/patch-source-config.php
@@ -25,10 +25,6 @@ $pinnedSources = [
         'url' => 'https://pyyaml.org/download/libyaml/yaml-0.2.5.tar.gz',
         'filename' => 'yaml-0.2.5.tar.gz',
     ],
-    'openssl' => [
-        'url' => 'https://github.com/openssl/openssl/releases/download/openssl-3.5.4/openssl-3.5.4.tar.gz',
-        'filename' => 'openssl-3.5.4.tar.gz',
-    ],
     'zlib' => [
         'url' => 'https://github.com/madler/zlib/releases/download/v1.3.1/zlib-1.3.1.tar.gz',
         'filename' => 'zlib-1.3.1.tar.gz',

--- a/composer-dependency-analyser.php
+++ b/composer-dependency-analyser.php
@@ -15,8 +15,6 @@ return (new Configuration())
     ->addPathToScan($root . '/yii', isDev: false)
     ->addPathToScan($root . '/tests', isDev: true)
     ->ignoreErrorsOnPackage('psr/container', [ErrorType::UNUSED_DEPENDENCY])
-    // Required by PHP's HTTPS stream wrapper used by ReleaseClient.
-    ->ignoreErrorsOnExtension('ext-openssl', [ErrorType::UNUSED_DEPENDENCY])
     ->ignoreErrorsOnPackage('yiisoft/config', [ErrorType::UNUSED_DEPENDENCY])
     ->ignoreErrorsOnPackage('yiisoft/di', [ErrorType::UNUSED_DEPENDENCY])
     ->ignoreErrorsOnPackage('yiisoft/yii-event', [ErrorType::UNUSED_DEPENDENCY])

--- a/composer.json
+++ b/composer.json
@@ -40,7 +40,6 @@
         "ext-inotify": "*",
         "ext-mdparser": "*",
         "ext-mbstring": "*",
-        "ext-openssl": "*",
         "ext-pcntl": "*",
         "ext-posix": "*",
         "ext-xmlwriter": "*",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "ad75f156ad68bb887545011b7e73cf63",
+    "content-hash": "78267b02298cb5573fc1a5565f4357a9",
     "packages": [
         {
             "name": "alexkart/curl-builder",
@@ -10400,7 +10400,6 @@
         "ext-inotify": "*",
         "ext-mdparser": "*",
         "ext-mbstring": "*",
-        "ext-openssl": "*",
         "ext-pcntl": "*",
         "ext-posix": "*",
         "ext-xmlwriter": "*",

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -137,7 +137,7 @@ RUN --mount=type=cache,target=/tmp/composer-cache \
 FROM app-base AS static-package
 ARG PHP_VERSION=8.5
 ARG STATIC_PHP_CLI_REF=5b5861c366a0d94bc84002db7b3f46144b388fbb
-ARG STATIC_PHP_EXTENSIONS=ctype,dom,filter,highlighter,inotify,mdparser,mbstring,opcache,openssl,pcntl,phar,posix,xmlwriter,yaml
+ARG STATIC_PHP_EXTENSIONS=ctype,dom,filter,highlighter,inotify,mdparser,mbstring,opcache,pcntl,phar,posix,xmlwriter,yaml
 ARG TARGETARCH
 ENV CARGO_HOME=/root/.cargo \
     RUSTUP_HOME=/usr/local/rustup \

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -178,10 +178,7 @@ ADD https://repo.packagist.org/p2/yiipress/highlighter.json /tmp/static-yiipress
 RUN --mount=type=cache,target=/tmp/composer-cache \
     curl -fsSL "https://github.com/crazywhalecc/static-php-cli/archive/${STATIC_PHP_CLI_REF}.tar.gz" \
     | tar -xz --strip-components=1 -C /static-php \
-    && COMPOSER_CACHE_DIR=/tmp/composer-cache composer install --no-dev --no-progress --no-interaction --classmap-authoritative \
-    && sed -i \
-        's#https://musl.libc.org/releases/{$musl_version_name}.tar.gz#https://github.com/ifduyue/musl/archive/refs/tags/v1.2.5.tar.gz#' \
-        src/SPC/doctor/item/LinuxMuslCheck.php
+    && COMPOSER_CACHE_DIR=/tmp/composer-cache composer install --no-dev --no-progress --no-interaction --classmap-authoritative
 RUN --mount=type=cache,target=/tmp/composer-cache \
     COMPOSER_CACHE_DIR=/tmp/composer-cache composer create-project --no-dev --no-progress --no-interaction iliaal/mdparser /opt/mdparser
 RUN --mount=type=cache,target=/tmp/composer-cache \
@@ -199,12 +196,7 @@ RUN --mount=type=cache,target=/root/.cargo/git \
     && bin/spc install-pkg upx \
     && mkdir -p buildroot/bin \
     && ln -sf /usr/bin/pkg-config buildroot/bin/pkg-config \
-    && attempts=0 \
-    && until SPC_TOOLCHAIN='SPC\toolchain\MuslToolchain' SPC_TARGET=x86_64-linux-musl bin/spc doctor --auto-fix; do \
-        attempts=$((attempts + 1)); \
-        [ "$attempts" -ge 3 ] && exit 1; \
-        sleep $((attempts * 5)); \
-    done \
+    && SPC_TOOLCHAIN='SPC\toolchain\MuslToolchain' SPC_TARGET=x86_64-linux-musl bin/spc doctor --auto-fix \
     && (HIGHLIGHTER_VERSION="$(php -r '$package = "yiipress/highlighter"; $data = json_decode(file_get_contents("/tmp/static-yiipress-highlighter.json"), true, 512, JSON_THROW_ON_ERROR); foreach ($data["packages"][$package] as $release) { $version = $release["version"]; if (!preg_match("/(?:^dev-|dev$|alpha|beta|RC)/i", $version)) { echo $version; exit(0); } } exit(1);')" \
         bin/spc build "${STATIC_PHP_EXTENSIONS}" --build-micro --with-micro-fake-cli --with-upx-pack -P /opt/register-yiipress-highlighter.php \
         || (tail -n 200 /static-php/log/spc.shell.log && false))

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -178,7 +178,10 @@ ADD https://repo.packagist.org/p2/yiipress/highlighter.json /tmp/static-yiipress
 RUN --mount=type=cache,target=/tmp/composer-cache \
     curl -fsSL "https://github.com/crazywhalecc/static-php-cli/archive/${STATIC_PHP_CLI_REF}.tar.gz" \
     | tar -xz --strip-components=1 -C /static-php \
-    && COMPOSER_CACHE_DIR=/tmp/composer-cache composer install --no-dev --no-progress --no-interaction --classmap-authoritative
+    && COMPOSER_CACHE_DIR=/tmp/composer-cache composer install --no-dev --no-progress --no-interaction --classmap-authoritative \
+    && sed -i \
+        's#https://musl.libc.org/releases/{$musl_version_name}.tar.gz#https://github.com/ifduyue/musl/archive/refs/tags/v1.2.5.tar.gz#' \
+        src/SPC/doctor/item/LinuxMuslCheck.php
 RUN --mount=type=cache,target=/tmp/composer-cache \
     COMPOSER_CACHE_DIR=/tmp/composer-cache composer create-project --no-dev --no-progress --no-interaction iliaal/mdparser /opt/mdparser
 RUN --mount=type=cache,target=/tmp/composer-cache \

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -196,7 +196,12 @@ RUN --mount=type=cache,target=/root/.cargo/git \
     && bin/spc install-pkg upx \
     && mkdir -p buildroot/bin \
     && ln -sf /usr/bin/pkg-config buildroot/bin/pkg-config \
-    && SPC_TOOLCHAIN='SPC\toolchain\MuslToolchain' SPC_TARGET=x86_64-linux-musl bin/spc doctor --auto-fix \
+    && attempts=0 \
+    && until SPC_TOOLCHAIN='SPC\toolchain\MuslToolchain' SPC_TARGET=x86_64-linux-musl bin/spc doctor --auto-fix; do \
+        attempts=$((attempts + 1)); \
+        [ "$attempts" -ge 3 ] && exit 1; \
+        sleep $((attempts * 5)); \
+    done \
     && (HIGHLIGHTER_VERSION="$(php -r '$package = "yiipress/highlighter"; $data = json_decode(file_get_contents("/tmp/static-yiipress-highlighter.json"), true, 512, JSON_THROW_ON_ERROR); foreach ($data["packages"][$package] as $release) { $version = $release["version"]; if (!preg_match("/(?:^dev-|dev$|alpha|beta|RC)/i", $version)) { echo $version; exit(0); } } exit(1);')" \
         bin/spc build "${STATIC_PHP_EXTENSIONS}" --build-micro --with-micro-fake-cli --with-upx-pack -P /opt/register-yiipress-highlighter.php \
         || (tail -n 200 /static-php/log/spc.shell.log && false))

--- a/docs/binaries-phar-docker.md
+++ b/docs/binaries-phar-docker.md
@@ -69,7 +69,7 @@ The PHAR builder copies only runtime inputs into the build stage: `config/`, `pu
 
 PHPDoc comments are stripped from packaged PHP files to keep the standalone PHAR and embedded static-binary PHAR smaller while preserving runtime comments, code, and dependency PHPDoc that is read through reflection at runtime. Benchmark fixture helpers, Composer's `installed.json`, VCS placeholders, and non-runtime type stubs are omitted because packaged commands do not need them.
 Packaged PHAR entries are gzip-compressed before the archive is finalized. The static binary appends that same PHAR to the micro SAPI executable, so PHAR compression reduces both the standalone PHAR and the Linux, macOS, and Windows static executables.
-The static executable includes `ext-highlighter`, so syntax highlighting does not need FFI or an external shared library, and `ext-openssl` for HTTPS self-updates. `serve` uses ReactPHP stream sockets, serves built files and live reload SSE in the server loop, keeps one shared live reload watcher per server process, and does not require PHP's native `sockets` extension. On POSIX platforms with PCNTL and signal support, `serve` can prefork worker processes; Windows static binaries run a single server process.
+The static executable includes `ext-highlighter`, so syntax highlighting does not need FFI or an external shared library. It intentionally omits `ext-openssl`; self-update uses an available host downloader instead. `serve` uses ReactPHP stream sockets, serves built files and live reload SSE in the server loop, keeps one shared live reload watcher per server process, and does not require PHP's native `sockets` extension. On POSIX platforms with PCNTL and signal support, `serve` can prefork worker processes; Windows static binaries run a single server process.
 Relative `content-dir`, `output-dir`, `new`, `clean`, `serve`, and `import` paths are resolved from the directory where you run `yiipress`, not from the packaged executable location.
 PHAR and static binary runs keep build cache and incremental manifests under the OS temp directory, keyed by the current project directory, instead of writing to `runtime/` in the site checkout. `yiipress clean` removes that packaged cache as well as the configured output directory.
 
@@ -79,6 +79,11 @@ Packaged installations update themselves from release metadata and verify downlo
 yiipress self-update
 yiipress self-update --nightly
 ```
+
+The updater prefers `curl`, then uses the PHP HTTPS wrapper when the host PHP provides it,
+PowerShell on Windows, or `wget` on Linux and macOS. If none is available, install `curl`
+and retry. Distroless containers should be updated by pulling a newer image rather than by
+running `self-update` inside the container.
 
 The first command installs the latest stable release. The second installs the newest nightly prerelease containing a compatible package. Static binaries identify their outer executable through the micro SAPI runtime. The verified replacement is staged beside the installed package and activated only after normal command shutdown, avoiding stale PHAR metadata while the old package is still running. If a nightly package is unavailable for the current installation type or platform, the command reports that clearly instead of selecting an incompatible asset. Composer/source checkouts must be updated with Composer instead.
 

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -381,6 +381,9 @@ yiipress self-update --nightly
 
 The command is intentionally unavailable in a Composer/source checkout. Use Composer to update those installations. Before downloading a release, the command verifies that the user can write to the installed PHAR or binary directory and reports an actionable permissions error otherwise.
 The verified package is staged next to the installation and replacement is deferred until the running command has shut down, so PHP never reads the new archive using cached metadata from the old one. On Windows, replacement is completed by a short-lived background helper after the running command exits.
+Downloads prefer `curl`, then an existing PHP HTTPS wrapper, PowerShell on Windows, or
+`wget` on Linux and macOS. Install `curl` if no supported downloader is available. Container
+images should be updated by pulling a newer image instead of running this command.
 
 ## `clean` / `clear`
 

--- a/src/Update/AvailableUrlDownloader.php
+++ b/src/Update/AvailableUrlDownloader.php
@@ -11,11 +11,14 @@ use function fclose;
 use function in_array;
 use function is_file;
 use function is_resource;
+use function is_string;
+use function parse_url;
 use function proc_close;
 use function proc_open;
 use function stream_get_contents;
 use function stream_get_wrappers;
 use function strlen;
+use function strtolower;
 use function substr;
 use function trim;
 use function unlink;
@@ -41,9 +44,14 @@ final class AvailableUrlDownloader implements UrlDownloaderInterface
 
     public function download(string $url, string $destination): void
     {
-        $transport = $this->transport ??= $this->selectTransport();
         @unlink($destination);
 
+        if (!$this->isHttpUrl($url)) {
+            (new StreamUrlDownloader())->download($url, $destination);
+            return;
+        }
+
+        $transport = $this->transport ??= $this->selectTransport();
         if ($transport === 'stream') {
             (new StreamUrlDownloader())->download($url, $destination);
             return;
@@ -80,6 +88,13 @@ final class AvailableUrlDownloader implements UrlDownloaderInterface
             $details = $this->errorDetails($result['stderr']);
             throw new RuntimeException("Could not download $url using $transport.$details");
         }
+    }
+
+    private function isHttpUrl(string $url): bool
+    {
+        $scheme = parse_url($url, PHP_URL_SCHEME);
+
+        return is_string($scheme) && in_array(strtolower($scheme), ['http', 'https'], true);
     }
 
     private function selectTransport(): string

--- a/src/Update/AvailableUrlDownloader.php
+++ b/src/Update/AvailableUrlDownloader.php
@@ -1,0 +1,161 @@
+<?php
+
+declare(strict_types=1);
+
+namespace YiiPress\Update;
+
+use Closure;
+use RuntimeException;
+
+use function fclose;
+use function in_array;
+use function is_file;
+use function is_resource;
+use function proc_close;
+use function proc_open;
+use function stream_get_contents;
+use function stream_get_wrappers;
+use function strlen;
+use function substr;
+use function trim;
+use function unlink;
+
+final class AvailableUrlDownloader implements UrlDownloaderInterface
+{
+    private const int MAX_ERROR_LENGTH = 2_000;
+
+    /** @var Closure(list<string>): array{exitCode: int, stdout: string, stderr: string} */
+    private Closure $runner;
+    private ?string $transport = null;
+
+    /**
+     * @param null|callable(list<string>): array{exitCode: int, stdout: string, stderr: string} $runner
+     */
+    public function __construct(
+        ?callable $runner = null,
+        private readonly string $osFamily = PHP_OS_FAMILY,
+        private readonly ?bool $httpsStreamAvailable = null,
+    ) {
+        $this->runner = $runner === null ? $this->run(...) : Closure::fromCallable($runner);
+    }
+
+    public function download(string $url, string $destination): void
+    {
+        $transport = $this->transport ??= $this->selectTransport();
+        @unlink($destination);
+
+        if ($transport === 'stream') {
+            (new StreamUrlDownloader())->download($url, $destination);
+            return;
+        }
+
+        $command = match ($transport) {
+            'curl' => [
+                'curl', '--fail', '--location', '--silent', '--show-error', '--retry', '3',
+                '--retry-delay', '2', '--connect-timeout', '30', '--max-time', '300',
+                '--output', $destination, $url,
+            ],
+            'wget' => ['wget', '-q', '-T', '30', '-t', '3', '-O', $destination, $url],
+            'pwsh', 'powershell.exe' => [
+                $transport,
+                '-NoLogo',
+                '-NoProfile',
+                '-NonInteractive',
+                '-Command',
+                '$ProgressPreference = "SilentlyContinue"; '
+                . '$lastError = $null; '
+                . 'for ($attempt = 1; $attempt -le 3; $attempt++) { '
+                . 'try { Invoke-WebRequest -UseBasicParsing -TimeoutSec 300 -Uri $args[0] -OutFile $args[1]; exit 0 } '
+                . 'catch { $lastError = $_; if ($attempt -lt 3) { Start-Sleep -Seconds 2 } } }; '
+                . 'Write-Error $lastError; exit 1',
+                $url,
+                $destination,
+            ],
+            default => throw new RuntimeException("Unsupported download transport: $transport."),
+        };
+
+        $result = ($this->runner)($command);
+        if ($result['exitCode'] !== 0 || !is_file($destination)) {
+            @unlink($destination);
+            $details = $this->errorDetails($result['stderr']);
+            throw new RuntimeException("Could not download $url using $transport.$details");
+        }
+    }
+
+    private function selectTransport(): string
+    {
+        if ($this->available(['curl', '--version'])) {
+            return 'curl';
+        }
+
+        if ($this->httpsStreamAvailable ?? in_array('https', stream_get_wrappers(), true)) {
+            return 'stream';
+        }
+
+        if ($this->osFamily === 'Windows') {
+            if ($this->available(['pwsh', '-NoLogo', '-NoProfile', '-NonInteractive', '-Command', 'exit 0'])) {
+                return 'pwsh';
+            }
+            if ($this->available(['powershell.exe', '-NoLogo', '-NoProfile', '-NonInteractive', '-Command', 'exit 0'])) {
+                return 'powershell.exe';
+            }
+        } elseif ($this->available(['wget', '--help'])) {
+            return 'wget';
+        }
+
+        throw new RuntimeException(
+            'Self-update requires curl or another HTTPS downloader. Install curl and retry. '
+            . 'In a container, pull a newer YiiPress image instead.',
+        );
+    }
+
+    /** @param list<string> $command */
+    private function available(array $command): bool
+    {
+        return ($this->runner)($command)['exitCode'] === 0;
+    }
+
+    private function errorDetails(string $stderr): string
+    {
+        $stderr = trim($stderr);
+        if ($stderr === '') {
+            return '';
+        }
+
+        if (strlen($stderr) > self::MAX_ERROR_LENGTH) {
+            $stderr = substr($stderr, 0, self::MAX_ERROR_LENGTH) . '…';
+        }
+
+        return ' ' . $stderr;
+    }
+
+    /**
+     * @param list<string> $command
+     * @return array{exitCode: int, stdout: string, stderr: string}
+     */
+    private function run(array $command): array
+    {
+        $pipes = [];
+        $process = @proc_open(
+            $command,
+            [0 => ['pipe', 'r'], 1 => ['pipe', 'w'], 2 => ['pipe', 'w']],
+            $pipes,
+            options: ['bypass_shell' => true],
+        );
+        if (!is_resource($process)) {
+            return ['exitCode' => 127, 'stdout' => '', 'stderr' => 'Could not start ' . $command[0] . '.'];
+        }
+
+        fclose($pipes[0]);
+        $stdout = stream_get_contents($pipes[1]);
+        $stderr = stream_get_contents($pipes[2]);
+        fclose($pipes[1]);
+        fclose($pipes[2]);
+
+        return [
+            'exitCode' => proc_close($process),
+            'stdout' => $stdout === false ? '' : $stdout,
+            'stderr' => $stderr === false ? '' : $stderr,
+        ];
+    }
+}

--- a/src/Update/AvailableUrlDownloader.php
+++ b/src/Update/AvailableUrlDownloader.php
@@ -8,10 +8,12 @@ use Closure;
 use RuntimeException;
 
 use function fclose;
+use function getenv;
 use function in_array;
 use function is_file;
 use function is_resource;
 use function is_string;
+use function mb_strcut;
 use function parse_url;
 use function proc_close;
 use function proc_open;
@@ -19,7 +21,6 @@ use function stream_get_contents;
 use function stream_get_wrappers;
 use function strlen;
 use function strtolower;
-use function substr;
 use function trim;
 use function unlink;
 
@@ -27,12 +28,12 @@ final class AvailableUrlDownloader implements UrlDownloaderInterface
 {
     private const int MAX_ERROR_LENGTH = 2_000;
 
-    /** @var Closure(list<string>): array{exitCode: int, stdout: string, stderr: string} */
+    /** @var Closure(list<string>, array<string, string>): array{exitCode: int, stdout: string, stderr: string} */
     private Closure $runner;
     private ?string $transport = null;
 
     /**
-     * @param null|callable(list<string>): array{exitCode: int, stdout: string, stderr: string} $runner
+     * @param null|callable(list<string>, array<string, string>): array{exitCode: int, stdout: string, stderr: string} $runner
      */
     public function __construct(
         ?callable $runner = null,
@@ -73,16 +74,18 @@ final class AvailableUrlDownloader implements UrlDownloaderInterface
                 '$ProgressPreference = "SilentlyContinue"; '
                 . '$lastError = $null; '
                 . 'for ($attempt = 1; $attempt -le 3; $attempt++) { '
-                . 'try { Invoke-WebRequest -UseBasicParsing -TimeoutSec 300 -Uri $args[0] -OutFile $args[1]; exit 0 } '
+                . 'try { Invoke-WebRequest -UseBasicParsing -TimeoutSec 300 '
+                . '-Uri $env:YIIPRESS_DOWNLOAD_URL -OutFile $env:YIIPRESS_DOWNLOAD_DESTINATION; exit 0 } '
                 . 'catch { $lastError = $_; if ($attempt -lt 3) { Start-Sleep -Seconds 2 } } }; '
                 . 'Write-Error $lastError; exit 1',
-                $url,
-                $destination,
             ],
             default => throw new RuntimeException("Unsupported download transport: $transport."),
         };
 
-        $result = ($this->runner)($command);
+        $environment = in_array($transport, ['pwsh', 'powershell.exe'], true)
+            ? ['YIIPRESS_DOWNLOAD_URL' => $url, 'YIIPRESS_DOWNLOAD_DESTINATION' => $destination]
+            : [];
+        $result = ($this->runner)($command, $environment);
         if ($result['exitCode'] !== 0 || !is_file($destination)) {
             @unlink($destination);
             $details = $this->errorDetails($result['stderr']);
@@ -127,7 +130,7 @@ final class AvailableUrlDownloader implements UrlDownloaderInterface
     /** @param list<string> $command */
     private function available(array $command): bool
     {
-        return ($this->runner)($command)['exitCode'] === 0;
+        return ($this->runner)($command, [])['exitCode'] === 0;
     }
 
     private function errorDetails(string $stderr): string
@@ -138,7 +141,7 @@ final class AvailableUrlDownloader implements UrlDownloaderInterface
         }
 
         if (strlen($stderr) > self::MAX_ERROR_LENGTH) {
-            $stderr = substr($stderr, 0, self::MAX_ERROR_LENGTH) . '…';
+            $stderr = mb_strcut($stderr, 0, self::MAX_ERROR_LENGTH) . '…';
         }
 
         return ' ' . $stderr;
@@ -148,13 +151,17 @@ final class AvailableUrlDownloader implements UrlDownloaderInterface
      * @param list<string> $command
      * @return array{exitCode: int, stdout: string, stderr: string}
      */
-    private function run(array $command): array
+    private function run(array $command, array $environment): array
     {
         $pipes = [];
+        $inheritedEnvironment = getenv();
         $process = @proc_open(
             $command,
             [0 => ['pipe', 'r'], 1 => ['pipe', 'w'], 2 => ['pipe', 'w']],
             $pipes,
+            env_vars: $environment === []
+                ? null
+                : [...$inheritedEnvironment, ...$environment],
             options: ['bypass_shell' => true],
         );
         if (!is_resource($process)) {

--- a/src/Update/PackageReplacer.php
+++ b/src/Update/PackageReplacer.php
@@ -17,7 +17,7 @@ use function rename;
 use function str_contains;
 use function unlink;
 
-final readonly class PackageReplacer
+final readonly class PackageReplacer implements PackageReplacerInterface
 {
     /** @var Closure(Closure(): void): void */
     private Closure $shutdownRegistrar;
@@ -51,7 +51,6 @@ final readonly class PackageReplacer
                     ($this->failureHandler)("Could not replace $targetPath. Check its permissions.");
                 }
             });
-
             return;
         }
 

--- a/src/Update/PackageReplacerInterface.php
+++ b/src/Update/PackageReplacerInterface.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+namespace YiiPress\Update;
+
+interface PackageReplacerInterface
+{
+    public function replace(string $temporaryPath, string $targetPath): void;
+}

--- a/src/Update/ReleaseClient.php
+++ b/src/Update/ReleaseClient.php
@@ -7,13 +7,14 @@ namespace YiiPress\Update;
 use JsonException;
 use RuntimeException;
 
-use function fclose;
-use function fopen;
+use function bin2hex;
+use function file_get_contents;
 use function is_array;
 use function is_string;
 use function json_decode;
+use function random_bytes;
 use function sprintf;
-use function stream_copy_to_stream;
+use function sys_get_temp_dir;
 use function unlink;
 use function str_starts_with;
 
@@ -26,6 +27,7 @@ final class ReleaseClient
     public function __construct(
         private readonly string $downloadBaseUrl = 'https://github.com/' . self::REPOSITORY . '/releases',
         private readonly string $apiUrl = 'https://api.github.com/repos/' . self::REPOSITORY . '/releases?per_page=100',
+        private readonly UrlDownloaderInterface $downloader = new AvailableUrlDownloader(),
     ) {}
 
     /** @return array{version: string, checksums: string} */
@@ -82,47 +84,23 @@ final class ReleaseClient
 
     private function get(string $url): string
     {
-        $context = stream_context_create(['http' => ['header' => "User-Agent: YiiPress self-update\r\n", 'timeout' => 30]]);
-        $stream = @fopen($url, 'rb', false, $context);
-        if ($stream === false) {
-            throw new RuntimeException("Could not download $url.");
-        }
+        $destination = sys_get_temp_dir() . '/yiipress-metadata-' . bin2hex(random_bytes(16));
 
         try {
-            $contents = stream_get_contents($stream);
+            $this->downloader->download($url, $destination);
+            $contents = file_get_contents($destination);
             if ($contents === false) {
                 throw new RuntimeException("Could not download $url.");
             }
 
             return $contents;
         } finally {
-            fclose($stream);
+            @unlink($destination);
         }
     }
 
     private function downloadTo(string $url, string $destination): void
     {
-        $context = stream_context_create(['http' => ['header' => "User-Agent: YiiPress self-update\r\n", 'timeout' => 30]]);
-        $source = @fopen($url, 'rb', false, $context);
-        if ($source === false) {
-            throw new RuntimeException("Could not download $url.");
-        }
-        $target = @fopen($destination, 'wb');
-        if ($target === false) {
-            fclose($source);
-            throw new RuntimeException("Could not write temporary update file $destination.");
-        }
-
-        $copied = false;
-        try {
-            $copied = stream_copy_to_stream($source, $target) !== false;
-        } finally {
-            fclose($source);
-            fclose($target);
-        }
-        if (!$copied) {
-            @unlink($destination);
-            throw new RuntimeException("Could not download $url.");
-        }
+        $this->downloader->download($url, $destination);
     }
 }

--- a/src/Update/SelfUpdater.php
+++ b/src/Update/SelfUpdater.php
@@ -28,7 +28,7 @@ final readonly class SelfUpdater
     public function __construct(
         private PackageLocator $packageLocator,
         private ReleaseClient $releaseClient,
-        private PackageReplacer $packageReplacer = new PackageReplacer(),
+        private PackageReplacerInterface $packageReplacer = new PackageReplacer(),
     ) {}
 
     public function update(bool $nightly = false, ?Package $package = null): string

--- a/src/Update/StreamUrlDownloader.php
+++ b/src/Update/StreamUrlDownloader.php
@@ -9,6 +9,7 @@ use RuntimeException;
 use function fclose;
 use function fopen;
 use function stream_copy_to_stream;
+use function stream_context_create;
 use function unlink;
 
 final readonly class StreamUrlDownloader implements UrlDownloaderInterface

--- a/src/Update/StreamUrlDownloader.php
+++ b/src/Update/StreamUrlDownloader.php
@@ -1,0 +1,43 @@
+<?php
+
+declare(strict_types=1);
+
+namespace YiiPress\Update;
+
+use RuntimeException;
+
+use function fclose;
+use function fopen;
+use function stream_copy_to_stream;
+use function unlink;
+
+final readonly class StreamUrlDownloader implements UrlDownloaderInterface
+{
+    public function download(string $url, string $destination): void
+    {
+        $context = stream_context_create(['http' => ['header' => "User-Agent: YiiPress self-update\r\n", 'timeout' => 30]]);
+        $source = @fopen($url, 'rb', false, $context);
+        if ($source === false) {
+            throw new RuntimeException("Could not download $url.");
+        }
+
+        $target = @fopen($destination, 'wb');
+        if ($target === false) {
+            fclose($source);
+            throw new RuntimeException("Could not write temporary update file $destination.");
+        }
+
+        $copied = false;
+        try {
+            $copied = stream_copy_to_stream($source, $target) !== false;
+        } finally {
+            fclose($source);
+            fclose($target);
+        }
+
+        if (!$copied) {
+            @unlink($destination);
+            throw new RuntimeException("Could not download $url.");
+        }
+    }
+}

--- a/src/Update/UrlDownloaderInterface.php
+++ b/src/Update/UrlDownloaderInterface.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+namespace YiiPress\Update;
+
+interface UrlDownloaderInterface
+{
+    public function download(string $url, string $destination): void;
+}

--- a/tests/Unit/Packaging/ConfigurationPackagingTest.php
+++ b/tests/Unit/Packaging/ConfigurationPackagingTest.php
@@ -168,6 +168,10 @@ final class ConfigurationPackagingTest extends TestCase
             $dockerfile,
         );
         self::assertStringContainsString('[ "$attempts" -ge 3 ] && exit 1', $dockerfile);
+        self::assertStringContainsString(
+            'https://github.com/ifduyue/musl/archive/refs/tags/v1.2.5.tar.gz',
+            $dockerfile,
+        );
     }
 
     #[Test]

--- a/tests/Unit/Packaging/ConfigurationPackagingTest.php
+++ b/tests/Unit/Packaging/ConfigurationPackagingTest.php
@@ -158,23 +158,6 @@ final class ConfigurationPackagingTest extends TestCase
     }
 
     #[Test]
-    public function linuxStaticBuildRetriesMuslToolchainBootstrap(): void
-    {
-        $dockerfile = file_get_contents(dirname(__DIR__, 3) . '/docker/Dockerfile');
-        self::assertIsString($dockerfile);
-
-        self::assertStringContainsString(
-            "until SPC_TOOLCHAIN='SPC\\toolchain\\MuslToolchain' SPC_TARGET=x86_64-linux-musl bin/spc doctor --auto-fix",
-            $dockerfile,
-        );
-        self::assertStringContainsString('[ "$attempts" -ge 3 ] && exit 1', $dockerfile);
-        self::assertStringContainsString(
-            'https://github.com/ifduyue/musl/archive/refs/tags/v1.2.5.tar.gz',
-            $dockerfile,
-        );
-    }
-
-    #[Test]
     public function distrolessImageCopiesOnlyStaticBinary(): void
     {
         $dockerfile = file_get_contents(dirname(__DIR__, 3) . '/docker/Dockerfile');

--- a/tests/Unit/Packaging/ConfigurationPackagingTest.php
+++ b/tests/Unit/Packaging/ConfigurationPackagingTest.php
@@ -158,6 +158,19 @@ final class ConfigurationPackagingTest extends TestCase
     }
 
     #[Test]
+    public function linuxStaticBuildRetriesMuslToolchainBootstrap(): void
+    {
+        $dockerfile = file_get_contents(dirname(__DIR__, 3) . '/docker/Dockerfile');
+        self::assertIsString($dockerfile);
+
+        self::assertStringContainsString(
+            "until SPC_TOOLCHAIN='SPC\\toolchain\\MuslToolchain' SPC_TARGET=x86_64-linux-musl bin/spc doctor --auto-fix",
+            $dockerfile,
+        );
+        self::assertStringContainsString('[ "$attempts" -ge 3 ] && exit 1', $dockerfile);
+    }
+
+    #[Test]
     public function distrolessImageCopiesOnlyStaticBinary(): void
     {
         $dockerfile = file_get_contents(dirname(__DIR__, 3) . '/docker/Dockerfile');

--- a/tests/Unit/Packaging/ConfigurationPackagingTest.php
+++ b/tests/Unit/Packaging/ConfigurationPackagingTest.php
@@ -139,6 +139,25 @@ final class ConfigurationPackagingTest extends TestCase
     }
 
     #[Test]
+    public function shippedStaticBinariesOmitOpenSsl(): void
+    {
+        $root = dirname(__DIR__, 3);
+        $dockerfile = file_get_contents($root . '/docker/Dockerfile');
+        $macosScript = file_get_contents($root . '/build/package-macos.sh');
+        $windowsScript = file_get_contents($root . '/build/package-windows.ps1');
+        $composer = file_get_contents($root . '/composer.json');
+
+        self::assertIsString($dockerfile);
+        self::assertIsString($macosScript);
+        self::assertIsString($windowsScript);
+        self::assertIsString($composer);
+        self::assertDoesNotMatchRegularExpression('/STATIC_PHP_EXTENSIONS=.*openssl/', $dockerfile);
+        self::assertDoesNotMatchRegularExpression('/STATIC_PHP_EXTENSIONS=.*openssl/', $macosScript);
+        self::assertDoesNotMatchRegularExpression('/StaticPhpExtensions = .*openssl/', $windowsScript);
+        self::assertStringNotContainsString('"ext-openssl"', $composer);
+    }
+
+    #[Test]
     public function distrolessImageCopiesOnlyStaticBinary(): void
     {
         $dockerfile = file_get_contents(dirname(__DIR__, 3) . '/docker/Dockerfile');
@@ -235,6 +254,7 @@ final class ConfigurationPackagingTest extends TestCase
         self::assertStringContainsString('highlighter.lib', $script);
         self::assertStringContainsString('$env:RUSTFLAGS = "-C target-feature=+crt-static"', $script);
         self::assertStringContainsString('upx', $script);
+        self::assertStringNotContainsString('opcache,openssl,phar', $script);
     }
 
     #[Test]
@@ -272,6 +292,7 @@ final class ConfigurationPackagingTest extends TestCase
         self::assertStringContainsString('rustup target add "$CARGO_BUILD_TARGET"', $script);
         self::assertStringContainsString('cargo build --release --target "$CARGO_BUILD_TARGET"', $script);
         self::assertStringContainsString('chmod +x "$BIN_PATH"', $script);
+        self::assertStringNotContainsString('opcache,openssl,pcntl', $script);
     }
 
     #[Test]
@@ -609,7 +630,6 @@ final class ConfigurationPackagingTest extends TestCase
                         'curl' => ['repo' => 'curl/curl', 'match' => '^curl-(.*)$', 'prefer-stable' => true, 'alt' => []],
                         'icu' => ['repo' => 'unicode-org/icu', 'match' => '^release-(.*)$', 'prefer-stable' => true, 'alt' => []],
                         'libyaml' => ['repo' => 'yaml/libyaml', 'match' => '^(.*)$', 'prefer-stable' => true, 'alt' => []],
-                        'openssl' => ['repo' => 'openssl/openssl', 'match' => '^openssl-(.*)$', 'prefer-stable' => true, 'alt' => []],
                         'zlib' => ['repo' => 'madler/zlib', 'match' => '^(.*)$', 'prefer-stable' => true, 'alt' => []],
                     ],
                     JSON_THROW_ON_ERROR,

--- a/tests/Unit/Update/AvailableUrlDownloaderTest.php
+++ b/tests/Unit/Update/AvailableUrlDownloaderTest.php
@@ -69,7 +69,7 @@ final class AvailableUrlDownloaderTest extends TestCase
     }
 
     #[Test]
-    public function usesPhpStreamsBeforePlatformCommands(): void
+    public function usesPhpStreamsForNonHttpUrlsWithoutProbingPlatformCommands(): void
     {
         $commands = [];
         $runner = static function (array $command) use (&$commands): array {
@@ -87,7 +87,7 @@ final class AvailableUrlDownloaderTest extends TestCase
         }
 
         self::assertSame('streamed', file_get_contents($this->destination));
-        self::assertSame([['curl', '--version']], $commands);
+        self::assertSame([], $commands);
     }
 
     #[Test]

--- a/tests/Unit/Update/AvailableUrlDownloaderTest.php
+++ b/tests/Unit/Update/AvailableUrlDownloaderTest.php
@@ -12,6 +12,8 @@ use YiiPress\Update\AvailableUrlDownloader;
 use function array_filter;
 use function file_get_contents;
 use function file_put_contents;
+use function mb_check_encoding;
+use function str_repeat;
 use function sys_get_temp_dir;
 use function unlink;
 use function uniqid;
@@ -34,7 +36,7 @@ final class AvailableUrlDownloaderTest extends TestCase
     public function prefersCurlAndCachesSelection(): void
     {
         $commands = [];
-        $runner = static function (array $command) use (&$commands): array {
+        $runner = static function (array $command, array $environment = []) use (&$commands): array {
             $commands[] = $command;
             if ($command === ['curl', '--version']) {
                 return self::commandResult();
@@ -72,7 +74,7 @@ final class AvailableUrlDownloaderTest extends TestCase
     public function usesPhpStreamsForNonHttpUrlsWithoutProbingPlatformCommands(): void
     {
         $commands = [];
-        $runner = static function (array $command) use (&$commands): array {
+        $runner = static function (array $command, array $environment = []) use (&$commands): array {
             $commands[] = $command;
             return self::commandResult(127);
         };
@@ -94,7 +96,7 @@ final class AvailableUrlDownloaderTest extends TestCase
     public function usesWgetOnUnix(): void
     {
         $commands = [];
-        $runner = static function (array $command) use (&$commands): array {
+        $runner = static function (array $command, array $environment = []) use (&$commands): array {
             $commands[] = $command;
             if ($command === ['wget', '--help']) {
                 return self::commandResult();
@@ -119,13 +121,15 @@ final class AvailableUrlDownloaderTest extends TestCase
     public function usesPowerShellOnWindows(): void
     {
         $commands = [];
-        $runner = static function (array $command) use (&$commands): array {
+        $environments = [];
+        $runner = static function (array $command, array $environment = []) use (&$commands, &$environments): array {
             $commands[] = $command;
+            $environments[] = $environment;
             if ($command[0] === 'pwsh' && $command[5] === 'exit 0') {
                 return self::commandResult();
             }
             if ($command[0] === 'pwsh') {
-                file_put_contents($command[7], 'downloaded');
+                file_put_contents($environment['YIIPRESS_DOWNLOAD_DESTINATION'], 'downloaded');
                 return self::commandResult();
             }
             return self::commandResult(127);
@@ -137,13 +141,16 @@ final class AvailableUrlDownloaderTest extends TestCase
         self::assertSame('downloaded', file_get_contents($this->destination));
         self::assertSame('pwsh', $commands[2][0]);
         self::assertStringContainsString('Invoke-WebRequest', $commands[2][5]);
+        self::assertStringContainsString('$env:YIIPRESS_DOWNLOAD_URL', $commands[2][5]);
+        self::assertSame('https://example.com/package', $environments[2]['YIIPRESS_DOWNLOAD_URL']);
+        self::assertSame($this->destination, $environments[2]['YIIPRESS_DOWNLOAD_DESTINATION']);
     }
 
     #[Test]
     public function doesNotFallBackAfterTransferFailure(): void
     {
         $commands = [];
-        $runner = static function (array $command) use (&$commands): array {
+        $runner = static function (array $command, array $environment = []) use (&$commands): array {
             $commands[] = $command;
             return $command === ['curl', '--version']
                 ? self::commandResult()
@@ -166,13 +173,34 @@ final class AvailableUrlDownloaderTest extends TestCase
     public function reportsWhenNoDownloaderIsAvailable(): void
     {
         $downloader = new AvailableUrlDownloader(
-            static fn(array $command): array => self::commandResult(127),
+            static fn(array $command, array $environment = []): array => self::commandResult(127),
             'Linux',
             false,
         );
 
         $this->expectExceptionMessage('Install curl and retry');
         $downloader->download('https://example.com/package', $this->destination);
+    }
+
+    #[Test]
+    public function truncatesErrorDetailsWithoutSplittingUtf8Characters(): void
+    {
+        $stderr = str_repeat('a', 1_999) . '😀trailing';
+        $downloader = new AvailableUrlDownloader(
+            static fn(array $command, array $environment = []): array => $command === ['curl', '--version']
+                ? self::commandResult()
+                : self::commandResult(1, $stderr),
+            'Linux',
+            false,
+        );
+
+        try {
+            $downloader->download('https://example.com/package', $this->destination);
+            self::fail('Expected the download to fail.');
+        } catch (RuntimeException $exception) {
+            self::assertTrue(mb_check_encoding($exception->getMessage(), 'UTF-8'));
+            self::assertStringEndsWith(str_repeat('a', 1_999) . '…', $exception->getMessage());
+        }
     }
 
     /** @return array{exitCode: int, stdout: string, stderr: string} */

--- a/tests/Unit/Update/AvailableUrlDownloaderTest.php
+++ b/tests/Unit/Update/AvailableUrlDownloaderTest.php
@@ -1,0 +1,183 @@
+<?php
+
+declare(strict_types=1);
+
+namespace YiiPress\Tests\Unit\Update;
+
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+use RuntimeException;
+use YiiPress\Update\AvailableUrlDownloader;
+
+use function array_filter;
+use function file_get_contents;
+use function file_put_contents;
+use function sys_get_temp_dir;
+use function unlink;
+use function uniqid;
+
+final class AvailableUrlDownloaderTest extends TestCase
+{
+    private string $destination;
+
+    protected function setUp(): void
+    {
+        $this->destination = sys_get_temp_dir() . '/yiipress-downloader-' . uniqid('', true);
+    }
+
+    protected function tearDown(): void
+    {
+        @unlink($this->destination);
+    }
+
+    #[Test]
+    public function prefersCurlAndCachesSelection(): void
+    {
+        $commands = [];
+        $runner = static function (array $command) use (&$commands): array {
+            $commands[] = $command;
+            if ($command === ['curl', '--version']) {
+                return self::commandResult();
+            }
+            file_put_contents($command[14], 'downloaded');
+            return self::commandResult();
+        };
+        $downloader = new AvailableUrlDownloader($runner, httpsStreamAvailable: true);
+
+        $downloader->download('https://example.com/first', $this->destination);
+        $downloader->download('https://example.com/second', $this->destination);
+
+        self::assertSame('downloaded', file_get_contents($this->destination));
+        self::assertSame(['curl', '--version'], $commands[0]);
+        self::assertCount(1, array_filter($commands, static fn(array $command): bool => $command === ['curl', '--version']));
+        self::assertSame('https://example.com/second', $commands[2][15]);
+    }
+
+    #[Test]
+    public function downloadsWithAvailableHostTransport(): void
+    {
+        $source = sys_get_temp_dir() . '/yiipress-downloader-source-' . uniqid('', true);
+        file_put_contents($source, 'host transport');
+
+        try {
+            (new AvailableUrlDownloader())->download('file://' . $source, $this->destination);
+        } finally {
+            unlink($source);
+        }
+
+        self::assertSame('host transport', file_get_contents($this->destination));
+    }
+
+    #[Test]
+    public function usesPhpStreamsBeforePlatformCommands(): void
+    {
+        $commands = [];
+        $runner = static function (array $command) use (&$commands): array {
+            $commands[] = $command;
+            return self::commandResult(127);
+        };
+        $source = sys_get_temp_dir() . '/yiipress-downloader-source-' . uniqid('', true);
+        file_put_contents($source, 'streamed');
+
+        try {
+            $downloader = new AvailableUrlDownloader($runner, httpsStreamAvailable: true);
+            $downloader->download('file://' . $source, $this->destination);
+        } finally {
+            unlink($source);
+        }
+
+        self::assertSame('streamed', file_get_contents($this->destination));
+        self::assertSame([['curl', '--version']], $commands);
+    }
+
+    #[Test]
+    public function usesWgetOnUnix(): void
+    {
+        $commands = [];
+        $runner = static function (array $command) use (&$commands): array {
+            $commands[] = $command;
+            if ($command === ['wget', '--help']) {
+                return self::commandResult();
+            }
+            if ($command[0] === 'wget') {
+                file_put_contents($command[7], 'downloaded');
+                return self::commandResult();
+            }
+            return self::commandResult(127);
+        };
+        $downloader = new AvailableUrlDownloader($runner, 'Linux', false);
+
+        $downloader->download('https://example.com/package', $this->destination);
+
+        self::assertSame('downloaded', file_get_contents($this->destination));
+        self::assertSame(['curl', '--version'], $commands[0]);
+        self::assertSame(['wget', '--help'], $commands[1]);
+        self::assertSame('wget', $commands[2][0]);
+    }
+
+    #[Test]
+    public function usesPowerShellOnWindows(): void
+    {
+        $commands = [];
+        $runner = static function (array $command) use (&$commands): array {
+            $commands[] = $command;
+            if ($command[0] === 'pwsh' && $command[5] === 'exit 0') {
+                return self::commandResult();
+            }
+            if ($command[0] === 'pwsh') {
+                file_put_contents($command[7], 'downloaded');
+                return self::commandResult();
+            }
+            return self::commandResult(127);
+        };
+        $downloader = new AvailableUrlDownloader($runner, 'Windows', false);
+
+        $downloader->download('https://example.com/package', $this->destination);
+
+        self::assertSame('downloaded', file_get_contents($this->destination));
+        self::assertSame('pwsh', $commands[2][0]);
+        self::assertStringContainsString('Invoke-WebRequest', $commands[2][5]);
+    }
+
+    #[Test]
+    public function doesNotFallBackAfterTransferFailure(): void
+    {
+        $commands = [];
+        $runner = static function (array $command) use (&$commands): array {
+            $commands[] = $command;
+            return $command === ['curl', '--version']
+                ? self::commandResult()
+                : self::commandResult(22, 'certificate failure');
+        };
+        $downloader = new AvailableUrlDownloader($runner, 'Linux', false);
+
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessage('certificate failure');
+
+        try {
+            $downloader->download('https://example.com/package', $this->destination);
+        } finally {
+            self::assertCount(2, $commands);
+            self::assertFileDoesNotExist($this->destination);
+        }
+    }
+
+    #[Test]
+    public function reportsWhenNoDownloaderIsAvailable(): void
+    {
+        $downloader = new AvailableUrlDownloader(
+            static fn(array $command): array => self::commandResult(127),
+            'Linux',
+            false,
+        );
+
+        $this->expectExceptionMessage('Install curl and retry');
+        $downloader->download('https://example.com/package', $this->destination);
+    }
+
+    /** @return array{exitCode: int, stdout: string, stderr: string} */
+    private static function commandResult(int $exitCode = 0, string $stderr = ''): array
+    {
+        return ['exitCode' => $exitCode, 'stdout' => '', 'stderr' => $stderr];
+    }
+}

--- a/tests/Unit/Update/PackageReplacerTest.php
+++ b/tests/Unit/Update/PackageReplacerTest.php
@@ -41,7 +41,6 @@ final class PackageReplacerTest extends TestCase
             self::assertInstanceOf(Closure::class, $replacement);
 
             $replacement();
-
             self::assertSame('new', file_get_contents($targetPath));
             self::assertFileDoesNotExist($temporaryPath);
         } finally {

--- a/tests/Unit/Update/PackageReplacerTest.php
+++ b/tests/Unit/Update/PackageReplacerTest.php
@@ -9,6 +9,14 @@ use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
 use YiiPress\Update\PackageReplacer;
 
+use function file_get_contents;
+use function file_put_contents;
+use function mkdir;
+use function rmdir;
+use function sys_get_temp_dir;
+use function unlink;
+use function uniqid;
+
 final class PackageReplacerTest extends TestCase
 {
     #[Test]
@@ -38,6 +46,7 @@ final class PackageReplacerTest extends TestCase
             self::assertFileDoesNotExist($temporaryPath);
         } finally {
             @unlink($temporaryPath);
+            @unlink($temporaryPath . '.sh');
             @unlink($targetPath);
             @rmdir($directory);
         }

--- a/tests/Unit/Update/SelfUpdaterTest.php
+++ b/tests/Unit/Update/SelfUpdaterTest.php
@@ -4,22 +4,23 @@ declare(strict_types=1);
 
 namespace YiiPress\Tests\Unit\Update;
 
-use Closure;
 use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
 use Phar;
 use PharData;
 use YiiPress\Update\Package;
 use YiiPress\Update\PackageLocator;
-use YiiPress\Update\PackageReplacer;
+use YiiPress\Update\PackageReplacerInterface;
 use YiiPress\Update\ReleaseClient;
 use YiiPress\Update\SelfUpdater;
+use YiiPress\Update\StreamUrlDownloader;
 
 use function chmod;
 use function file_put_contents;
 use function hash;
 use function json_encode;
 use function mkdir;
+use function rename;
 use function sys_get_temp_dir;
 use function uniqid;
 
@@ -199,10 +200,14 @@ final class SelfUpdaterTest extends TestCase
             new ReleaseClient(
                 'file://' . $this->directory . '/releases',
                 'file://' . $this->directory . '/releases.json',
+                new StreamUrlDownloader(),
             ),
-            new PackageReplacer('Linux', static function (Closure $callback): void {
-                $callback();
-            }),
+            new class implements PackageReplacerInterface {
+                public function replace(string $temporaryPath, string $targetPath): void
+                {
+                    rename($temporaryPath, $targetPath);
+                }
+            },
         );
     }
 


### PR DESCRIPTION
## Summary

- remove OpenSSL from Linux, macOS, and Windows static binaries
- use curl first for self-update downloads, with PHP HTTPS streams, PowerShell, and wget as platform fallbacks
- defer executable replacement until the updater exits to keep the running PHAR readable
- document downloader requirements and add unit, packaging, and benchmark coverage

## Size

The Linux package compresses to 6,125,667 bytes (about 5.84 MiB), down from about 7.48 MiB and near the 5.83 MiB stable release.

## Verification

- `make test CLI_ARGS='tests/Unit/Update tests/Unit/Packaging/ConfigurationPackagingTest.php'` — 50 tests, 540 assertions
- `make psalm` — no errors
- `make bench BENCH_FILTER=SelfUpdaterBench` — passed
- Linux static build contains no OpenSSL and completed an end-to-end self-update smoke test
- `git diff --check` — clean

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Self-updates now support multiple download methods across platforms, with automatic fallbacks when a preferred method is unavailable.
  * Package replacement on supported systems completes safely after the application exits.
  * Static binaries no longer require OpenSSL.

* **Bug Fixes**
  * Improved download failure handling, cleanup, and error reporting.

* **Documentation**
  * Expanded self-update and container guidance, including downloader behavior and replacement timing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->