### PR TITLE
Fix nightly installation on Windows

### DIFF
--- a/docs/binaries-phar-docker.md
+++ b/docs/binaries-phar-docker.md
@@ -28,8 +28,16 @@ curl -fsSL https://raw.githubusercontent.com/yiipress/engine/master/install.sh |
 curl -fsSL https://raw.githubusercontent.com/yiipress/engine/master/install.sh | YIIPRESS_VERSION=nightly sh
 ```
 
+Or, with the PowerShell installer:
+
+```powershell
+$env:YIIPRESS_VERSION = "nightly"
+irm https://raw.githubusercontent.com/yiipress/engine/master/install.ps1 | iex
+```
+
 `YIIPRESS_VERSION=nightly` resolves the newest immutable nightly prerelease through the GitHub releases API. It does not require
-`jq` or GitHub CLI. Nightly builds contain unreleased changes and are intended for preview and testing.
+`jq` or GitHub CLI. Both installers inspect up to ten release pages and use the first prerelease whose tag matches the immutable
+`nightly-<run>-<attempt>-<sha>` format. Nightly builds contain unreleased changes and are intended for preview and testing.
 
 YiiPress can be packaged as reproducible artifacts:
 

--- a/install.ps1
+++ b/install.ps1
@@ -16,6 +16,24 @@ if ([Runtime.InteropServices.RuntimeInformation]::OSArchitecture -ne [Runtime.In
 }
 
 $Asset = "yiipress-windows-amd64.zip"
+if ($Version -eq "nightly") {
+    $ResolvedVersion = $null
+    for ($Page = 1; -not $ResolvedVersion -and $Page -le 10; $Page++) {
+        $Releases = @(
+            Invoke-RestMethod -Uri "https://api.github.com/repos/$Repository/releases?per_page=100&page=$Page"
+        )
+        $ResolvedVersion = $Releases | Where-Object {
+            $_.prerelease -eq $true -and $_.tag_name -match '^nightly-[0-9]+-[0-9]+-[0-9a-f]+$'
+        } | Select-Object -First 1 -ExpandProperty tag_name
+        if ($Releases.Count -eq 0) {
+            break
+        }
+    }
+    if (-not $ResolvedVersion) {
+        throw "Could not find a YiiPress nightly release for $Repository."
+    }
+    $Version = $ResolvedVersion
+}
 $ReleaseUrl = if ($Version -eq "latest") {
     "https://github.com/$Repository/releases/latest/download"
 } else {

--- a/install.ps1
+++ b/install.ps1
@@ -19,11 +19,23 @@ $Asset = "yiipress-windows-amd64.zip"
 if ($Version -eq "nightly") {
     $ResolvedVersion = $null
     for ($Page = 1; -not $ResolvedVersion -and $Page -le 10; $Page++) {
-        $Releases = @(
-            Invoke-RestMethod -Uri "https://api.github.com/repos/$Repository/releases?per_page=100&page=$Page"
-        )
+        $Releases = $null
+        for ($Attempt = 1; $Attempt -le 3; $Attempt++) {
+            try {
+                $Releases = @(
+                    Invoke-RestMethod -Uri "https://api.github.com/repos/$Repository/releases?per_page=100&page=$Page"
+                )
+                break
+            } catch {
+                if ($Attempt -eq 3) {
+                    throw
+                }
+                Start-Sleep -Seconds 2
+            }
+        }
         $ResolvedVersion = $Releases | Where-Object {
-            $_.prerelease -eq $true -and $_.tag_name -match '^nightly-[0-9]+-[0-9]+-[0-9a-f]+$'
+            $_.prerelease -eq $true -and $_.draft -ne $true `
+                -and $_.tag_name -match '^nightly-[0-9]+-[0-9]+-[0-9a-f]+$'
         } | Select-Object -First 1 -ExpandProperty tag_name
         if ($Releases.Count -eq 0) {
             break

--- a/tests/Unit/Packaging/InstallerTest.php
+++ b/tests/Unit/Packaging/InstallerTest.php
@@ -262,8 +262,12 @@ SH);
             $script,
         );
         self::assertStringContainsString("-match '^nightly-[0-9]+-[0-9]+-[0-9a-f]+$'", $script);
+        self::assertStringContainsString('$_.draft -ne $true', $script);
         self::assertStringContainsString('Select-Object -First 1 -ExpandProperty tag_name', $script);
         self::assertStringContainsString('$Page -le 10', $script);
+        self::assertStringContainsString('$Attempt -le 3', $script);
+        self::assertStringContainsString('Start-Sleep -Seconds 2', $script);
+        self::assertStringContainsString('if ($Attempt -eq 3)', $script);
         self::assertStringContainsString('Could not find a YiiPress nightly release for $Repository.', $script);
     }
 

--- a/tests/Unit/Packaging/InstallerTest.php
+++ b/tests/Unit/Packaging/InstallerTest.php
@@ -256,6 +256,15 @@ SH);
         self::assertStringContainsString('[Environment]::SetEnvironmentVariable("Path", $UpdatedPath, "User")', $script);
         self::assertStringContainsString('YIIPRESS_INSTALL_DIR', $script);
         self::assertStringContainsString('YIIPRESS_VERSION', $script);
+        self::assertStringContainsString('if ($Version -eq "nightly")', $script);
+        self::assertStringContainsString(
+            'https://api.github.com/repos/$Repository/releases?per_page=100&page=$Page',
+            $script,
+        );
+        self::assertStringContainsString("-match '^nightly-[0-9]+-[0-9]+-[0-9a-f]+$'", $script);
+        self::assertStringContainsString('Select-Object -First 1 -ExpandProperty tag_name', $script);
+        self::assertStringContainsString('$Page -le 10', $script);
+        self::assertStringContainsString('Could not find a YiiPress nightly release for $Repository.', $script);
     }
 
     private function createRelease(


### PR DESCRIPTION
## Summary

- resolve `YIIPRESS_VERSION=nightly` through GitHub prereleases in the PowerShell installer
- match the shell installer pagination limit and immutable nightly tag format
- document PowerShell nightly installation and cover the behavior in the installer test

## Tests

- `make test CLI_ARGS='tests/Unit/Packaging/InstallerTest.php'` (10 tests, 155 assertions)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * The Windows installer now supports selecting the latest available nightly release.
  * Nightly releases are identified automatically across GitHub release pages, searching up to ten pages.
  * Added PowerShell usage instructions for installing nightly versions.

* **Bug Fixes**
  * The installer now reports a clear error when no matching nightly release is available.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->