### PR TITLE
Fix README badges

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -14,8 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-    env:
-      CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
+      id-token: write
 
     steps:
       - name: Checkout repository
@@ -30,13 +29,9 @@ jobs:
         run: make test-coverage-clover
 
       - name: Upload coverage to Codecov
-        if: env.CODECOV_TOKEN != ''
+        if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
         uses: codecov/codecov-action@e79a6962e0d4c0c17b229090214935d2e33f8354
         with:
-          token: ${{ env.CODECOV_TOKEN }}
+          use_oidc: true
           files: runtime/coverage/clover.xml
           fail_ci_if_error: true
-
-      - name: Skip Codecov upload
-        if: env.CODECOV_TOKEN == ''
-        run: echo "CODECOV_TOKEN is not configured; generated coverage but skipped Codecov upload."

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -14,7 +14,8 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-      id-token: write
+    env:
+      CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
 
     steps:
       - name: Checkout repository
@@ -29,9 +30,13 @@ jobs:
         run: make test-coverage-clover
 
       - name: Upload coverage to Codecov
-        if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
+        if: env.CODECOV_TOKEN != ''
         uses: codecov/codecov-action@e79a6962e0d4c0c17b229090214935d2e33f8354
         with:
-          use_oidc: true
+          token: ${{ env.CODECOV_TOKEN }}
           files: runtime/coverage/clover.xml
           fail_ci_if_error: true
+
+      - name: Skip Codecov upload
+        if: env.CODECOV_TOKEN == ''
+        run: echo "CODECOV_TOKEN is not configured; generated coverage but skipped Codecov upload."

--- a/README.md
+++ b/README.md
@@ -6,11 +6,11 @@
     <br>
 </p>
 
-[![Latest Stable Version](https://poser.pugx.org/yiipress/engine/v)](https://packagist.org/packages/yiipress/engine)
-[![Total Downloads](https://poser.pugx.org/yiipress/engine/downloads)](https://packagist.org/packages/yiipress/engine)
+[![Latest Stable Version](https://img.shields.io/github/v/release/yiipress/engine?sort=semver)](https://github.com/yiipress/engine/releases/latest)
+[![Total Downloads](https://img.shields.io/github/downloads/yiipress/engine/total)](https://github.com/yiipress/engine/releases)
 [![Tests](https://github.com/yiipress/engine/actions/workflows/run-tests.yml/badge.svg)](https://github.com/yiipress/engine/actions/workflows/run-tests.yml)
 [![Static Analysis](https://github.com/yiipress/engine/actions/workflows/static-analysis.yml/badge.svg)](https://github.com/yiipress/engine/actions/workflows/static-analysis.yml)
-[![Coverage](https://codecov.io/gh/yiipress/engine/branch/master/graph/badge.svg)](https://codecov.io/gh/yiipress/engine)
+[![Coverage](https://codecov.io/github/yiipress/engine/graph/badge.svg)](https://codecov.io/github/yiipress/engine)
 [![Package](https://github.com/yiipress/engine/actions/workflows/package-static.yml/badge.svg)](https://github.com/yiipress/engine/actions/workflows/package-static.yml)
 
 YiiPress is a fast, file-based static website engine powered by [Yii3](https://www.yiiframework.com/).

--- a/tests/Unit/Packaging/ConfigurationPackagingTest.php
+++ b/tests/Unit/Packaging/ConfigurationPackagingTest.php
@@ -610,15 +610,13 @@ final class ConfigurationPackagingTest extends TestCase
         self::assertStringContainsString('make -- composer install --no-progress --no-interaction', $workflow);
         self::assertStringContainsString('make test-coverage-clover', $workflow);
         self::assertStringContainsString('runtime/coverage/clover.xml', $workflow);
-        self::assertStringContainsString('id-token: write', $workflow);
-        self::assertStringContainsString('use_oidc: true', $workflow);
-        self::assertStringContainsString(
-            "if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository",
-            $workflow,
-        );
+        self::assertStringContainsString('CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}', $workflow);
+        self::assertStringContainsString("if: env.CODECOV_TOKEN != ''", $workflow);
+        self::assertStringContainsString('token: ${{ env.CODECOV_TOKEN }}', $workflow);
         self::assertStringContainsString('uses: codecov/codecov-action@e79a6962e0d4c0c17b229090214935d2e33f8354', $workflow);
         self::assertStringContainsString('fail_ci_if_error: true', $workflow);
-        self::assertStringNotContainsString('CODECOV_TOKEN', $workflow);
+        self::assertStringContainsString("if: env.CODECOV_TOKEN == ''", $workflow);
+        self::assertStringContainsString('generated coverage but skipped Codecov upload', $workflow);
         self::assertDoesNotMatchRegularExpression('/uses:\s+[^@\s]+@v\d+/', $workflow);
         self::assertStringContainsString('test-coverage-clover: ## Run tests with Clover coverage', $makefile);
         self::assertStringContainsString('--coverage-clover runtime/coverage/clover.xml', $makefile);

--- a/tests/Unit/Packaging/ConfigurationPackagingTest.php
+++ b/tests/Unit/Packaging/ConfigurationPackagingTest.php
@@ -558,7 +558,7 @@ final class ConfigurationPackagingTest extends TestCase
         self::assertIsString($readme);
 
         self::assertStringContainsString(
-            '[![Latest Stable Version](https://img.shields.io/github/v/release/yiipress/engine?sort=semver)]',
+            '[![Latest Stable Version](https://img.shields.io/github/v/release/yiipress/engine?sort=semver)](https://github.com/yiipress/engine/releases/latest)',
             $readme,
         );
         self::assertStringContainsString(

--- a/tests/Unit/Packaging/ConfigurationPackagingTest.php
+++ b/tests/Unit/Packaging/ConfigurationPackagingTest.php
@@ -610,13 +610,15 @@ final class ConfigurationPackagingTest extends TestCase
         self::assertStringContainsString('make -- composer install --no-progress --no-interaction', $workflow);
         self::assertStringContainsString('make test-coverage-clover', $workflow);
         self::assertStringContainsString('runtime/coverage/clover.xml', $workflow);
-        self::assertStringContainsString('CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}', $workflow);
-        self::assertStringContainsString("if: env.CODECOV_TOKEN != ''", $workflow);
-        self::assertStringContainsString('token: ${{ env.CODECOV_TOKEN }}', $workflow);
+        self::assertStringContainsString('id-token: write', $workflow);
+        self::assertStringContainsString('use_oidc: true', $workflow);
+        self::assertStringContainsString(
+            "if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository",
+            $workflow,
+        );
         self::assertStringContainsString('uses: codecov/codecov-action@e79a6962e0d4c0c17b229090214935d2e33f8354', $workflow);
         self::assertStringContainsString('fail_ci_if_error: true', $workflow);
-        self::assertStringContainsString("if: env.CODECOV_TOKEN == ''", $workflow);
-        self::assertStringContainsString('generated coverage but skipped Codecov upload', $workflow);
+        self::assertStringNotContainsString('CODECOV_TOKEN', $workflow);
         self::assertDoesNotMatchRegularExpression('/uses:\s+[^@\s]+@v\d+/', $workflow);
         self::assertStringContainsString('test-coverage-clover: ## Run tests with Clover coverage', $makefile);
         self::assertStringContainsString('--coverage-clover runtime/coverage/clover.xml', $makefile);

--- a/tests/Unit/Packaging/ConfigurationPackagingTest.php
+++ b/tests/Unit/Packaging/ConfigurationPackagingTest.php
@@ -552,17 +552,25 @@ final class ConfigurationPackagingTest extends TestCase
     }
 
     #[Test]
-    public function readmeExposesStaticAnalysisAndCoverageBadges(): void
+    public function readmeExposesReleaseDownloadAnalysisAndCoverageBadges(): void
     {
         $readme = file_get_contents(dirname(__DIR__, 3) . '/README.md');
         self::assertIsString($readme);
 
         self::assertStringContainsString(
+            '[![Latest Stable Version](https://img.shields.io/github/v/release/yiipress/engine?sort=semver)]',
+            $readme,
+        );
+        self::assertStringContainsString(
+            '[![Total Downloads](https://img.shields.io/github/downloads/yiipress/engine/total)]',
+            $readme,
+        );
+        self::assertStringContainsString(
             '[![Static Analysis](https://github.com/yiipress/engine/actions/workflows/static-analysis.yml/badge.svg)]',
             $readme,
         );
         self::assertStringContainsString(
-            '[![Coverage](https://codecov.io/gh/yiipress/engine/branch/master/graph/badge.svg)]',
+            '[![Coverage](https://codecov.io/github/yiipress/engine/graph/badge.svg)]',
             $readme,
         );
     }


### PR DESCRIPTION
## Summary

- replace Packagist-oriented badges with GitHub release version and total download badges
- update the Codecov badge to its current repository endpoint
- extend README badge regression coverage

The GitHub badges were verified to return the current stable release (`v0.1.8`) and total release downloads.

## Tests

- `make test CLI_ARGS='tests/Unit/Packaging/ConfigurationPackagingTest.php'` (32 tests, 532 assertions)

## Note

Codecov currently reports this repository as inactive with no coverage totals. The corrected badge endpoint renders successfully and will show a percentage after coverage is uploaded.