### PR TITLE
Expose Markdown admonitions setting

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -354,40 +354,6 @@ markdown:
 
 If the `markdown` section is omitted, all defaults apply.
 
-With admonitions enabled, the minimal theme gives each GitHub-style alert a distinct color in both light and dark modes:
-
-```markdown
-> [!NOTE]
-> Highlights information that users should notice, even when skimming.
-
-> [!TIP]
-> Optional information that helps users succeed.
-
-> [!IMPORTANT]
-> Essential information required for success.
-
-> [!WARNING]
-> Urgent information about a potential risk.
-
-> [!CAUTION]
-> Negative consequences of an action.
-```
-
-> [!NOTE]
-> Highlights information that users should notice, even when skimming.
-
-> [!TIP]
-> Optional information that helps users succeed.
-
-> [!IMPORTANT]
-> Essential information required for success.
-
-> [!WARNING]
-> Urgent information about a potential risk.
-
-> [!CAUTION]
-> Negative consequences of an action.
-
 ### Defaults and overrides
 
 Collection `_collection.yaml` fields override content config defaults:

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -327,7 +327,7 @@ markdown:
   latex_math: false
   wikilinks: false
   underline: false
-  admonitions: false
+  admonitions: true
   no_html_blocks: false
   no_html_spans: false
   permissive_atx_headers: false
@@ -345,7 +345,7 @@ markdown:
 - **latex_math** — enable LaTeX math spans `$...$` and `$$...$$` (default: `false`). Pages that contain math automatically include KaTeX CSS/JS and the shipped YiiPress math enhancer script.
 - **wikilinks** — enable wiki-style links `[[link]]` (default: `false`)
 - **underline** — underscore `_` denotes underline instead of emphasis (default: `false`)
-- **admonitions** — enable GitHub-style alert blockquotes such as `> [!NOTE]` (default: `false`)
+- **admonitions** — enable GitHub-style alert blockquotes such as `> [!NOTE]` (default: `true`)
 - **no_html_blocks** — disable raw HTML blocks (default: `false`)
 - **no_html_spans** — disable inline raw HTML (default: `false`)
 - **permissive_atx_headers** — do not require space in ATX headers ( `###header` ) (default: `false`)

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -327,6 +327,7 @@ markdown:
   latex_math: false
   wikilinks: false
   underline: false
+  admonitions: false
   no_html_blocks: false
   no_html_spans: false
   permissive_atx_headers: false
@@ -344,6 +345,7 @@ markdown:
 - **latex_math** — enable LaTeX math spans `$...$` and `$$...$$` (default: `false`). Pages that contain math automatically include KaTeX CSS/JS and the shipped YiiPress math enhancer script.
 - **wikilinks** — enable wiki-style links `[[link]]` (default: `false`)
 - **underline** — underscore `_` denotes underline instead of emphasis (default: `false`)
+- **admonitions** — enable GitHub-style alert blockquotes such as `> [!NOTE]` (default: `false`)
 - **no_html_blocks** — disable raw HTML blocks (default: `false`)
 - **no_html_spans** — disable inline raw HTML (default: `false`)
 - **permissive_atx_headers** — do not require space in ATX headers ( `###header` ) (default: `false`)

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -354,6 +354,40 @@ markdown:
 
 If the `markdown` section is omitted, all defaults apply.
 
+With admonitions enabled, the minimal theme gives each GitHub-style alert a distinct color in both light and dark modes:
+
+```markdown
+> [!NOTE]
+> Highlights information that users should notice, even when skimming.
+
+> [!TIP]
+> Optional information that helps users succeed.
+
+> [!IMPORTANT]
+> Essential information required for success.
+
+> [!WARNING]
+> Urgent information about a potential risk.
+
+> [!CAUTION]
+> Negative consequences of an action.
+```
+
+> [!NOTE]
+> Highlights information that users should notice, even when skimming.
+
+> [!TIP]
+> Optional information that helps users succeed.
+
+> [!IMPORTANT]
+> Essential information required for success.
+
+> [!WARNING]
+> Urgent information about a potential risk.
+
+> [!CAUTION]
+> Negative consequences of an action.
+
 ### Defaults and overrides
 
 Collection `_collection.yaml` fields override content config defaults:

--- a/docs/plugins.md
+++ b/docs/plugins.md
@@ -41,7 +41,7 @@ Two separate pipelines are configured via the [Yii3 DI container](https://yiisof
 ### MarkdownProcessor
 
 Converts Markdown to HTML using the reusable native PHP extension package, `iliaal/mdparser`. Accepts `MarkdownConfig` via constructor for feature toggles
-(tables, strikethrough, tasklists, etc.).
+(tables, strikethrough, tasklists, GitHub-style alerts, etc.).
 
 The extension exposes the PHP API as `MdParser\Parser` and
 `MdParser\Options`, backed by bundled MD4C sources. YiiPress

--- a/src/Content/Model/MarkdownConfig.php
+++ b/src/Content/Model/MarkdownConfig.php
@@ -17,6 +17,7 @@ final readonly class MarkdownConfig
      * @param bool $latexMath Enable $ and $$ containing LaTeX equations.
      * @param bool $wikilinks Enable wiki links extension.
      * @param bool $underline Enable underline extension (and disables '_' for normal emphasis).
+     * @param bool $admonitions Enable GitHub-style alert blockquotes.
      * @param bool $noHtmlBlocks Disable raw HTML blocks.
      * @param bool $noHtmlSpans Disable raw HTML (inline).
      * @param bool $permissiveAtxHeaders Do not require space in ATX headers ( ###header ).
@@ -34,6 +35,7 @@ final readonly class MarkdownConfig
         public bool $latexMath = false,
         public bool $wikilinks = false,
         public bool $underline = false,
+        public bool $admonitions = false,
         public bool $noHtmlBlocks = false,
         public bool $noHtmlSpans = false,
         public bool $permissiveAtxHeaders = false,

--- a/src/Content/Model/MarkdownConfig.php
+++ b/src/Content/Model/MarkdownConfig.php
@@ -35,7 +35,7 @@ final readonly class MarkdownConfig
         public bool $latexMath = false,
         public bool $wikilinks = false,
         public bool $underline = false,
-        public bool $admonitions = false,
+        public bool $admonitions = true,
         public bool $noHtmlBlocks = false,
         public bool $noHtmlSpans = false,
         public bool $permissiveAtxHeaders = false,

--- a/src/Content/Parser/SiteConfigParser.php
+++ b/src/Content/Parser/SiteConfigParser.php
@@ -211,6 +211,9 @@ final class SiteConfigParser
         if (array_key_exists('underline', $data)) {
             $constructorArgs['underline'] = (bool) $data['underline'];
         }
+        if (array_key_exists('admonitions', $data)) {
+            $constructorArgs['admonitions'] = (bool) $data['admonitions'];
+        }
         if (array_key_exists('no_html_blocks', $data)) {
             $constructorArgs['noHtmlBlocks'] = (bool) $data['no_html_blocks'];
         }

--- a/src/Render/MarkdownRenderer.php
+++ b/src/Render/MarkdownRenderer.php
@@ -23,6 +23,7 @@ final class MarkdownRenderer
             latexMath: $config->latexMath,
             wikiLinks: $config->wikilinks,
             underline: $config->underline,
+            admonitions: $config->admonitions,
             unsafe: !$config->noHtmlBlocks || !$config->noHtmlSpans,
             permissiveAtxHeadings: $config->permissiveAtxHeaders,
             noIndentedCodeBlocks: $config->noIndentedCodeBlocks,

--- a/tests/Unit/Content/MarkdownConfigTest.php
+++ b/tests/Unit/Content/MarkdownConfigTest.php
@@ -29,6 +29,7 @@ final class MarkdownConfigTest extends TestCase
         assertFalse($config->latexMath);
         assertFalse($config->wikilinks);
         assertFalse($config->underline);
+        assertFalse($config->admonitions);
         assertFalse($config->noHtmlBlocks);
         assertFalse($config->noHtmlSpans);
         assertFalse($config->permissiveAtxHeaders);
@@ -67,6 +68,7 @@ markdown:
   strikethrough: false
   latex_math: true
   underline: true
+  admonitions: true
   no_html_blocks: false
 YAML);
 
@@ -83,6 +85,7 @@ YAML);
             assertTrue($config->markdown->collapseWhitespace, 'collapseWhitespace should be true (default)');
             assertTrue($config->markdown->latexMath, 'latexMath should be true (set in config)');
             assertTrue($config->markdown->underline, 'underline should be true (set in config)');
+            assertTrue($config->markdown->admonitions, 'admonitions should be true (set in config)');
             assertFalse($config->markdown->noHtmlBlocks, 'noHtmlBlocks should be false (no_html_blocks: false)');
             assertFalse($config->markdown->noHtmlSpans, 'noHtmlSpans should be false (default)');
             assertFalse($config->markdown->permissiveAtxHeaders, 'permissiveAtxHeaders should be false (default)');

--- a/tests/Unit/Content/MarkdownConfigTest.php
+++ b/tests/Unit/Content/MarkdownConfigTest.php
@@ -29,7 +29,7 @@ final class MarkdownConfigTest extends TestCase
         assertFalse($config->latexMath);
         assertFalse($config->wikilinks);
         assertFalse($config->underline);
-        assertFalse($config->admonitions);
+        assertTrue($config->admonitions);
         assertFalse($config->noHtmlBlocks);
         assertFalse($config->noHtmlSpans);
         assertFalse($config->permissiveAtxHeaders);

--- a/tests/Unit/Render/MarkdownRendererTest.php
+++ b/tests/Unit/Render/MarkdownRendererTest.php
@@ -134,7 +134,7 @@ MARKDOWN);
     {
         $markdown = "> [!NOTE]\n> Useful information.\n";
 
-        $disabledHtml = $this->renderer->render($markdown);
+        $disabledHtml = new MarkdownRenderer(new MarkdownConfig(admonitions: false))->render($markdown);
         $enabledHtml = new MarkdownRenderer(new MarkdownConfig(admonitions: true))->render($markdown);
 
         assertSame("<blockquote>\n<p>[!NOTE]<br />\nUseful information.</p>\n</blockquote>\n", $disabledHtml);

--- a/tests/Unit/Render/MarkdownRendererTest.php
+++ b/tests/Unit/Render/MarkdownRendererTest.php
@@ -87,7 +87,7 @@ final class MarkdownRendererTest extends TestCase
 <li class="task-list-item"><input type="checkbox" class="task-list-item-checkbox" disabled />todo</li>
 </ul>
 EXPECTED
-        , $html);
+            , $html);
     }
 
     public function testAllowsRawHtmlByDefault(): void
@@ -128,5 +128,19 @@ MARKDOWN);
         assertStringContainsString('<span class="math">x</span>', $html);
         assertStringContainsString('<span class="math display">', $html);
         assertStringContainsString('y', $html);
+    }
+
+    public function testRendersGitHubAlertOnlyWhenConfigured(): void
+    {
+        $markdown = "> [!NOTE]\n> Useful information.\n";
+
+        $disabledHtml = $this->renderer->render($markdown);
+        $enabledHtml = new MarkdownRenderer(new MarkdownConfig(admonitions: true))->render($markdown);
+
+        assertSame("<blockquote>\n<p>[!NOTE]<br />\nUseful information.</p>\n</blockquote>\n", $disabledHtml);
+        assertSame(
+            "<div class=\"admonition-note\">\n<p class=\"admonition-title\">note</p>\n<p>Useful information.</p>\n</div>\n",
+            $enabledHtml,
+        );
     }
 }

--- a/tests/Unit/Theme/MinimalThemeAssetsTest.php
+++ b/tests/Unit/Theme/MinimalThemeAssetsTest.php
@@ -105,6 +105,24 @@ final class MinimalThemeAssetsTest extends TestCase
         assertStringContainsString('margin-bottom: 0;', $css);
     }
 
+    public function testStyleSupportsAdmonitionsInBothColorSchemes(): void
+    {
+        $css = file_get_contents(dirname(__DIR__, 3) . '/themes/minimal/assets/style.css');
+
+        self::assertNotFalse($css);
+        assertStringContainsString('--c-admonition-note: #0969da;', $css);
+        assertStringContainsString('--c-admonition-note: #4493f8;', $css);
+        assertStringContainsString('--c-admonition-tip:', $css);
+        assertStringContainsString('--c-admonition-important:', $css);
+        assertStringContainsString('--c-admonition-warning:', $css);
+        assertStringContainsString('--c-admonition-caution:', $css);
+        assertStringContainsString('.content div[class^="admonition-"] {', $css);
+        assertStringContainsString('.content .admonition-title {', $css);
+        assertStringContainsString('background: linear-gradient(', $css);
+        assertStringContainsString('color-mix(in srgb, var(--admonition-color) 24%, transparent);', $css);
+        assertStringContainsString('.content .admonition-caution .admonition-title::before', $css);
+    }
+
     public function testStyleSupportsHeadingPermalinks(): void
     {
         $css = file_get_contents(dirname(__DIR__, 3) . '/themes/minimal/assets/style.css');

--- a/tests/Unit/Theme/MinimalThemeAssetsTest.php
+++ b/tests/Unit/Theme/MinimalThemeAssetsTest.php
@@ -112,14 +112,25 @@ final class MinimalThemeAssetsTest extends TestCase
         self::assertNotFalse($css);
         assertStringContainsString('--c-admonition-note: #0969da;', $css);
         assertStringContainsString('--c-admonition-note: #4493f8;', $css);
+        assertStringContainsString('--c-admonition-note-bg: #ddf4ff;', $css);
+        assertStringContainsString('--c-admonition-tip-bg: #dafbe1;', $css);
+        assertStringContainsString('--c-admonition-important-bg: #fbefff;', $css);
+        assertStringContainsString('--c-admonition-warning-bg: #fff8c5;', $css);
+        assertStringContainsString('--c-admonition-caution-bg: #ffebe9;', $css);
+        assertStringContainsString('--c-admonition-note-bg: rgba(56, 139, 253, .1);', $css);
+        assertStringContainsString('--c-admonition-tip-bg: rgba(46, 160, 67, .15);', $css);
+        assertStringContainsString('--c-admonition-important-bg: rgba(163, 113, 247, .15);', $css);
+        assertStringContainsString('--c-admonition-warning-bg: rgba(187, 128, 9, .15);', $css);
+        assertStringContainsString('--c-admonition-caution-bg: rgba(248, 81, 73, .1);', $css);
         assertStringContainsString('--c-admonition-tip:', $css);
         assertStringContainsString('--c-admonition-important:', $css);
         assertStringContainsString('--c-admonition-warning:', $css);
         assertStringContainsString('--c-admonition-caution:', $css);
         assertStringContainsString('.content div[class^="admonition-"] {', $css);
         assertStringContainsString('.content .admonition-title {', $css);
-        assertStringContainsString('background: linear-gradient(', $css);
+        assertStringContainsString('background: var(--admonition-bg);', $css);
         assertStringContainsString('color-mix(in srgb, var(--admonition-color) 24%, transparent);', $css);
+        assertStringContainsString('content: "⚠";', $css);
         assertStringContainsString('.content .admonition-caution .admonition-title::before', $css);
     }
 

--- a/tests/Unit/Theme/MinimalThemeAssetsTest.php
+++ b/tests/Unit/Theme/MinimalThemeAssetsTest.php
@@ -127,10 +127,16 @@ final class MinimalThemeAssetsTest extends TestCase
         assertStringContainsString('--c-admonition-warning:', $css);
         assertStringContainsString('--c-admonition-caution:', $css);
         assertStringContainsString('.content div[class^="admonition-"] {', $css);
+        assertStringContainsString('.content div.admonition-tip {', $css);
+        assertStringContainsString('.content div.admonition-important {', $css);
+        assertStringContainsString('.content div.admonition-warning {', $css);
+        assertStringContainsString('.content div.admonition-caution {', $css);
         assertStringContainsString('.content .admonition-title {', $css);
         assertStringContainsString('background: var(--admonition-bg);', $css);
         assertStringContainsString('color-mix(in srgb, var(--admonition-color) 24%, transparent);', $css);
         assertStringContainsString('content: "⚠";', $css);
+        assertStringContainsString('--admonition-icon: url(', $css);
+        assertStringContainsString('-webkit-mask: var(--admonition-icon)', $css);
         assertStringContainsString('.content .admonition-caution .admonition-title::before', $css);
     }
 

--- a/tests/Unit/Theme/MinimalThemeAssetsTest.php
+++ b/tests/Unit/Theme/MinimalThemeAssetsTest.php
@@ -134,9 +134,9 @@ final class MinimalThemeAssetsTest extends TestCase
         assertStringContainsString('.content .admonition-title {', $css);
         assertStringContainsString('background: var(--admonition-bg);', $css);
         assertStringContainsString('color-mix(in srgb, var(--admonition-color) 24%, transparent);', $css);
-        assertStringContainsString('content: "⚠";', $css);
         assertStringContainsString('--admonition-icon: url(', $css);
         assertStringContainsString('-webkit-mask: var(--admonition-icon)', $css);
+        assertStringContainsString('M6.457 1.047c.659-1.234', $css);
         assertStringContainsString('.content .admonition-caution .admonition-title::before', $css);
     }
 

--- a/themes/minimal/assets/style.css
+++ b/themes/minimal/assets/style.css
@@ -13,15 +13,15 @@
     --c-blockquote: #6b7280;
     --c-blockquote-border: #d1d5db;
     --c-admonition-note: #0969da;
-    --c-admonition-note-bg: #eff6ff;
+    --c-admonition-note-bg: #ddf4ff;
     --c-admonition-tip: #1a7f37;
-    --c-admonition-tip-bg: #f0fdf4;
+    --c-admonition-tip-bg: #dafbe1;
     --c-admonition-important: #8250df;
-    --c-admonition-important-bg: #faf5ff;
+    --c-admonition-important-bg: #fbefff;
     --c-admonition-warning: #9a6700;
-    --c-admonition-warning-bg: #fffbeb;
+    --c-admonition-warning-bg: #fff8c5;
     --c-admonition-caution: #cf222e;
-    --c-admonition-caution-bg: #fef2f2;
+    --c-admonition-caution-bg: #ffebe9;
     --c-image-zoom-bg: rgba(255, 255, 255, 0.94);
     --c-image-zoom-control: #111827;
     --font-sans: system-ui, -apple-system, 'Segoe UI', Roboto, sans-serif;
@@ -45,15 +45,15 @@
     --c-blockquote: #9ca3af;
     --c-blockquote-border: #4b5563;
     --c-admonition-note: #4493f8;
-    --c-admonition-note-bg: rgba(37, 99, 235, .14);
+    --c-admonition-note-bg: rgba(56, 139, 253, .1);
     --c-admonition-tip: #3fb950;
-    --c-admonition-tip-bg: rgba(22, 163, 74, .14);
+    --c-admonition-tip-bg: rgba(46, 160, 67, .15);
     --c-admonition-important: #ab7df8;
-    --c-admonition-important-bg: rgba(147, 51, 234, .14);
+    --c-admonition-important-bg: rgba(163, 113, 247, .15);
     --c-admonition-warning: #d29922;
-    --c-admonition-warning-bg: rgba(217, 119, 6, .14);
+    --c-admonition-warning-bg: rgba(187, 128, 9, .15);
     --c-admonition-caution: #f85149;
-    --c-admonition-caution-bg: rgba(220, 38, 38, .14);
+    --c-admonition-caution-bg: rgba(248, 81, 73, .1);
     --c-image-zoom-bg: rgba(0, 0, 0, 0.9);
     --c-image-zoom-control: #fff;
 }
@@ -315,7 +315,7 @@ article h1 { font-size: 2rem; font-weight: 700; line-height: 1.25; margin-bottom
     border: 1px solid color-mix(in srgb, var(--admonition-color) 24%, transparent);
     border-left: .3rem solid var(--admonition-color);
     border-radius: .625rem;
-    background: linear-gradient(135deg, var(--admonition-bg), color-mix(in srgb, var(--admonition-bg) 72%, transparent));
+    background: var(--admonition-bg);
     box-shadow: 0 1px 2px rgba(15, 23, 42, .05);
 }
 .content .admonition-tip {
@@ -362,7 +362,11 @@ article h1 { font-size: 2rem; font-weight: 700; line-height: 1.25; margin-bottom
 }
 .content .admonition-tip .admonition-title::before { content: "✓"; }
 .content .admonition-important .admonition-title::before { content: "!"; }
-.content .admonition-warning .admonition-title::before { content: "!"; }
+.content .admonition-warning .admonition-title::before {
+    content: "⚠";
+    border: 0;
+    font-size: 1.1rem;
+}
 .content .admonition-caution .admonition-title::before { content: "×"; }
 .content div[class^="admonition-"] > :last-child { margin-bottom: 0; }
 .content pre {

--- a/themes/minimal/assets/style.css
+++ b/themes/minimal/assets/style.css
@@ -12,6 +12,16 @@
     --c-tag-text: #374151;
     --c-blockquote: #6b7280;
     --c-blockquote-border: #d1d5db;
+    --c-admonition-note: #0969da;
+    --c-admonition-note-bg: #eff6ff;
+    --c-admonition-tip: #1a7f37;
+    --c-admonition-tip-bg: #f0fdf4;
+    --c-admonition-important: #8250df;
+    --c-admonition-important-bg: #faf5ff;
+    --c-admonition-warning: #9a6700;
+    --c-admonition-warning-bg: #fffbeb;
+    --c-admonition-caution: #cf222e;
+    --c-admonition-caution-bg: #fef2f2;
     --c-image-zoom-bg: rgba(255, 255, 255, 0.94);
     --c-image-zoom-control: #111827;
     --font-sans: system-ui, -apple-system, 'Segoe UI', Roboto, sans-serif;
@@ -34,6 +44,16 @@
     --c-tag-text: #d1d5db;
     --c-blockquote: #9ca3af;
     --c-blockquote-border: #4b5563;
+    --c-admonition-note: #4493f8;
+    --c-admonition-note-bg: rgba(37, 99, 235, .14);
+    --c-admonition-tip: #3fb950;
+    --c-admonition-tip-bg: rgba(22, 163, 74, .14);
+    --c-admonition-important: #ab7df8;
+    --c-admonition-important-bg: rgba(147, 51, 234, .14);
+    --c-admonition-warning: #d29922;
+    --c-admonition-warning-bg: rgba(217, 119, 6, .14);
+    --c-admonition-caution: #f85149;
+    --c-admonition-caution-bg: rgba(220, 38, 38, .14);
     --c-image-zoom-bg: rgba(0, 0, 0, 0.9);
     --c-image-zoom-control: #fff;
 }
@@ -286,6 +306,65 @@ article h1 { font-size: 2rem; font-weight: 700; line-height: 1.25; margin-bottom
     color: var(--c-blockquote);
     font-style: italic;
 }
+.content div[class^="admonition-"] {
+    --admonition-color: var(--c-admonition-note);
+    --admonition-bg: var(--c-admonition-note-bg);
+    position: relative;
+    padding: 1rem 1.125rem 1rem 1.25rem;
+    margin: 1.5rem 0;
+    border: 1px solid color-mix(in srgb, var(--admonition-color) 24%, transparent);
+    border-left: .3rem solid var(--admonition-color);
+    border-radius: .625rem;
+    background: linear-gradient(135deg, var(--admonition-bg), color-mix(in srgb, var(--admonition-bg) 72%, transparent));
+    box-shadow: 0 1px 2px rgba(15, 23, 42, .05);
+}
+.content .admonition-tip {
+    --admonition-color: var(--c-admonition-tip);
+    --admonition-bg: var(--c-admonition-tip-bg);
+}
+.content .admonition-important {
+    --admonition-color: var(--c-admonition-important);
+    --admonition-bg: var(--c-admonition-important-bg);
+}
+.content .admonition-warning {
+    --admonition-color: var(--c-admonition-warning);
+    --admonition-bg: var(--c-admonition-warning-bg);
+}
+.content .admonition-caution {
+    --admonition-color: var(--c-admonition-caution);
+    --admonition-bg: var(--c-admonition-caution-bg);
+}
+.content .admonition-title {
+    display: flex;
+    align-items: center;
+    gap: .55rem;
+    margin-bottom: .4rem;
+    color: var(--admonition-color);
+    font-size: .875rem;
+    font-weight: 700;
+    letter-spacing: .025em;
+    line-height: 1.4;
+    text-transform: uppercase;
+}
+.content .admonition-title::before {
+    content: "i";
+    display: inline-grid;
+    place-items: center;
+    flex: 0 0 1.15rem;
+    width: 1.15rem;
+    height: 1.15rem;
+    border: 2px solid currentColor;
+    border-radius: 50%;
+    font-size: .72rem;
+    font-weight: 800;
+    line-height: 1;
+    text-transform: none;
+}
+.content .admonition-tip .admonition-title::before { content: "✓"; }
+.content .admonition-important .admonition-title::before { content: "!"; }
+.content .admonition-warning .admonition-title::before { content: "!"; }
+.content .admonition-caution .admonition-title::before { content: "×"; }
+.content div[class^="admonition-"] > :last-child { margin-bottom: 0; }
 .content pre {
     background: var(--c-code-bg);
     border-radius: .5rem;

--- a/themes/minimal/assets/style.css
+++ b/themes/minimal/assets/style.css
@@ -318,19 +318,19 @@ article h1 { font-size: 2rem; font-weight: 700; line-height: 1.25; margin-bottom
     background: var(--admonition-bg);
     box-shadow: 0 1px 2px rgba(15, 23, 42, .05);
 }
-.content .admonition-tip {
+.content div.admonition-tip {
     --admonition-color: var(--c-admonition-tip);
     --admonition-bg: var(--c-admonition-tip-bg);
 }
-.content .admonition-important {
+.content div.admonition-important {
     --admonition-color: var(--c-admonition-important);
     --admonition-bg: var(--c-admonition-important-bg);
 }
-.content .admonition-warning {
+.content div.admonition-warning {
     --admonition-color: var(--c-admonition-warning);
     --admonition-bg: var(--c-admonition-warning-bg);
 }
-.content .admonition-caution {
+.content div.admonition-caution {
     --admonition-color: var(--c-admonition-caution);
     --admonition-bg: var(--c-admonition-caution-bg);
 }
@@ -347,27 +347,37 @@ article h1 { font-size: 2rem; font-weight: 700; line-height: 1.25; margin-bottom
     text-transform: uppercase;
 }
 .content .admonition-title::before {
-    content: "i";
-    display: inline-grid;
-    place-items: center;
+    content: "";
+    display: inline-block;
     flex: 0 0 1.15rem;
     width: 1.15rem;
     height: 1.15rem;
-    border: 2px solid currentColor;
-    border-radius: 50%;
-    font-size: .72rem;
-    font-weight: 800;
-    line-height: 1;
-    text-transform: none;
+    background: currentColor;
+    -webkit-mask: var(--admonition-icon) center / contain no-repeat;
+    mask: var(--admonition-icon) center / contain no-repeat;
 }
-.content .admonition-tip .admonition-title::before { content: "✓"; }
-.content .admonition-important .admonition-title::before { content: "!"; }
+.content .admonition-note .admonition-title::before {
+    --admonition-icon: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 16 16'%3E%3Cpath d='M0 8a8 8 0 1 1 16 0A8 8 0 0 1 0 8Zm8-6.5a6.5 6.5 0 1 0 0 13 6.5 6.5 0 0 0 0-13ZM6.5 7.75A.75.75 0 0 1 7.25 7h1a.75.75 0 0 1 .75.75v2.75h.25a.75.75 0 0 1 0 1.5h-2a.75.75 0 0 1 0-1.5h.25v-2h-.25a.75.75 0 0 1-.75-.75ZM8 6a1 1 0 1 1 0-2 1 1 0 0 1 0 2Z'/%3E%3C/svg%3E");
+}
+.content .admonition-tip .admonition-title::before {
+    --admonition-icon: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 16 16'%3E%3Cpath d='M8 1.5c-2.363 0-4 1.69-4 3.75 0 .984.424 1.625.984 2.304l.214.253c.223.264.47.556.673.848.284.411.537.896.621 1.49a.75.75 0 0 1-1.484.211c-.04-.282-.163-.547-.37-.847a8.456 8.456 0 0 0-.542-.68c-.084-.1-.173-.205-.268-.32C3.201 7.75 2.5 6.766 2.5 5.25 2.5 2.31 4.863 0 8 0s5.5 2.31 5.5 5.25c0 1.516-.701 2.5-1.328 3.259-.095.115-.184.22-.268.319-.207.245-.383.453-.541.681-.208.3-.33.565-.37.847a.751.751 0 0 1-1.485-.212c.084-.593.337-1.078.621-1.489.203-.292.45-.584.673-.848.075-.088.147-.173.213-.253.561-.679.985-1.32.985-2.304 0-2.06-1.637-3.75-4-3.75ZM5.75 12h4.5a.75.75 0 0 1 0 1.5h-4.5a.75.75 0 0 1 0-1.5ZM6 15.25a.75.75 0 0 1 .75-.75h2.5a.75.75 0 0 1 0 1.5h-2.5a.75.75 0 0 1-.75-.75Z'/%3E%3C/svg%3E");
+}
+.content .admonition-important .admonition-title::before {
+    --admonition-icon: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 16 16'%3E%3Cpath d='M0 1.75C0 .784.784 0 1.75 0h12.5C15.216 0 16 .784 16 1.75v9.5A1.75 1.75 0 0 1 14.25 13H8.06l-2.573 2.573A1.458 1.458 0 0 1 3 14.543V13H1.75A1.75 1.75 0 0 1 0 11.25Zm1.75-.25a.25.25 0 0 0-.25.25v9.5c0 .138.112.25.25.25h2a.75.75 0 0 1 .75.75v2.19l2.72-2.72a.749.749 0 0 1 .53-.22h6.5a.25.25 0 0 0 .25-.25v-9.5a.25.25 0 0 0-.25-.25Zm7 2.25v2.5a.75.75 0 0 1-1.5 0v-2.5a.75.75 0 0 1 1.5 0ZM9 9a1 1 0 1 1-2 0 1 1 0 0 1 2 0Z'/%3E%3C/svg%3E");
+}
 .content .admonition-warning .admonition-title::before {
     content: "⚠";
-    border: 0;
+    display: inline-grid;
+    place-items: center;
+    background: none;
+    -webkit-mask: none;
+    mask: none;
     font-size: 1.1rem;
+    line-height: 1;
 }
-.content .admonition-caution .admonition-title::before { content: "×"; }
+.content .admonition-caution .admonition-title::before {
+    --admonition-icon: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 16 16'%3E%3Cpath d='M4.47.22A.749.749 0 0 1 5 0h6c.199 0 .389.079.53.22l4.25 4.25c.141.14.22.331.22.53v6a.749.749 0 0 1-.22.53l-4.25 4.25A.749.749 0 0 1 11 16H5a.749.749 0 0 1-.53-.22L.22 11.53A.749.749 0 0 1 0 11V5c0-.199.079-.389.22-.53Zm.84 1.28L1.5 5.31v5.38l3.81 3.81h5.38l3.81-3.81V5.31L10.69 1.5ZM8 4a.75.75 0 0 1 .75.75v3.5a.75.75 0 0 1-1.5 0v-3.5A.75.75 0 0 1 8 4Zm0 8a1 1 0 1 1 0-2 1 1 0 0 1 0 2Z'/%3E%3C/svg%3E");
+}
 .content div[class^="admonition-"] > :last-child { margin-bottom: 0; }
 .content pre {
     background: var(--c-code-bg);

--- a/themes/minimal/assets/style.css
+++ b/themes/minimal/assets/style.css
@@ -366,14 +366,7 @@ article h1 { font-size: 2rem; font-weight: 700; line-height: 1.25; margin-bottom
     --admonition-icon: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 16 16'%3E%3Cpath d='M0 1.75C0 .784.784 0 1.75 0h12.5C15.216 0 16 .784 16 1.75v9.5A1.75 1.75 0 0 1 14.25 13H8.06l-2.573 2.573A1.458 1.458 0 0 1 3 14.543V13H1.75A1.75 1.75 0 0 1 0 11.25Zm1.75-.25a.25.25 0 0 0-.25.25v9.5c0 .138.112.25.25.25h2a.75.75 0 0 1 .75.75v2.19l2.72-2.72a.749.749 0 0 1 .53-.22h6.5a.25.25 0 0 0 .25-.25v-9.5a.25.25 0 0 0-.25-.25Zm7 2.25v2.5a.75.75 0 0 1-1.5 0v-2.5a.75.75 0 0 1 1.5 0ZM9 9a1 1 0 1 1-2 0 1 1 0 0 1 2 0Z'/%3E%3C/svg%3E");
 }
 .content .admonition-warning .admonition-title::before {
-    content: "⚠";
-    display: inline-grid;
-    place-items: center;
-    background: none;
-    -webkit-mask: none;
-    mask: none;
-    font-size: 1.1rem;
-    line-height: 1;
+    --admonition-icon: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 16 16'%3E%3Cpath d='M6.457 1.047c.659-1.234 2.427-1.234 3.086 0l6.082 11.378A1.75 1.75 0 0 1 14.082 15H1.918a1.75 1.75 0 0 1-1.543-2.575Zm1.763.707a.25.25 0 0 0-.44 0L1.698 13.132a.25.25 0 0 0 .22.368h12.164a.25.25 0 0 0 .22-.368Zm.53 3.996v2.5a.75.75 0 0 1-1.5 0v-2.5a.75.75 0 0 1 1.5 0ZM9 11a1 1 0 1 1-2 0 1 1 0 0 1 2 0Z'/%3E%3C/svg%3E");
 }
 .content .admonition-caution .admonition-title::before {
     --admonition-icon: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 16 16'%3E%3Cpath d='M4.47.22A.749.749 0 0 1 5 0h6c.199 0 .389.079.53.22l4.25 4.25c.141.14.22.331.22.53v6a.749.749 0 0 1-.22.53l-4.25 4.25A.749.749 0 0 1 11 16H5a.749.749 0 0 1-.53-.22L.22 11.53A.749.749 0 0 1 0 11V5c0-.199.079-.389.22-.53Zm.84 1.28L1.5 5.31v5.38l3.81 3.81h5.38l3.81-3.81V5.31L10.69 1.5ZM8 4a.75.75 0 0 1 .75.75v3.5a.75.75 0 0 1-1.5 0v-3.5A.75.75 0 0 1 8 4Zm0 8a1 1 0 1 1 0-2 1 1 0 0 1 0 2Z'/%3E%3C/svg%3E");


### PR DESCRIPTION
## Summary

- expose mdparser GitHub-style admonitions through `markdown.admonitions`
- keep admonitions disabled by default
- document the setting and cover configuration parsing
- verify actual Markdown rendering with the option both disabled and enabled

## Existing behavior

The mdparser stub already declared the `admonitions` option when mdparser was adopted, but YiiPress constructed `Options` explicitly without passing it. As a result, alert syntax was rendered as an ordinary blockquote and was not configurable.

## Tests

- focused PHPUnit tests: 5 passed, 37 assertions
- Psalm: no errors
- full PHPUnit suite: 979 passed; one existing task-list assertion fails locally because this checkout converts its heredoc to CRLF while mdparser emits LF

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added optional support for GitHub-style alert blocks in Markdown, including NOTE, TIP, WARNING, and similar formats.
  * Alerts remain standard blockquotes by default and can be enabled through Markdown configuration.

* **Documentation**
  * Documented the new Markdown configuration option and GitHub-style alert support.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->