### PR TITLE
Update Codecov action to v7

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -31,7 +31,7 @@ jobs:
 
       - name: Upload coverage to Codecov
         if: env.CODECOV_TOKEN != ''
-        uses: codecov/codecov-action@e79a6962e0d4c0c17b229090214935d2e33f8354
+        uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f
         with:
           token: ${{ env.CODECOV_TOKEN }}
           files: runtime/coverage/clover.xml

--- a/tests/Unit/Packaging/ConfigurationPackagingTest.php
+++ b/tests/Unit/Packaging/ConfigurationPackagingTest.php
@@ -617,7 +617,7 @@ final class ConfigurationPackagingTest extends TestCase
         self::assertStringContainsString('CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}', $workflow);
         self::assertStringContainsString("if: env.CODECOV_TOKEN != ''", $workflow);
         self::assertStringContainsString('token: ${{ env.CODECOV_TOKEN }}', $workflow);
-        self::assertStringContainsString('uses: codecov/codecov-action@e79a6962e0d4c0c17b229090214935d2e33f8354', $workflow);
+        self::assertStringContainsString('uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f', $workflow);
         self::assertStringContainsString('fail_ci_if_error: true', $workflow);
         self::assertStringContainsString("if: env.CODECOV_TOKEN == ''", $workflow);
         self::assertStringContainsString('generated coverage but skipped Codecov upload', $workflow);


### PR DESCRIPTION
## Summary

- update the pinned Codecov action from v6.0.1 to v7.0.0
- use the immutable v7.0.0 commit SHA
- update the workflow configuration assertion

Codecov uploads have repeatedly failed because the v6 wrapper cannot import its uploader verification key and reports `gpg: no valid OpenPGP data found`. Codecov v7 changes verification-key retrieval to the `codecovsecops` Keybase account.

## Verification

- `make test -- tests/Unit/Packaging/ConfigurationPackagingTest.php` — 32 tests, 533 assertions

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the code coverage reporting workflow to use a newer verified action version.
  * Updated the related coverage workflow test configuration accordingly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->