### PR TITLE
Fix Windows self-update helper launch

### DIFF
--- a/docs/commands.md
+++ b/docs/commands.md
@@ -380,7 +380,7 @@ yiipress self-update --nightly
 ```
 
 The command is intentionally unavailable in a Composer/source checkout. Use Composer to update those installations. Before downloading a release, the command verifies that the user can write to the installed PHAR or binary directory and reports an actionable permissions error otherwise.
-The verified package is staged next to the installation and replacement is deferred until the running command has shut down, so PHP never reads the new archive using cached metadata from the old one. On Windows, replacement is completed by a short-lived background command interpreter after the running executable exits.
+The verified package is staged next to the installation and replacement is deferred until the running command has shut down, so PHP never reads the new archive using cached metadata from the old one. On Windows, replacement is completed by a short-lived background command interpreter after the running process exits.
 Downloads prefer `curl`, then an existing PHP HTTPS wrapper, PowerShell on Windows, or
 `wget` on Linux and macOS. Install `curl` if no supported downloader is available. Container
 images should be updated by pulling a newer image instead of running this command.

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -380,7 +380,7 @@ yiipress self-update --nightly
 ```
 
 The command is intentionally unavailable in a Composer/source checkout. Use Composer to update those installations. Before downloading a release, the command verifies that the user can write to the installed PHAR or binary directory and reports an actionable permissions error otherwise.
-The verified package is staged next to the installation and replacement is deferred until the running command has shut down, so PHP never reads the new archive using cached metadata from the old one. On Windows, replacement is completed by a short-lived background helper after the running command exits.
+The verified package is staged next to the installation and replacement is deferred until the running command has shut down, so PHP never reads the new archive using cached metadata from the old one. On Windows, replacement is completed by a short-lived background command interpreter after the running executable exits.
 Downloads prefer `curl`, then an existing PHP HTTPS wrapper, PowerShell on Windows, or
 `wget` on Linux and macOS. Install `curl` if no supported downloader is available. Container
 images should be updated by pulling a newer image instead of running this command.

--- a/src/Update/PackageReplacer.php
+++ b/src/Update/PackageReplacer.php
@@ -25,14 +25,19 @@ final readonly class PackageReplacer implements PackageReplacerInterface
     /** @var Closure(string): void */
     private Closure $failureHandler;
 
+    /** @var Closure(list<string>): bool */
+    private Closure $processStarter;
+
     /**
      * @param Closure(Closure(): void): void|null $shutdownRegistrar
      * @param Closure(string): void|null $failureHandler
+     * @param Closure(list<string>): bool|null $processStarter
      */
     public function __construct(
         private string $osFamily = PHP_OS_FAMILY,
         ?Closure $shutdownRegistrar = null,
         ?Closure $failureHandler = null,
+        ?Closure $processStarter = null,
     ) {
         $this->shutdownRegistrar = $shutdownRegistrar ?? static function (Closure $callback): void {
             register_shutdown_function($callback);
@@ -41,6 +46,7 @@ final readonly class PackageReplacer implements PackageReplacerInterface
             fwrite(STDERR, $message . "\n");
             exit(1);
         };
+        $this->processStarter = $processStarter ?? self::startProcess(...);
     }
 
     public function replace(string $temporaryPath, string $targetPath): void
@@ -76,20 +82,39 @@ final readonly class PackageReplacer implements PackageReplacerInterface
             throw new RuntimeException('Could not create the Windows update helper.');
         }
 
+        if (!(($this->processStarter)([
+            'cmd.exe',
+            '/d',
+            '/c',
+            'start',
+            '',
+            '/b',
+            'cmd.exe',
+            '/d',
+            '/c',
+            'call',
+            $scriptPath,
+        ]))) {
+            @unlink($scriptPath);
+            throw new RuntimeException('Could not start the Windows update helper.');
+        }
+    }
+
+    /** @param list<string> $command */
+    private static function startProcess(array $command): bool
+    {
         $pipes = [];
         $process = @proc_open(
-            ['cmd.exe', '/d', '/c', 'start', '', '/b', $scriptPath],
+            $command,
             [0 => ['pipe', 'r'], 1 => ['file', 'NUL', 'a'], 2 => ['file', 'NUL', 'a']],
             $pipes,
+            options: ['bypass_shell' => true],
         );
         if (!is_resource($process)) {
-            @unlink($scriptPath);
-            throw new RuntimeException('Could not start the Windows update helper.');
+            return false;
         }
         fclose($pipes[0]);
-        if (proc_close($process) !== 0) {
-            @unlink($scriptPath);
-            throw new RuntimeException('Could not start the Windows update helper.');
-        }
+
+        return proc_close($process) === 0;
     }
 }

--- a/tests/Unit/Update/PackageReplacerTest.php
+++ b/tests/Unit/Update/PackageReplacerTest.php
@@ -60,6 +60,72 @@ final class PackageReplacerTest extends TestCase
     }
 
     #[Test]
+    public function startsWindowsHelperThroughDetachedCommandInterpreter(): void
+    {
+        $directory = sys_get_temp_dir() . '/yiipress-replacer-' . uniqid('', true);
+        mkdir($directory);
+        $temporaryPath = $directory . '/update package';
+        $targetPath = $directory . '/yiipress.exe';
+        $command = null;
+        $processStarter = static function (array $value) use (&$command): bool {
+            $command = $value;
+
+            return true;
+        };
+
+        try {
+            new PackageReplacer('Windows', processStarter: $processStarter)->replace($temporaryPath, $targetPath);
+
+            self::assertSame(
+                [
+                    'cmd.exe',
+                    '/d',
+                    '/c',
+                    'start',
+                    '',
+                    '/b',
+                    'cmd.exe',
+                    '/d',
+                    '/c',
+                    'call',
+                    $temporaryPath . '.cmd',
+                ],
+                $command,
+            );
+            self::assertStringContainsString(
+                "move /Y \"$temporaryPath\" \"$targetPath\"",
+                (string) file_get_contents($temporaryPath . '.cmd'),
+            );
+        } finally {
+            @unlink($temporaryPath . '.cmd');
+            @rmdir($directory);
+        }
+    }
+
+    #[Test]
+    public function removesWindowsHelperWhenItCannotBeStarted(): void
+    {
+        $directory = sys_get_temp_dir() . '/yiipress-replacer-' . uniqid('', true);
+        mkdir($directory);
+        $temporaryPath = $directory . '/update';
+        $scriptPath = $temporaryPath . '.cmd';
+
+        try {
+            new PackageReplacer(
+                'Windows',
+                processStarter: static fn(array $command): bool => false,
+            )->replace($temporaryPath, $directory . '/yiipress.exe');
+            self::fail('Expected the Windows helper launch to fail.');
+        } catch (\RuntimeException $exception) {
+            self::assertSame('Could not start the Windows update helper.', $exception->getMessage());
+            self::assertFileDoesNotExist($scriptPath);
+        } finally {
+            @unlink($scriptPath);
+            @rmdir($directory);
+        }
+    }
+
+    #[Test]
     public function reportsDeferredReplacementFailureWithoutThrowing(): void
     {
         $replacement = null;


### PR DESCRIPTION
## Summary

- launch the Windows replacement batch file through an explicit detached `cmd.exe` process
- bypass PHP’s implicit Windows shell handling and make the launcher injectable for deterministic tests
- document that Windows replacement uses a background command interpreter

## Context

`yiipress self-update` created its replacement script successfully on Windows 11, but `start` returned a non-zero status when the batch file was supplied directly. Starting a detached command interpreter and invoking the script with `call` avoids the batch-file-specific launch behavior.

## Verification

- `make test` — 1025 tests, 3703 assertions
- `make phpstan` — no errors
- `make cs-fix` — no changes
- `git diff --check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Windows package replacement reliability by using a short-lived background command interpreter.
  * Added cleanup and error handling when the update process cannot start.
  * Updates now report startup failures more reliably and avoid leaving temporary update files behind.

* **Documentation**
  * Updated self-update documentation to describe the revised Windows replacement process.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->